### PR TITLE
Parse tuple types and expressions

### DIFF
--- a/specs/src/lang/language_primitives.md
+++ b/specs/src/lang/language_primitives.md
@@ -62,7 +62,7 @@ Identifiers have the following syntax:
 <ident> ::= _?[A-Za-z][A-Za-z0-9]*     % excluding keywords
 ```
 
-A number of keywords are reserved and cannot be used as identifiers. The keywords are: `bool`, `constraint`, `else`, `false`, `real`, `fn`, `if`, `int`, `let`, `maximize`, `minimize`, `satisfy`, `solve`, `true`, `type`.
+A number of keywords are reserved and cannot be used as identifiers. The keywords are: `bool`, `constraint`, `else`, `false`, `real`, `fn`, `if`, `int`, `let`, `maximize`, `minimize`, `satisfy`, `solve`, `true`.
 
 ## High-level Intent Structure
 
@@ -138,7 +138,8 @@ Expressions represent values and have the following syntax:
               | <int-literal>
               | <real-literal>
               | <string-literal>
-              | <tuple-literal>
+              | <tuple-expr>
+              | <tuple-index-expr>
               | <if-expr>
               | <call-expr>
 ```
@@ -249,15 +250,23 @@ let string = "first line\
              third line";
 ```
 
-#### Tuple Literals
+#### Tuple Expressions and Tuple Indexing Expressions
 
-Tuple literals are written as:
+Tuple Expressions are written as:
 
 ```ebnf
-<tuple-literal> ::= "(" <expr> "," [ <expr> "," ... ] ")"
+<tuple-expr> ::= "(" <expr> "," [ <expr> "," ... ] ")"
 ```
 
-For example: `let t = (5, 3, "foo")`;
+For example: `let t = (5, 3, "foo");`.
+
+Tuple indexing expressions are written as:
+
+```ebnf
+<tuple-index-expr> ::= <expr-atom> "." [0-9]+
+```
+
+For example: `let second = t.1;` which extracts the second element of tuple `t` and stores it into `second`.
 
 #### "If" Expressions
 
@@ -279,7 +288,7 @@ Call expressions are used to call functions and have the following syntax:
 <call-expr> ::= <ident> "(" ( <expr> "," ... ) ")"
 ```
 
-For example, `x = foo(5, 2);`
+For example: `x = foo(5, 2);`.
 
 The type of the expressions passed as arguments must match the argument types of the called function. The return type of the function must also be appropriate for the calling context.
 

--- a/yurtc/src/ast.rs
+++ b/yurtc/src/ast.rs
@@ -41,6 +41,7 @@ pub(super) enum Type {
     Int,
     Bool,
     String,
+    Tuple(Vec<Type>),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -62,6 +63,11 @@ pub(super) enum Expr {
     },
     Block(Block),
     If(IfExpr),
+    Tuple(Vec<Expr>),
+    TupleIndex {
+        tuple: Box<Expr>,
+        index: usize,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/yurtc/src/error.rs
+++ b/yurtc/src/error.rs
@@ -28,6 +28,10 @@ pub(super) enum ParseError<'a> {
         "type annotation or initializer needed for decision variable \"{}\"", name.0
     )]
     UntypedDecisionVar { span: Span, name: ast::Ident },
+    #[error("Invalid integer value \"{}\" for tuple index", index)]
+    InvalidIntegerForTupleIndex { span: Span, index: Token<'a> },
+    #[error("Invalid value \"{}\" for tuple index", index)]
+    InvalidTupleIndex { span: Span, index: Token<'a> },
 }
 
 fn format_expected_found_error<'a>(
@@ -120,6 +124,8 @@ impl<'a> CompileError<'a> {
                 ParseError::ExpectedFound { span, .. } => span.clone(),
                 ParseError::KeywordAsIdent { span, .. } => span.clone(),
                 ParseError::UntypedDecisionVar { span, .. } => span.clone(),
+                ParseError::InvalidIntegerForTupleIndex { span, .. } => span.clone(),
+                ParseError::InvalidTupleIndex { span, .. } => span.clone(),
             },
         }
     }

--- a/yurtc/src/lexer.rs
+++ b/yurtc/src/lexer.rs
@@ -49,6 +49,8 @@ pub(super) enum Token<'sc> {
     ParenClose,
     #[token("->")]
     Arrow,
+    #[token(".")]
+    Dot,
 
     #[token("real")]
     Real,
@@ -150,6 +152,7 @@ impl<'sc> fmt::Display for Token<'sc> {
             Token::ParenOpen => write!(f, "("),
             Token::ParenClose => write!(f, ")"),
             Token::Arrow => write!(f, "->"),
+            Token::Dot => write!(f, "."),
             Token::Real => write!(f, "real"),
             Token::Int => write!(f, "int"),
             Token::Bool => write!(f, "bool"),
@@ -258,12 +261,17 @@ fn lex_one_success(src: &str) -> Token<'_> {
     toks[0].0.clone()
 }
 
-#[cfg(test)]
-fn lex_one_error(src: &str) -> CompileError {
-    // Tokenise src, assume a single error.
-    let (_, errs) = lex(src);
-    assert_eq!(errs.len(), 1, "Testing for single error only.");
-    errs[0].clone()
+#[test]
+fn control_tokens() {
+    assert_eq!(lex_one_success(":"), Token::Colon);
+    assert_eq!(lex_one_success(";"), Token::Semi);
+    assert_eq!(lex_one_success(","), Token::Comma);
+    assert_eq!(lex_one_success("{"), Token::BraceOpen);
+    assert_eq!(lex_one_success("}"), Token::BraceClose);
+    assert_eq!(lex_one_success("("), Token::ParenOpen);
+    assert_eq!(lex_one_success(")"), Token::ParenClose);
+    assert_eq!(lex_one_success("->"), Token::Arrow);
+    assert_eq!(lex_one_success("."), Token::Dot);
 }
 
 #[test]
@@ -275,12 +283,12 @@ fn reals() {
     assert_eq!(lex_one_success("0.34"), Token::RealLiteral("0.34"));
     assert_eq!(lex_one_success("-0.34"), Token::RealLiteral("-0.34"));
     check(
-        &format!("{:?}", lex_one_error(".34")),
-        expect_test::expect![[r#"Lex { span: 0..1, error: InvalidToken }"#]],
+        &format!("{:?}", lex(".34")),
+        expect_test::expect![[r#"([(Dot, 0..1), (IntLiteral("34"), 1..3)], [])"#]],
     );
     check(
-        &format!("{:?}", lex_one_error("12.")),
-        expect_test::expect!["Lex { span: 2..3, error: InvalidToken }"],
+        &format!("{:?}", lex("12.")),
+        expect_test::expect![[r#"([(IntLiteral("12"), 0..2), (Dot, 2..3)], [])"#]],
     );
 }
 


### PR DESCRIPTION
Closes #72 

Fairly simple change:
- Tuple types
- Tuple expressions
- Tuple indexing expressions. Error out on invalid indices such as `0xa` or anything that is not a `usize`.

Note that `t.0.0` does not currently work, but `t.0 .0`. Once we implement #66, we can then write `(t.0).0`. In the future, we can support `t.0.0` which can be done in two ways:
- Special case the lexer to _not_ parse the `0.0` as a real in the case of a tuple access (this means the lexer now has to concern itself with the context).
- Break the real `0.0` apart in the pasrer, which kinda what Rust does (see https://github.com/rust-lang/rust/pull/71322 after an attempt for the other method in https://github.com/rust-lang/rust/pull/70420)