### PR TITLE
Basic error reporting using `ariadne`

### DIFF
--- a/yurtc/Cargo.lock
+++ b/yurtc/Cargo.lock
@@ -69,6 +69,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "ariadne"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72fe02fc62033df9ba41cba57ee19acf5e742511a140c7dbc3a873e19a19a1bd"
+dependencies = [
+ "unicode-width",
+ "yansi",
+]
+
+[[package]]
 name = "astmaker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,18 +124,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.3"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8f255e4b8027970e78db75e78831229c9815fdbfa67eb1a1b777a62e24b4a0"
+checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.3"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd4f3c17c83b0ba34ffbc4f8bbd74f079413f747f84a6f89292f138057e36ab"
+checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
 dependencies = [
  "anstream",
  "anstyle",
@@ -146,6 +156,12 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "errno"
@@ -221,6 +237,15 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -351,10 +376,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "utf8parse"
@@ -463,12 +514,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
 name = "yurtc"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ariadne",
  "astmaker",
  "chumsky",
  "clap",
+ "itertools",
  "logos",
+ "thiserror",
 ]

--- a/yurtc/Cargo.toml
+++ b/yurtc/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 astmaker = "0.2"
+ariadne = "0.3.0"
+itertools = "0.10.5"
 chumsky = "0.9"
 clap = { version = "4.3", features = ["cargo"] }
 logos = "0.13"
+thiserror = "1.0"

--- a/yurtc/src/error.rs
+++ b/yurtc/src/error.rs
@@ -1,0 +1,67 @@
+use crate::lexer::Token;
+use ariadne::{Color, Fmt, Label, Report, ReportKind, Source};
+use chumsky::prelude::*;
+use thiserror::Error;
+
+pub(super) type Span = std::ops::Range<usize>;
+
+/// An error originating from the lexer
+#[derive(Error, Debug, Clone, PartialEq, Default)]
+pub(super) enum LexError {
+    #[default]
+    #[error("Invalid token")]
+    InvalidToken,
+}
+
+/// A general compile error
+#[derive(Error, Debug, Clone, PartialEq)]
+pub(super) enum CompileError<'a> {
+    #[error("{}", error)]
+    Lex { span: Span, error: LexError },
+    #[error("{}", error)]
+    ParseError { error: Simple<Token<'a>> },
+}
+
+impl<'a> CompileError<'a> {
+    fn span(&self) -> Span {
+        use CompileError::*;
+        match self {
+            Lex { span, .. } => span.clone(),
+            ParseError { error } => error.span(),
+        }
+    }
+}
+
+/// Print a list of `CompileError` using the `ariadne` library
+pub(super) fn print_on_failure(filename: &str, source: &str, errs: &Vec<CompileError>) -> usize {
+    for err in errs {
+        let span = err.span();
+        Report::build(ReportKind::Error, filename, span.start())
+            .with_label(
+                Label::new((filename, span.start()..span.end()))
+                    .with_message(format!("{}", err.fg(Color::Red)))
+                    .with_color(Color::Red),
+            )
+            .finish()
+            .print((filename, Source::from(source)))
+            .unwrap();
+    }
+
+    errs.len()
+}
+
+/// A simple warpper around `anyhow::bail!` that prints a different messages based on a the number
+/// of compiler errors.
+macro_rules! yurtc_bail {
+    ($number_of_errors: expr, $filename: expr) => {
+        if $number_of_errors == 1 {
+            anyhow::bail!("could not compile {} due to previous error", $filename)
+        } else {
+            anyhow::bail!(
+                "could not compile {} due to {} previous errors",
+                $filename,
+                $number_of_errors
+            )
+        }
+    };
+}

--- a/yurtc/src/lexer.rs
+++ b/yurtc/src/lexer.rs
@@ -1,9 +1,11 @@
+use crate::error::{CompileError, LexError, Span};
+use itertools::{Either, Itertools};
 use logos::Logos;
-
-type Span = std::ops::Range<usize>;
+use std::fmt;
 
 #[derive(Clone, Debug, Eq, Hash, Logos, PartialEq)]
 #[logos(skip r"[ \t\n\r\f]+")]
+#[logos(error = LexError)]
 pub(super) enum Token<'sc> {
     #[token(":")]
     Colon,
@@ -43,9 +45,94 @@ pub(super) enum Token<'sc> {
     Comment,
 }
 
