### PR TITLE
Parse decision variables `var` and differentiate them from config variables (+ spec update)

### DIFF
--- a/specs/src/lang/language_primitives.md
+++ b/specs/src/lang/language_primitives.md
@@ -77,16 +77,13 @@ Items can occur in any order; identifiers need not be declared before they are u
 ```ebnf
 <item> ::= <let-item>
          | <var-item>
-         | <assign-item>
          | <constraint-item>
          | <function-item>
          | <solve-item>
          | <transition-item>
 ```
 
-Variable declaration items (`<let-item>` and `<var-item`) introduce variables and optinoally bind them to a value ([Variable Declaration Items](#variable-declaration-items)).
-
-Assignment items bind values to variables ([Assignment Items](#assignment-items)).
+Variable declaration items (`<let-item>` and `<var-item`) introduce variables and optionally bind them to a value ([Variable Declaration Items](#variable-declaration-items)).
 
 Constraint items describe intent constraints ([Constraint Items](#constraint-items)).
 
@@ -189,7 +186,6 @@ Block expressions are expressions that contains a list of _statements_ followed 
 
 <block-statement> ::= <let-item>
                     | <var-item>
-                    | <assign-item>
                     | <constraint-item>
                     | <if-expr>
 ```
@@ -302,7 +298,7 @@ These are variables whose values are fixed for each given _instance_ of an inten
 Configuration variables have the following syntax:
 
 ```ebnf
-<let-item> ::= "let" <ident> [ ":" <ty> ] [ "=" <expr> ]
+<let-item> ::= "let" <ident> [ ":" <ty> ] "=" <expr>
 ```
 
 For example:
@@ -311,17 +307,6 @@ For example:
 let a:int = 10;
 let b = 5;
 ```
-
-A variable whose declaration does not include an assignment can be initialized by a separate assignment item ([Assignment Items](#assignment-items)). For example, the above items can be separated into the following items:
-
-```rust
-let a:int;
-a = 10;
-let b;
-b = 5;
-```
-
-Variables can only be assigned once in an intent.
 
 #### Decision variables
 
@@ -336,11 +321,11 @@ Decision variables have the following syntax:
 For example:
 
 ```rust
-var x:int;
+var x: int;
 let y = 5;
 ```
 
-Similarly to configuration variables, decision variables can also be assigned, at most once, by a separate assignment item. Values used for initialization or assignment enforce an equality constraint on the decision variable. For example, the following:
+The optional value used for initializing a decision variable enforce an equality constraint on the variable. For example, the following:
 
 ```rust
 var x: int = 5;
@@ -351,14 +336,6 @@ is equivalent to
 ```rust
 var x: int;
 constraint x == 5;
-```
-
-### Assignment Items
-
-Assignments have this syntax:
-
-```ebnf
-<assign-item> ::= <ident> "=" <expr>
 ```
 
 ### Constraint Items

--- a/yurtc/src/ast.rs
+++ b/yurtc/src/ast.rs
@@ -1,26 +1,27 @@
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
-pub(super) enum ValueKind {
-    Var,
-    Config,
-}
-
 #[derive(Clone, Debug, PartialEq)]
-pub(super) struct ValueDeclStatement {
-    pub(super) kind: ValueKind,
+pub(super) struct VarStatement {
     pub(super) name: Ident,
     pub(super) ty: Option<Type>,
     pub(super) init: Option<Expr>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub(super) struct LetStatement {
+    pub(super) name: Ident,
+    pub(super) ty: Option<Type>,
+    pub(super) init: Expr,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub(super) struct CodeBlock {
-    pub(super) statements: Vec<ValueDeclStatement>,
+    pub(super) statements: Vec<LetStatement>,
     pub(super) final_expr: Expr,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) enum Decl {
-    Value(ValueDeclStatement),
+    Var(VarStatement),
+    Let(LetStatement),
     Constraint(Expr),
     Fn {
         name: Ident,

--- a/yurtc/src/lexer.rs
+++ b/yurtc/src/lexer.rs
@@ -38,10 +38,10 @@ pub(super) enum Token<'sc> {
     #[token("fn")]
     Fn,
 
-    #[token("let")]
-    Let,
     #[token("var")]
     Var,
+    #[token("let")]
+    Let,
     #[token("constraint")]
     Constraint,
     #[token("maximize")]

--- a/yurtc/src/parser.rs
+++ b/yurtc/src/parser.rs
@@ -55,32 +55,47 @@ fn parse_str_to_ast_inner(source: &str) -> Result<Ast, Vec<CompileError>> {
 }
 
 fn yurt_program<'sc>() -> impl Parser<Token<'sc>, Ast, Error = Simple<Token<'sc>>> + Clone {
-    choice((value_decl(), constraint_decl(), solve_decl(), fn_decl()))
-        .repeated()
-        .then_ignore(end())
+    choice((
+        var_decl(),
+        let_decl(),
+        constraint_decl(),
+        solve_decl(),
+        fn_decl(),
+    ))
+    .repeated()
+    .then_ignore(end())
 }
 
-fn value_decl<'sc>() -> impl Parser<Token<'sc>, ast::Decl, Error = Simple<Token<'sc>>> + Clone {
-    value_decl_statement().map(ast::Decl::Value)
+fn var_decl<'sc>() -> impl Parser<Token<'sc>, ast::Decl, Error = Simple<Token<'sc>>> + Clone {
+    var_statement().map(ast::Decl::Var)
 }
 
-fn value_decl_statement<'sc>(
-) -> impl Parser<Token<'sc>, ast::ValueDeclStatement, Error = Simple<Token<'sc>>> + Clone {
+fn var_statement<'sc>(
+) -> impl Parser<Token<'sc>, ast::VarStatement, Error = Simple<Token<'sc>>> + Clone {
     let type_spec = just(Token::Colon).ignore_then(type_());
     let init = just(Token::Eq).ignore_then(expr());
-    let var_value = just(Token::Var).to(ast::ValueKind::Var);
-    let config_value = just(Token::Let).to(ast::ValueKind::Config);
-    choice((var_value, config_value))
-        .then(ident())
+    just(Token::Var)
+        .ignore_then(ident())
         .then(type_spec.or_not())
         .then(init.or_not())
         .then_ignore(just(Token::Semi))
-        .map(|(((kind, name), ty), init)| ast::ValueDeclStatement {
-            kind,
-            name,
-            ty,
-            init,
-        })
+        .map(|((name, ty), init)| ast::VarStatement { name, ty, init })
+}
+
+fn let_decl<'sc>() -> impl Parser<Token<'sc>, ast::Decl, Error = Simple<Token<'sc>>> + Clone {
+    let_statement().map(ast::Decl::Let)
+}
+
+fn let_statement<'sc>(
+) -> impl Parser<Token<'sc>, ast::LetStatement, Error = Simple<Token<'sc>>> + Clone {
+    let type_spec = just(Token::Colon).ignore_then(type_());
+    let init = just(Token::Eq).ignore_then(expr());
+    just(Token::Let)
+        .ignore_then(ident())
+        .then(type_spec.or_not())
+        .then(init)
+        .then_ignore(just(Token::Semi))
+        .map(|((name, ty), init)| ast::LetStatement { name, ty, init })
 }
 
 fn constraint_decl<'sc>() -> impl Parser<Token<'sc>, ast::Decl, Error = Simple<Token<'sc>>> + Clone
@@ -117,7 +132,7 @@ fn fn_decl<'sc>() -> impl Parser<Token<'sc>, ast::Decl, Error = Simple<Token<'sc
 
     let return_type = just(Token::Arrow).ignore_then(type_());
 
-    let body = value_decl_statement().repeated().then(expr());
+    let body = let_statement().repeated().then(expr());
 
     just(Token::Fn)
         .ignore_then(ident())
@@ -223,60 +238,54 @@ fn check(actual: &str, expect: expect_test::Expect) {
 }
 
 #[test]
-fn value_decls() {
+fn let_decls() {
     check(
-        &format!("{:?}", run_parser!(value_decl(), "let blah = 1;")),
+        &format!("{:?}", run_parser!(let_decl(), "let blah = 1;")),
         expect_test::expect![[
-            r#"Ok(Value(ValueDeclStatement { kind: Config, name: Ident("blah"), ty: None, init: Some(Immediate(Real(1.0))) }))"#
+            r#"Ok(Let(LetStatement { name: Ident("blah"), ty: None, init: Immediate(Real(1.0)) }))"#
         ]],
     );
 
     check(
-        &format!("{:?}", run_parser!(value_decl(), "let blah: real = 1;")),
+        &format!("{:?}", run_parser!(let_decl(), "let blah: real = 1;")),
         expect_test::expect![[
-            r#"Ok(Value(ValueDeclStatement { kind: Config, name: Ident("blah"), ty: Some(Real), init: Some(Immediate(Real(1.0))) }))"#
+            r#"Ok(Let(LetStatement { name: Ident("blah"), ty: Some(Real), init: Immediate(Real(1.0)) }))"#
         ]],
     );
 
     check(
-        &format!("{:?}", run_parser!(value_decl(), "let blah: real;")),
+        &format!("{:?}", run_parser!(let_decl(), "let blah: real")),
+        expect_test::expect!["Err([Simple { span: 14..14, reason: Unexpected, expected: {Some(Eq)}, found: None, label: None }])"],
+    );
+}
+
+#[test]
+fn var_decls() {
+    check(
+        &format!("{:?}", run_parser!(var_decl(), "var blah = 1;")),
         expect_test::expect![[
-            r#"Ok(Value(ValueDeclStatement { kind: Config, name: Ident("blah"), ty: Some(Real), init: None }))"#
+            r#"Ok(Var(VarStatement { name: Ident("blah"), ty: None, init: Some(Immediate(Real(1.0))) }))"#
         ]],
     );
 
     check(
-        &format!("{:?}", run_parser!(value_decl(), "let blah;")),
+        &format!("{:?}", run_parser!(var_decl(), "var blah: real = 1;")),
         expect_test::expect![[
-            r#"Ok(Value(ValueDeclStatement { kind: Config, name: Ident("blah"), ty: None, init: None }))"#
+            r#"Ok(Var(VarStatement { name: Ident("blah"), ty: Some(Real), init: Some(Immediate(Real(1.0))) }))"#
         ]],
     );
 
     check(
-        &format!("{:?}", run_parser!(value_decl(), "var blah = 1;")),
+        &format!("{:?}", run_parser!(var_decl(), "var blah: real;")),
         expect_test::expect![[
-            r#"Ok(Value(ValueDeclStatement { kind: Var, name: Ident("blah"), ty: None, init: Some(Immediate(Real(1.0))) }))"#
+            r#"Ok(Var(VarStatement { name: Ident("blah"), ty: Some(Real), init: None }))"#
         ]],
     );
 
     check(
-        &format!("{:?}", run_parser!(value_decl(), "var blah: real = 1;")),
+        &format!("{:?}", run_parser!(var_decl(), "var blah;")),
         expect_test::expect![[
-            r#"Ok(Value(ValueDeclStatement { kind: Var, name: Ident("blah"), ty: Some(Real), init: Some(Immediate(Real(1.0))) }))"#
-        ]],
-    );
-
-    check(
-        &format!("{:?}", run_parser!(value_decl(), "var blah: real;")),
-        expect_test::expect![[
-            r#"Ok(Value(ValueDeclStatement { kind: Var, name: Ident("blah"), ty: Some(Real), init: None }))"#
-        ]],
-    );
-
-    check(
-        &format!("{:?}", run_parser!(value_decl(), "var blah;")),
-        expect_test::expect![[
-            r#"Ok(Value(ValueDeclStatement { kind: Var, name: Ident("blah"), ty: None, init: None }))"#
+            r#"Ok(Var(VarStatement { name: Ident("blah"), ty: None, init: None }))"#
         ]],
     );
 }
@@ -412,7 +421,6 @@ fn fn_decl_test() {
     let src = r#"
 fn foo(x: real, y: real) -> real {
     let z = 5;
-    var t;
     z
 }
 "#;
@@ -420,7 +428,7 @@ fn foo(x: real, y: real) -> real {
     check(
         &format!("{:?}", run_parser!(yurt_program(), src)),
         expect_test::expect![[
-            r#"Ok([Fn { name: Ident("foo"), params: [(Ident("x"), Real), (Ident("y"), Real)], return_type: Real, body: CodeBlock { statements: [ValueDeclStatement { kind: Config, name: Ident("z"), ty: None, init: Some(Immediate(Real(5.0))) }, ValueDeclStatement { kind: Var, name: Ident("t"), ty: None, init: None }], final_expr: Ident(Ident("z")) } }])"#
+            r#"Ok([Fn { name: Ident("foo"), params: [(Ident("x"), Real), (Ident("y"), Real)], return_type: Real, body: CodeBlock { statements: [LetStatement { name: Ident("z"), ty: None, init: Immediate(Real(5.0)) }], final_expr: Ident(Ident("z")) } }])"#
         ]],
     );
 }
@@ -434,7 +442,7 @@ let x = foo(a*3, c);
     check(
         &format!("{:?}", run_parser!(yurt_program(), src)),
         expect_test::expect![[
-            r#"Ok([Value(ValueDeclStatement { kind: Config, name: Ident("x"), ty: None, init: Some(Call { name: Ident("foo"), args: [BinaryOp { op: Mul, lhs: Ident(Ident("a")), rhs: Immediate(Real(3.0)) }, Ident(Ident("c"))] }) })])"#
+            r#"Ok([Let(LetStatement { name: Ident("x"), ty: None, init: Call { name: Ident("foo"), args: [BinaryOp { op: Mul, lhs: Ident(Ident("a")), rhs: Immediate(Real(3.0)) }, Ident(Ident("c"))] } })])"#
         ]],
     );
 }
@@ -442,7 +450,7 @@ let x = foo(a*3, c);
 #[test]
 fn basic_program() {
     let src = r#"
-let low_val: real = 1.23;
+var low_val: real = 1.23;
 let high_val = 4.56;        // Implicit type.
 
 // Here's the constraints.
@@ -455,7 +463,7 @@ solve minimize mid;
     check(
         &format!("{:?}", run_parser!(yurt_program(), src)),
         expect_test::expect![[
-            r#"Ok([Value(ValueDeclStatement { kind: Config, name: Ident("low_val"), ty: Some(Real), init: Some(Immediate(Real(1.23))) }), Value(ValueDeclStatement { kind: Config, name: Ident("high_val"), ty: None, init: Some(Immediate(Real(4.56))) }), Constraint(BinaryOp { op: GreaterThan, lhs: Ident(Ident("mid")), rhs: BinaryOp { op: Mul, lhs: Ident(Ident("low_val")), rhs: Immediate(Real(2.0)) } }), Constraint(BinaryOp { op: LessThan, lhs: Ident(Ident("mid")), rhs: Ident(Ident("high_val")) }), Solve(Minimize(Ident("mid")))])"#
+            r#"Ok([Var(VarStatement { name: Ident("low_val"), ty: Some(Real), init: Some(Immediate(Real(1.23))) }), Let(LetStatement { name: Ident("high_val"), ty: None, init: Immediate(Real(4.56)) }), Constraint(BinaryOp { op: GreaterThan, lhs: Ident(Ident("mid")), rhs: BinaryOp { op: Mul, lhs: Ident(Ident("low_val")), rhs: Immediate(Real(2.0)) } }), Constraint(BinaryOp { op: LessThan, lhs: Ident(Ident("mid")), rhs: Ident(Ident("high_val")) }), Solve(Minimize(Ident("mid")))])"#
         ]],
     );
 }
@@ -464,7 +472,7 @@ solve minimize mid;
 fn with_errors() {
     let src = r#"let low_val: bad = 1.23"#;
 
-    let res = run_parser!(value_decl(), src);
+    let res = run_parser!(var_decl(), src);
     assert!(res.is_err());
     let errs = res.unwrap_err();
     assert!(matches!(errs[0], Simple { .. }));
@@ -489,11 +497,7 @@ fn fn_errors() {
     let err = &res.unwrap_err()[0];
     assert_eq!(err.reason(), &chumsky::error::SimpleReason::Unexpected);
     assert_eq!(err.found(), Some(&Token::BraceClose));
-
-    // The tokens in `err.found()` are stored in a non-deterministic order.
-    let err_expected: std::collections::HashSet<_> = err.expected().collect();
-    assert!(err_expected.contains(&Some(Token::Var)));
-    assert!(err_expected.contains(&Some(Token::Let)));
+    assert_eq!(err.expected().collect::<Vec<_>>(), vec![&Some(Token::Let)]);
 }
 
 #[test]
@@ -509,7 +513,7 @@ let low = 1;
     check(
         &format!("{:?}", run_parser!(yurt_program(), src)),
         expect_test::expect![[
-            r#"Ok([Solve(Maximize(Ident("low"))), Constraint(BinaryOp { op: LessThan, lhs: Ident(Ident("low")), rhs: Ident(Ident("high")) }), Value(ValueDeclStatement { kind: Config, name: Ident("high"), ty: None, init: Some(Immediate(Real(2.0))) }), Solve(Satisfy), Value(ValueDeclStatement { kind: Config, name: Ident("low"), ty: None, init: Some(Immediate(Real(1.0))) })])"#
+            r#"Ok([Solve(Maximize(Ident("low"))), Constraint(BinaryOp { op: LessThan, lhs: Ident(Ident("low")), rhs: Ident(Ident("high")) }), Let(LetStatement { name: Ident("high"), ty: None, init: Immediate(Real(2.0)) }), Solve(Satisfy), Let(LetStatement { name: Ident("low"), ty: None, init: Immediate(Real(1.0)) })])"#
         ]],
     );
 }


### PR DESCRIPTION
This now differentiates between "configurable" variables that are declared using `let`, and decision variables that are declared using `var`.

Also, I'm making initializers optional for `var` but not for `let`. I also removed `assign-item` from the specs because we don't seem to want it at the moment.

Note that initializing a decision variable is equivalent to having an equality constraint on that variable. That is
```rust
var x: real = 5;
```
is equivalent to
```rust
var x: real;
constraint x == 5;
```

Closes #27 