### PR TITLE
Implementing `use` statements in the parser

### DIFF
--- a/yurtc/src/ast.rs
+++ b/yurtc/src/ast.rs
@@ -1,4 +1,13 @@
 #[derive(Clone, Debug, PartialEq)]
+pub(super) enum UseTree {
+    Glob,
+    Name { name: Ident },
+    Path { prefix: Ident, suffix: Box<UseTree> },
+    Group { imports: Vec<UseTree> },
+    Alias { name: Ident, alias: Ident },
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub(super) struct LetDecl {
     pub(super) name: Ident,
     pub(super) ty: Option<Type>,
@@ -13,6 +22,10 @@ pub(super) struct Block {
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) enum Decl {
+    Use {
+        is_absolute: bool,
+        use_tree: UseTree,
+    },
     Let(LetDecl),
     Constraint(Expr),
     Fn {

--- a/yurtc/src/lexer.rs
+++ b/yurtc/src/lexer.rs
@@ -12,6 +12,8 @@ mod tests;
 pub(super) enum Token<'sc> {
     #[token(":")]
     Colon,
+    #[token("::")]
+    DoubleColon,
     #[token("!")]
     Bang,
     #[token("+")]
@@ -89,6 +91,11 @@ pub(super) enum Token<'sc> {
     #[token("satisfy")]
     Satisfy,
 
+    #[token("use")]
+    Use,
+    #[token("as")]
+    As,
+
     #[regex(r"[A-Za-z_][A-Za-z_0-9]*", |lex| lex.slice())]
     Ident(&'sc str),
     #[regex(r"[+-]?[0-9]+\.[0-9]+([Ee][-+]?[0-9]+)?|[0-9]+[Ee][-+]?[0-9]+", |lex| lex.slice())]
@@ -126,12 +133,15 @@ pub(super) static KEYWORDS: &[Token] = &[
     Token::Minimize,
     Token::Solve,
     Token::Satisfy,
+    Token::Use,
+    Token::As,
 ];
 
 impl<'sc> fmt::Display for Token<'sc> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Token::Colon => write!(f, ":"),
+            Token::DoubleColon => write!(f, "::"),
             Token::Bang => write!(f, "!"),
             Token::Plus => write!(f, "+"),
             Token::Minus => write!(f, "-"),
@@ -168,6 +178,8 @@ impl<'sc> fmt::Display for Token<'sc> {
             Token::Minimize => write!(f, "minimize"),
             Token::Solve => write!(f, "solve"),
             Token::Satisfy => write!(f, "satisfy"),
+            Token::Use => write!(f, "use"),
+            Token::As => write!(f, "as"),
             Token::Ident(ident) => write!(f, "{ident}"),
             Token::RealLiteral(ident) => write!(f, "{ident}"),
             Token::IntLiteral(ident) => write!(f, "{ident}"),

--- a/yurtc/src/lexer/tests.rs
+++ b/yurtc/src/lexer/tests.rs
@@ -18,6 +18,7 @@ fn lex_one_success(src: &str) -> Token<'_> {
 #[test]
 fn control_tokens() {
     assert_eq!(lex_one_success(":"), Token::Colon);
+    assert_eq!(lex_one_success("::"), Token::DoubleColon);
     assert_eq!(lex_one_success(";"), Token::Semi);
     assert_eq!(lex_one_success(","), Token::Comma);
     assert_eq!(lex_one_success("{"), Token::BraceOpen);
@@ -151,6 +152,16 @@ fn func() {
 fn if_and_else() {
     assert_eq!(lex_one_success("if"), Token::If);
     assert_eq!(lex_one_success("else"), Token::Else);
+}
+
+#[test]
+fn r#use() {
+    assert_eq!(lex_one_success("use"), Token::Use);
+}
+
+#[test]
+fn r#as() {
+    assert_eq!(lex_one_success("as"), Token::As);
 }
 
 #[test]


### PR DESCRIPTION
Closes #88 

This is fairly simple. Error messages can still be improve (tracked in #117)