### PR TITLE
Disallow `var`s from not having a type annotation nor an initializer

### DIFF
--- a/specs/src/lang/language_primitives.md
+++ b/specs/src/lang/language_primitives.md
@@ -317,7 +317,7 @@ These are variables whose values can be unknown for a given _instance_ for an in
 Decision variables have the following syntax:
 
 ```ebnf
-<var-item> ::= "var" <ident> [ ":" <ty> ] [ "=" <expr> ]
+<var-item> ::= "var" <ident> ( ( ":" <ty> ) | ("=" <expr> ) | ( ":" <ty> "=" <expr> )
 ```
 
 For example:
@@ -339,6 +339,8 @@ is equivalent to
 var x: int;
 constraint x == 5;
 ```
+
+Note that at least one of the type annotation and the initializing expression has to be present so that the type of the variable can be determined. This implies that `var x;` is not a valid variable declaration.
 
 ### Constraint Items
 

--- a/yurtc/src/error.rs
+++ b/yurtc/src/error.rs
@@ -1,4 +1,4 @@
-use crate::lexer::Token;
+use crate::{ast, lexer::Token};
 use ariadne::{Color, Fmt, Label, Report, ReportKind, Source};
 use chumsky::prelude::*;
 use thiserror::Error;
@@ -24,6 +24,10 @@ pub(super) enum ParseError<'a> {
     },
     #[error("expected identifier, found keyword \"{keyword}\"")]
     KeywordAsIdent { span: Span, keyword: Token<'a> },
+    #[error(
+        "type annotation or initializer needed for decision variable \"{}\"", name.0
+    )]
+    UntypedDecisionVar { span: Span, name: ast::Ident },
 }
 
 fn format_expected_found_error<'a>(
@@ -115,6 +119,7 @@ impl<'a> CompileError<'a> {
             Parse { error } => match error {
                 ParseError::ExpectedFound { span, .. } => span.clone(),
                 ParseError::KeywordAsIdent { span, .. } => span.clone(),
+                ParseError::UntypedDecisionVar { span, .. } => span.clone(),
             },
         }
     }


### PR DESCRIPTION
Closes #74 

Basically disallow `var x;` because it's impossible to infer the type of `x` in this case (recall: `x` can't be assigned later because it's a decision variable.. it can only be constrained)

Example:
<img width="627" alt="image" src="https://github.com/essential-contributions/yurt/assets/59666792/013d9e8a-18db-4c9f-badb-6ef8c6d674c4">