-pub(super) fn lex(src: &str) -> Result<Vec<(Token, Span)>, ()> {
+impl<'sc> fmt::Display for Token<'sc> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Token::Colon => write!(f, ":"),
+            Token::Eq => write!(f, "="),
+            Token::Gt => write!(f, ">"),
+            Token::Lt => write!(f, "<"),
+            Token::Semi => write!(f, ";"),
+            Token::Star => write!(f, "*"),
+            Token::Real => write!(f, "real"),
+            Token::Let => write!(f, "let"),
+            Token::Constraint => write!(f, "constraint"),
+            Token::Maximize => write!(f, "maximize"),
+            Token::Minimize => write!(f, "minimize"),
+            Token::Solve => write!(f, "solve"),
+            Token::Satisfy => write!(f, "satisfy"),
+            Token::Ident(ident) => write!(f, "{ident}"),
+            Token::Number(ident) => write!(f, "{ident}"),
+            Token::Comment => write!(f, "comment"),
+        }
+    }
+}
+
+/// Lex a stream of characters. Return a list of discovered tokens and a list of errors encountered
+/// along the way.
+pub(super) fn lex(src: &str) -> (Vec<(Token, Span)>, Vec<CompileError>) {
     Token::lexer(src)
         .spanned()
-        .map(|(tok, span)| tok.map(|tok| (tok, span)))
-        .collect()
+        .partition_map(|(r, span)| match r {
+            Ok(v) => Either::Left((v, span)),
+            Err(v) => Either::Right(CompileError::Lex { span, error: v }),
+        })
+}
+
+#[test]
+fn lex_with_error() {
+    let src = r#"
+let low_val: int = 5.0;
+constraint mid > low_val # 2;
+constraint mid < low_val @ 2;
+solve minimize mid;
+"#;
+
+    let (tokens, errors) = lex(src);
+
+    // Check errors
+    assert_eq!(errors.len(), 2);
+    assert!(matches!(
+        (&errors[0], &errors[1]),
+        (
+            CompileError::Lex {
+                error: LexError::InvalidToken,
+                ..
+            },
+            CompileError::Lex {
+                error: LexError::InvalidToken,
+                ..
+            }
+        )
+    ));
+
+    // Check tokens
+    use Token::*;
+    assert_eq!(tokens.len(), 23);
+    assert!(matches!(tokens[0].0, Let));
+    assert!(matches!(tokens[1].0, Ident("low_val")));
+    assert!(matches!(tokens[2].0, Colon));
+    assert!(matches!(tokens[3].0, Ident("int")));
+    assert!(matches!(tokens[4].0, Eq));
+    assert!(matches!(tokens[5].0, Number("5.0")));
+    assert!(matches!(tokens[6].0, Semi));
+
+    assert!(matches!(tokens[7].0, Constraint));
+    assert!(matches!(tokens[8].0, Ident("mid")));
+    assert!(matches!(tokens[9].0, Gt));
+    assert!(matches!(tokens[10].0, Ident("low_val")));
+    assert!(matches!(tokens[11].0, Number("2")));
+    assert!(matches!(tokens[12].0, Semi));
+
+    assert!(matches!(tokens[13].0, Constraint));
+    assert!(matches!(tokens[14].0, Ident("mid")));
+    assert!(matches!(tokens[15].0, Lt));
+    assert!(matches!(tokens[16].0, Ident("low_val")));
+    assert!(matches!(tokens[17].0, Number("2")));
+    assert!(matches!(tokens[18].0, Semi));
+
+    assert!(matches!(tokens[19].0, Solve));
+    assert!(matches!(tokens[20].0, Minimize));
+    assert!(matches!(tokens[21].0, Ident("mid")));
+    assert!(matches!(tokens[22].0, Semi));
 }

--- a/yurtc/src/main.rs
+++ b/yurtc/src/main.rs
@@ -1,4 +1,7 @@
 mod ast;
+
+#[macro_use]
+mod error;
 mod lexer;
 mod parser;
 
@@ -6,7 +9,7 @@ fn main() -> anyhow::Result<()> {
     let srcs = parse_cli();
     let asts = srcs
         .iter()
-        .map(|src| parser::parse_path_to_ast(std::path::Path::new(src)))
+        .map(|src| parser::parse_path_to_ast(std::path::Path::new(src), src))
         .collect::<anyhow::Result<Vec<_>>>()?;
 
     dbg!(asts);


### PR DESCRIPTION
List of changes: 

1. Introduce an `error` module with a bunch of error handling utilities including a `LexError` enum and a wrapper `CompileError` enum.
2. Update the lexer API to return the tokens discovered as well as **all** the errors encountered along the way.
3. Collect lex AND parse errors and print them out using `ariadne`.
4. Two new tests.

Sample output:
<img width="493" alt="image" src="https://github.com/essential-contributions/yurt/assets/59666792/80bfbe63-e242-4933-8166-474b2571b26b">

There are still may things we could do.
- More specific lex errors
- Better error messages: error code, error message, multiple labels where applicable, etc.

Closes #35 