### PR TITLE
Introduce custom errors using `ParseError` replacing `Simple` errors and disallow keywords as identifiers

### DIFF
--- a/yurtc/src/lexer.rs
+++ b/yurtc/src/lexer.rs
@@ -102,6 +102,25 @@ pub(super) enum Token<'sc> {
     Comment,
 }
 
+pub(super) static KEYWORDS: &[Token] = &[
+    Token::Real,
+    Token::Int,
+    Token::Bool,
+    Token::True,
+    Token::False,
+    Token::String,
+    Token::Fn,
+    Token::If,
+    Token::Else,
+    Token::Var,
+    Token::Let,
+    Token::Constraint,
+    Token::Maximize,
+    Token::Minimize,
+    Token::Solve,
+    Token::Satisfy,
+];
+
 impl<'sc> fmt::Display for Token<'sc> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -132,9 +151,9 @@ impl<'sc> fmt::Display for Token<'sc> {
             Token::True => write!(f, "true"),
             Token::False => write!(f, "false"),
             Token::String => write!(f, "string"),
-            Token::Fn => write!(f, "Fn"),
-            Token::If => write!(f, "If"),
-            Token::Else => write!(f, "Else"),
+            Token::Fn => write!(f, "fn"),
+            Token::If => write!(f, "if"),
+            Token::Else => write!(f, "else"),
             Token::Let => write!(f, "let"),
             Token::Var => write!(f, "var"),
             Token::Constraint => write!(f, "constraint"),


### PR DESCRIPTION
#### Change 1
Replace `Simple` with `ParseError`, a custom error `enum`. This uses the trait `Error` from Chumsky which requires implementing a few methods. The most important one is `expected_input_found()` which handles errors of the form "found ".." but expected "..". Implementing this properly and formatting the error correctly lead us back to where we were with `Simple` error. However, now we are able to add as many custom errors as we want.

This also has the added benefit of stabilizing the error output. That is, the order in which expected tokens are emitted is always going to be the same because I'm sorting them in the function that formats the `ExpectedFound` error. 

#### Change 2
Improve error message testing by changing `run_parser!` in the test to actually print the error as the user sees them instead of checking for the error object itself.

#### Change 3
Disallow keywords as identifiers. This was already disallowed technically but the error messages were all the same. Now, if we're expecting an identifier and we see a keyword, we emit a clear error: `expected identifier, found keyword`.

Closes #64 
Closes #65 

Example errors:
<img width="462" alt="image" src="https://github.com/essential-contributions/yurt/assets/59666792/6fb229ef-2f5f-405f-8209-cd1fc984aac6">
<img width="524" alt="image" src="https://github.com/essential-contributions/yurt/assets/59666792/c2e4d4d7-7bc1-48ed-8db6-19709f0045f6">
<img width="468" alt="image" src="https://github.com/essential-contributions/yurt/assets/59666792/70d5481d-7cbb-44b8-b258-d6d14d011ec3">
