### PR TITLE
Remove `var` in favour of just `let`, and introduce `const` to replace the old `let`

### DIFF
--- a/specs/src/lang/language_primitives.md
+++ b/specs/src/lang/language_primitives.md
@@ -76,14 +76,13 @@ Items can occur in any order; identifiers need not be declared before they are u
 
 ```ebnf
 <item> ::= <let-item>
-         | <var-item>
          | <constraint-item>
          | <function-item>
          | <solve-item>
          | <transition-item>
 ```
 
-Variable declaration items (`<let-item>` and `<var-item`) introduce variables and optionally bind them to a value ([Variable Declaration Items](#variable-declaration-items)).
+Variable declaration items (`<let-item>`) introduce variables and optionally bind them to a value ([Variable Declaration Items](#variable-declaration-items)).
 
 Constraint items describe intent constraints ([Constraint Items](#constraint-items)).
 
@@ -183,7 +182,6 @@ Block expressions are expressions that contains a list of _statements_ followed 
 <block-expr> ::= "{" [ <block-statement> ";" ... ] <expr> "}"
 
 <block-statement> ::= <let-item>
-                    | <var-item>
                     | <constraint-item>
                     | <if-expr>
 ```
@@ -297,56 +295,22 @@ This section describes the top-level program items.
 
 ### Variable Declaration Items
 
-There are two types of variable declarations:
+These are variables whose values may or may not be unknown for a given _instance_ for an intent. Solvers are required to find appropriate values for those variables with unknown values at compile-time.
 
-#### Configuration variables
-
-These are variables whose values are fixed for each given _instance_ of an intent.
-
-Configuration variables have the following syntax:
+Variable declaration items have the following syntax:
 
 ```ebnf
-<let-item> ::= "let" <ident> [ ":" <ty> ] "=" <expr>
+<let-item> ::= "let" <ident> ( ( ":" <ty> ) | ("=" <expr> ) | ( ":" <ty> "=" <expr> )
 ```
 
 For example:
 
 ```rust
-let a:int = 10;
-let b = 5;
-```
-
-#### Decision variables
-
-These are variables whose values can be unknown for a given _instance_ for an intent. Solver are required to find appropriate values for these variables.
-
-Decision variables have the following syntax:
-
-```ebnf
-<var-item> ::= "var" <ident> ( ( ":" <ty> ) | ("=" <expr> ) | ( ":" <ty> "=" <expr> )
-```
-
-For example:
-
-```rust
-var x: int;
+let x: int;
 let y = 5;
 ```
 
-The optional value used for initializing a decision variable enforce an equality constraint on the variable. For example, the following:
-
-```rust
-var x: int = 5;
-```
-
-is equivalent to
-
-```rust
-var x: int;
-constraint x == 5;
-```
-
-Note that at least one of the type annotation and the initializing expression has to be present so that the type of the variable can be determined. This implies that `var x;` is not a valid variable declaration.
+Note that at least one of the type annotation and the initializing expression has to be present so that the type of the variable can be determined. This implies that `let x;` is not a valid variable declaration.
 
 ### Constraint Items
 
@@ -405,7 +369,7 @@ fn even(x: int) -> bool {
 
 ### Transition Items
 
-Transition items represent a relationship between two decision variables that represent the state of a blockchain such as balances. Transition items have the following syntax:
+Transition items represent a relationship between two variables that represent the state of a blockchain such as balances. Transition items have the following syntax:
 
 ```ebnf
 <transition-item> ::= <ident> "~>" <ident>

--- a/yurtc/src/ast.rs
+++ b/yurtc/src/ast.rs
@@ -1,15 +1,8 @@
 #[derive(Clone, Debug, PartialEq)]
-pub(super) struct VarStatement {
+pub(super) struct LetDecl {
     pub(super) name: Ident,
     pub(super) ty: Option<Type>,
     pub(super) init: Option<Expr>,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub(super) struct LetStatement {
-    pub(super) name: Ident,
-    pub(super) ty: Option<Type>,
-    pub(super) init: Expr,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -20,8 +13,7 @@ pub(super) struct Block {
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) enum Decl {
-    Var(VarStatement),
-    Let(LetStatement),
+    Let(LetDecl),
     Constraint(Expr),
     Fn {
         name: Ident,

--- a/yurtc/src/error.rs
+++ b/yurtc/src/error.rs
@@ -25,9 +25,9 @@ pub(super) enum ParseError<'a> {
     #[error("expected identifier, found keyword \"{keyword}\"")]
     KeywordAsIdent { span: Span, keyword: Token<'a> },
     #[error(
-        "type annotation or initializer needed for decision variable \"{}\"", name.0
+        "type annotation or initializer needed for variable \"{}\"", name.0
     )]
-    UntypedDecisionVar { span: Span, name: ast::Ident },
+    UntypedVariable { span: Span, name: ast::Ident },
     #[error("invalid integer value \"{}\" for tuple index", index)]
     InvalidIntegerTupleIndex { span: Span, index: &'a str },
     #[error("invalid value \"{}\" for tuple index", index)]
@@ -123,7 +123,7 @@ impl<'a> CompileError<'a> {
             Parse { error } => match error {
                 ParseError::ExpectedFound { span, .. } => span.clone(),
                 ParseError::KeywordAsIdent { span, .. } => span.clone(),
-                ParseError::UntypedDecisionVar { span, .. } => span.clone(),
+                ParseError::UntypedVariable { span, .. } => span.clone(),
                 ParseError::InvalidIntegerTupleIndex { span, .. } => span.clone(),
                 ParseError::InvalidTupleIndex { span, .. } => span.clone(),
             },

--- a/yurtc/src/lexer.rs
+++ b/yurtc/src/lexer.rs
@@ -76,8 +76,6 @@ pub(super) enum Token<'sc> {
     #[token("else")]
     Else,
 
-    #[token("var")]
-    Var,
     #[token("let")]
     Let,
     #[token("constraint")]
@@ -122,7 +120,6 @@ pub(super) static KEYWORDS: &[Token] = &[
     Token::Fn,
     Token::If,
     Token::Else,
-    Token::Var,
     Token::Let,
     Token::Constraint,
     Token::Maximize,
@@ -166,7 +163,6 @@ impl<'sc> fmt::Display for Token<'sc> {
             Token::If => write!(f, "if"),
             Token::Else => write!(f, "else"),
             Token::Let => write!(f, "let"),
-            Token::Var => write!(f, "var"),
             Token::Constraint => write!(f, "constraint"),
             Token::Maximize => write!(f, "maximize"),
             Token::Minimize => write!(f, "minimize"),

--- a/yurtc/src/lexer/tests.rs
+++ b/yurtc/src/lexer/tests.rs
@@ -123,7 +123,6 @@ fn strings() {
 
 #[test]
 fn variables() {
-    assert_eq!(lex_one_success("var"), Token::Var);
     assert_eq!(lex_one_success("let"), Token::Let);
 }
 

--- a/yurtc/src/parser/tests.rs
+++ b/yurtc/src/parser/tests.rs
@@ -61,157 +61,81 @@ fn types() {
 #[test]
 fn let_decls() {
     check(
+        &run_parser!(let_decl(expr()), "let blah;"),
+        expect_test::expect![[r#"
+            @0..9: type annotation or initializer needed for variable "blah"
+        "#]],
+    );
+    check(
         &run_parser!(let_decl(expr()), "let blah = 1.0;"),
         expect_test::expect![[
-            r#"Let(LetStatement { name: Ident("blah"), ty: None, init: Immediate(Real(1.0)) })"#
+            r#"Let(LetDecl { name: Ident("blah"), ty: None, init: Some(Immediate(Real(1.0))) })"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: real = 1.0;"),
         expect_test::expect![[
-            r#"Let(LetStatement { name: Ident("blah"), ty: Some(Real), init: Immediate(Real(1.0)) })"#
+            r#"Let(LetDecl { name: Ident("blah"), ty: Some(Real), init: Some(Immediate(Real(1.0))) })"#
         ]],
     );
     check(
-        &run_parser!(let_decl(expr()), "let blah: real"),
-        expect_test::expect![[r#"
-            @14..14: found end of input but expected "="
-        "#]],
+        &run_parser!(let_decl(expr()), "let blah: real;"),
+        expect_test::expect![[
+            r#"Let(LetDecl { name: Ident("blah"), ty: Some(Real), init: None })"#
+        ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah = 1;"),
         expect_test::expect![[
-            r#"Let(LetStatement { name: Ident("blah"), ty: None, init: Immediate(Int(1)) })"#
+            r#"Let(LetDecl { name: Ident("blah"), ty: None, init: Some(Immediate(Int(1))) })"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: int = 1;"),
         expect_test::expect![[
-            r#"Let(LetStatement { name: Ident("blah"), ty: Some(Int), init: Immediate(Int(1)) })"#
+            r#"Let(LetDecl { name: Ident("blah"), ty: Some(Int), init: Some(Immediate(Int(1))) })"#
         ]],
     );
     check(
-        &run_parser!(let_decl(expr()), "let blah: int"),
-        expect_test::expect![[r#"
-            @13..13: found end of input but expected "="
-        "#]],
+        &run_parser!(let_decl(expr()), "let blah: int;"),
+        expect_test::expect![[
+            r#"Let(LetDecl { name: Ident("blah"), ty: Some(Int), init: None })"#
+        ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah = true;"),
         expect_test::expect![[
-            r#"Let(LetStatement { name: Ident("blah"), ty: None, init: Immediate(Bool(true)) })"#
+            r#"Let(LetDecl { name: Ident("blah"), ty: None, init: Some(Immediate(Bool(true))) })"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: bool = false;"),
         expect_test::expect![[
-            r#"Let(LetStatement { name: Ident("blah"), ty: Some(Bool), init: Immediate(Bool(false)) })"#
+            r#"Let(LetDecl { name: Ident("blah"), ty: Some(Bool), init: Some(Immediate(Bool(false))) })"#
         ]],
     );
     check(
-        &run_parser!(let_decl(expr()), "let blah: bool"),
-        expect_test::expect![[r#"
-            @14..14: found end of input but expected "="
-        "#]],
+        &run_parser!(let_decl(expr()), "let blah: bool;"),
+        expect_test::expect![[
+            r#"Let(LetDecl { name: Ident("blah"), ty: Some(Bool), init: None })"#
+        ]],
     );
     check(
         &run_parser!(let_decl(expr()), r#"let blah = "hello";"#),
         expect_test::expect![[
-            r#"Let(LetStatement { name: Ident("blah"), ty: None, init: Immediate(String("hello")) })"#
+            r#"Let(LetDecl { name: Ident("blah"), ty: None, init: Some(Immediate(String("hello"))) })"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), r#"let blah: string = "hello";"#),
         expect_test::expect![[
-            r#"Let(LetStatement { name: Ident("blah"), ty: Some(String), init: Immediate(String("hello")) })"#
+            r#"Let(LetDecl { name: Ident("blah"), ty: Some(String), init: Some(Immediate(String("hello"))) })"#
         ]],
     );
     check(
-        &run_parser!(let_decl(expr()), r#"let blah: string"#),
-        expect_test::expect![[r#"
-            @16..16: found end of input but expected "="
-        "#]],
-    );
-}
-
-#[test]
-fn var_decls() {
-    check(
-        &run_parser!(var_decl(expr()), "var blah;"),
-        expect_test::expect![[r#"
-            @0..9: type annotation or initializer needed for decision variable "blah"
-        "#]],
-    );
-    check(
-        &run_parser!(var_decl(expr()), "var blah = 1.0;"),
+        &run_parser!(let_decl(expr()), r#"let blah: string;"#),
         expect_test::expect![[
-            r#"Var(VarStatement { name: Ident("blah"), ty: None, init: Some(Immediate(Real(1.0))) })"#
-        ]],
-    );
-    check(
-        &run_parser!(var_decl(expr()), "var blah: real = 1.0;"),
-        expect_test::expect![[
-            r#"Var(VarStatement { name: Ident("blah"), ty: Some(Real), init: Some(Immediate(Real(1.0))) })"#
-        ]],
-    );
-    check(
-        &run_parser!(var_decl(expr()), "var blah: real;"),
-        expect_test::expect![[
-            r#"Var(VarStatement { name: Ident("blah"), ty: Some(Real), init: None })"#
-        ]],
-    );
-    check(
-        &run_parser!(var_decl(expr()), "var blah = 1;"),
-        expect_test::expect![[
-            r#"Var(VarStatement { name: Ident("blah"), ty: None, init: Some(Immediate(Int(1))) })"#
-        ]],
-    );
-    check(
-        &run_parser!(var_decl(expr()), "var blah: int = 1;"),
-        expect_test::expect![[
-            r#"Var(VarStatement { name: Ident("blah"), ty: Some(Int), init: Some(Immediate(Int(1))) })"#
-        ]],
-    );
-    check(
-        &run_parser!(var_decl(expr()), "var blah: int;"),
-        expect_test::expect![[
-            r#"Var(VarStatement { name: Ident("blah"), ty: Some(Int), init: None })"#
-        ]],
-    );
-    check(
-        &run_parser!(var_decl(expr()), "var blah = true;"),
-        expect_test::expect![[
-            r#"Var(VarStatement { name: Ident("blah"), ty: None, init: Some(Immediate(Bool(true))) })"#
-        ]],
-    );
-    check(
-        &run_parser!(var_decl(expr()), "var blah: bool = false;"),
-        expect_test::expect![[
-            r#"Var(VarStatement { name: Ident("blah"), ty: Some(Bool), init: Some(Immediate(Bool(false))) })"#
-        ]],
-    );
-    check(
-        &run_parser!(var_decl(expr()), "var blah: bool;"),
-        expect_test::expect![[
-            r#"Var(VarStatement { name: Ident("blah"), ty: Some(Bool), init: None })"#
-        ]],
-    );
-    check(
-        &run_parser!(var_decl(expr()), r#"var blah = "hello";"#),
-        expect_test::expect![[
-            r#"Var(VarStatement { name: Ident("blah"), ty: None, init: Some(Immediate(String("hello"))) })"#
-        ]],
-    );
-    check(
-        &run_parser!(var_decl(expr()), r#"var blah: string = "hello";"#),
-        expect_test::expect![[
-            r#"Var(VarStatement { name: Ident("blah"), ty: Some(String), init: Some(Immediate(String("hello"))) })"#
-        ]],
-    );
-    check(
-        &run_parser!(var_decl(expr()), r#"var blah: string;"#),
-        expect_test::expect![[
-            r#"Var(VarStatement { name: Ident("blah"), ty: Some(String), init: None })"#
+            r#"Let(LetDecl { name: Ident("blah"), ty: Some(String), init: None })"#
         ]],
     );
 }
@@ -469,7 +393,7 @@ fn foo(x: real, y: real) -> real {
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Fn { name: Ident("foo"), params: [(Ident("x"), Real), (Ident("y"), Real)], return_type: Real, body: Block { statements: [Let(LetStatement { name: Ident("z"), ty: None, init: Immediate(Real(5.0)) })], final_expr: Ident(Ident("z")) } }]"#
+            r#"[Fn { name: Ident("foo"), params: [(Ident("x"), Real), (Ident("y"), Real)], return_type: Real, body: Block { statements: [Let(LetDecl { name: Ident("z"), ty: None, init: Some(Immediate(Real(5.0))) })], final_expr: Ident(Ident("z")) } }]"#
         ]],
     );
 }
@@ -483,7 +407,7 @@ let x = foo(a*3, c);
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Let(LetStatement { name: Ident("x"), ty: None, init: Call { name: Ident("foo"), args: [BinaryOp { op: Mul, lhs: Ident(Ident("a")), rhs: Immediate(Int(3)) }, Ident(Ident("c"))] } })]"#
+            r#"[Let(LetDecl { name: Ident("x"), ty: None, init: Some(Call { name: Ident("foo"), args: [BinaryOp { op: Mul, lhs: Ident(Ident("a")), rhs: Immediate(Int(3)) }, Ident(Ident("c"))] }) })]"#
         ]],
     );
 }
@@ -493,14 +417,14 @@ fn code_blocks() {
     check(
         &run_parser!(let_decl(expr()), "let x = { 0 };"),
         expect_test::expect![[
-            r#"Let(LetStatement { name: Ident("x"), ty: None, init: Block(Block { statements: [], final_expr: Immediate(Int(0)) }) })"#
+            r#"Let(LetDecl { name: Ident("x"), ty: None, init: Some(Block(Block { statements: [], final_expr: Immediate(Int(0)) })) })"#
         ]],
     );
 
     check(
         &run_parser!(let_decl(expr()), "let x = { constraint x > 0.0; 0.0 };"),
         expect_test::expect![[
-            r#"Let(LetStatement { name: Ident("x"), ty: None, init: Block(Block { statements: [Constraint(BinaryOp { op: GreaterThan, lhs: Ident(Ident("x")), rhs: Immediate(Real(0.0)) })], final_expr: Immediate(Real(0.0)) }) })"#
+            r#"Let(LetDecl { name: Ident("x"), ty: None, init: Some(Block(Block { statements: [Constraint(BinaryOp { op: GreaterThan, lhs: Ident(Ident("x")), rhs: Immediate(Real(0.0)) })], final_expr: Immediate(Real(0.0)) })) })"#
         ]],
     );
 
@@ -517,14 +441,14 @@ fn code_blocks() {
     check(
         &run_parser!(let_decl(expr()), "let x = { 1.0 } * { 2.0 };"),
         expect_test::expect![[
-            r#"Let(LetStatement { name: Ident("x"), ty: None, init: BinaryOp { op: Mul, lhs: Block(Block { statements: [], final_expr: Immediate(Real(1.0)) }), rhs: Block(Block { statements: [], final_expr: Immediate(Real(2.0)) }) } })"#
+            r#"Let(LetDecl { name: Ident("x"), ty: None, init: Some(BinaryOp { op: Mul, lhs: Block(Block { statements: [], final_expr: Immediate(Real(1.0)) }), rhs: Block(Block { statements: [], final_expr: Immediate(Real(2.0)) }) }) })"#
         ]],
     );
 
     check(
         &format!("{:?}", run_parser!(let_decl(expr()), "let x = {};")),
         expect_test::expect![[
-            r#""@9..10: found \"}\" but expected \"!\", \"+\", \"-\", \"{\", \"(\", \"if\", \"var\", \"let\",  or \"constraint\"\n""#
+            r#""@9..10: found \"}\" but expected \"!\", \"+\", \"-\", \"{\", \"(\", \"if\", \"let\",  or \"constraint\"\n""#
         ]],
     );
 }
@@ -701,7 +625,7 @@ fn tuple_expressions() {
 #[test]
 fn basic_program() {
     let src = r#"
-var low_val: real = 1.23;
+let low_val: real = 1.23;
 let high_val = 4.56;        // Implicit type.
 
 // Here's the constraints.
@@ -714,7 +638,7 @@ solve minimize mid;
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Var(VarStatement { name: Ident("low_val"), ty: Some(Real), init: Some(Immediate(Real(1.23))) }), Let(LetStatement { name: Ident("high_val"), ty: None, init: Immediate(Real(4.56)) }), Constraint(BinaryOp { op: GreaterThan, lhs: Ident(Ident("mid")), rhs: BinaryOp { op: Mul, lhs: Ident(Ident("low_val")), rhs: Immediate(Real(2.0)) } }), Constraint(BinaryOp { op: LessThan, lhs: Ident(Ident("mid")), rhs: Ident(Ident("high_val")) }), Solve(Minimize(Ident("mid")))]"#
+            r#"[Let(LetDecl { name: Ident("low_val"), ty: Some(Real), init: Some(Immediate(Real(1.23))) }), Let(LetDecl { name: Ident("high_val"), ty: None, init: Some(Immediate(Real(4.56))) }), Constraint(BinaryOp { op: GreaterThan, lhs: Ident(Ident("mid")), rhs: BinaryOp { op: Mul, lhs: Ident(Ident("low_val")), rhs: Immediate(Real(2.0)) } }), Constraint(BinaryOp { op: LessThan, lhs: Ident(Ident("mid")), rhs: Ident(Ident("high_val")) }), Solve(Minimize(Ident("mid")))]"#
         ]],
     );
 }
@@ -741,7 +665,7 @@ fn fn_errors() {
     check(
         &run_parser!(yurt_program(), "fn foo() -> real {}"),
         expect_test::expect![[r#"
-            @18..19: found "}" but expected "!", "+", "-", "{", "(", "if", "var", "let",  or "constraint"
+            @18..19: found "}" but expected "!", "+", "-", "{", "(", "if", "let",  or "constraint"
         "#]],
     );
 }
@@ -759,7 +683,7 @@ let low = 1.0;
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Solve(Maximize(Ident("low"))), Constraint(BinaryOp { op: LessThan, lhs: Ident(Ident("low")), rhs: Ident(Ident("high")) }), Let(LetStatement { name: Ident("high"), ty: None, init: Immediate(Real(2.0)) }), Solve(Satisfy), Let(LetStatement { name: Ident("low"), ty: None, init: Immediate(Real(1.0)) })]"#
+            r#"[Solve(Maximize(Ident("low"))), Constraint(BinaryOp { op: LessThan, lhs: Ident(Ident("low")), rhs: Ident(Ident("high")) }), Let(LetDecl { name: Ident("high"), ty: None, init: Some(Immediate(Real(2.0))) }), Solve(Satisfy), Let(LetDecl { name: Ident("low"), ty: None, init: Some(Immediate(Real(1.0))) })]"#
         ]],
     );
 }
@@ -785,7 +709,7 @@ fn test_parse_str_to_ast() {
     check(
         &format!("{:?}", parse_str_to_ast("let x = 5;", "my_file")),
         expect_test::expect![[
-            r#"Ok([Let(LetStatement { name: Ident("x"), ty: None, init: Immediate(Int(5)) })])"#
+            r#"Ok([Let(LetDecl { name: Ident("x"), ty: None, init: Some(Immediate(Int(5))) })])"#
         ]],
     );
     check(
@@ -806,7 +730,7 @@ fn big_ints() {
             "let blah = 1234567890123456789012345678901234567890;"
         ),
         expect_test::expect![[
-            r#"Let(LetStatement { name: Ident("blah"), ty: None, init: Immediate(BigInt(1234567890123456789012345678901234567890)) })"#
+            r#"Let(LetDecl { name: Ident("blah"), ty: None, init: Some(Immediate(BigInt(1234567890123456789012345678901234567890))) })"#
         ]],
     );
     check(
@@ -816,7 +740,7 @@ fn big_ints() {
         ),
         // Confirmed by using the Python REPL to convert from hex to dec...
         expect_test::expect![[
-            r#"Let(LetStatement { name: Ident("blah"), ty: None, init: Immediate(BigInt(5421732407698601623698172315373246806734)) })"#
+            r#"Let(LetDecl { name: Ident("blah"), ty: None, init: Some(Immediate(BigInt(5421732407698601623698172315373246806734))) })"#
         ]],
     );
     check(


### PR DESCRIPTION
Closes #104 

* `var` is now `let`, to indicate a decision variable. The initializer here can be anything, including expression that are not evaluatable at compile-time such as ones that contain constraints.
* Old `let` is now _roughly_ `const`. The main constraint here is that `const` initializers need to be evaluatable at compile-time.