### PR TITLE
Fix `dependabot` to look in the right directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,10 @@
 version: 2
 updates:
   - package-ecosystem: cargo
-    directory: /
+    directory: /yurtc/
     schedule:
       interval: daily
+    versioning-strategy: lockfile-only
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Also update the update strategy to only update the lockfile. Otherwise, `dependabot` will try to update `Cargo.toml` which is not always a good idea. We can experiment with that in the future though.