### PR TITLE
Suppress coloured error output when running tests.

### DIFF
--- a/yurtc/src/parser.rs
+++ b/yurtc/src/parser.rs
@@ -21,7 +21,9 @@ fn parse_str_to_ast(source: &str, filename: &str) -> anyhow::Result<Ast> {
     match parse_str_to_ast_inner(source) {
         Ok(ast) => Ok(ast),
         Err(errors) => {
-            print_on_failure(filename, source, &errors);
+            if !cfg!(test) {
+                print_on_failure(filename, source, &errors);
+            }
             yurtc_bail!(errors.len(), filename)
         }
     }


### PR DESCRIPTION
When running `cargo test` the error output for successful runs via Ariadne was still getting printed, which messed up the screen and looked like failures when it wasn't.   This has been annoying me for a while.

At first I tried removing the ANSI colours as I thought that was the problem but the wayward output still appeared, just without colours.

This fix just prevents printing anything (via Ariadne) when running tests.  It might not be ideal -- perhaps we want to see that output when a test fails -- but I'm throwing this up here anyway.  The better solution is to fix it properly in Ariadne but it seems to be in the midst of a refactor currently.