### PR TITLE
Add parsing of big-ints which won't fit in an i64.

### DIFF
--- a/yurtc/Cargo.lock
+++ b/yurtc/Cargo.lock
@@ -79,6 +79,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +302,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbfc0d229f1f42d790440136d941afd806bc9e949e2bcb8faa813b0f00d1267e"
 dependencies = [
  "logos-codegen",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -536,5 +572,7 @@ dependencies = [
  "expect-test",
  "itertools",
  "logos",
+ "num-bigint",
+ "num-traits",
  "thiserror",
 ]

--- a/yurtc/Cargo.toml
+++ b/yurtc/Cargo.toml
@@ -7,10 +7,12 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-ariadne = "0.3.0"
+ariadne = "0.3"
 chumsky = "0.9"
 clap = { version = "4.3", features = ["cargo"] }
 expect-test = "1.4"
-itertools = "0.11.0"
+itertools = "0.11"
 logos = "0.13"
+num-bigint = "0.4"
+num-traits = "0.2"
 thiserror = "1.0"

--- a/yurtc/src/ast.rs
+++ b/yurtc/src/ast.rs
@@ -96,6 +96,7 @@ pub(super) enum BinaryOp {
 pub(super) enum Immediate {
     Real(f64),
     Int(i64),
+    BigInt(num_bigint::BigInt),
     Bool(bool),
     String(String),
 }

--- a/yurtc/src/lexer/tests.rs
+++ b/yurtc/src/lexer/tests.rs
@@ -52,6 +52,23 @@ fn ints() {
     assert_eq!(lex_one_success("0030"), Token::IntLiteral("0030"));
     assert_eq!(lex_one_success("0x333"), Token::IntLiteral("0x333"));
     assert_eq!(lex_one_success("0b1010"), Token::IntLiteral("0b1010"));
+
+    assert_eq!(
+        lex_one_success("1111111111222222222233333333334444444444"),
+        Token::IntLiteral("1111111111222222222233333333334444444444")
+    );
+    assert_eq!(
+        lex_one_success("0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd"),
+        Token::IntLiteral("0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd")
+    );
+    assert_eq!(
+        lex_one_success(
+            "0b11111111110000000000111111111100000000001111111111000000000011111111110000000000"
+        ),
+        Token::IntLiteral(
+            "0b11111111110000000000111111111100000000001111111111000000000011111111110000000000"
+        )
+    );
 }
 
 #[test]


### PR DESCRIPTION
Useful for blockchain addresses and other hashes.

Closes #91.

I chose to keep regular `ast::Immediate::Int` and to add `ast::Immedate::BigInt`.   I guess we won't be doing arithmetic with bigints in Yurt, since I don't really see us needing to manipulate hashes or addresses..?  Maybe.  Either way the `num_bigint` library should support it.