### PR TITLE
Support for array types, array expressions, and array element accesses

### DIFF
--- a/yurtc/src/ast.rs
+++ b/yurtc/src/ast.rs
@@ -61,6 +61,7 @@ pub(super) enum Type {
     Int,
     Bool,
     String,
+    Array { ty: Box<Type>, range: Expr },
     Tuple(Vec<(Option<String>, Type)>),
 }
 
@@ -84,6 +85,11 @@ pub(super) enum Expr {
     Block(Block),
     If(IfExpr),
     Cond(CondExpr),
+    Array(Vec<Expr>),
+    ArrayElementAccess {
+        array: Box<Expr>,
+        index: Box<Expr>,
+    },
     Tuple(Vec<(Option<String>, Expr)>),
     TupleFieldAccess {
         tuple: Box<Expr>,

--- a/yurtc/src/error.rs
+++ b/yurtc/src/error.rs
@@ -26,6 +26,8 @@ pub(super) enum ParseError<'a> {
     KeywordAsIdent { span: Span, keyword: Token<'a> },
     #[error("type annotation or initializer needed for variable \"{name}\"")]
     UntypedVariable { span: Span, name: String },
+    #[error("empty array expressions are not allowed")]
+    EmptyArrayExpr { span: Span },
     #[error("invalid integer value \"{}\" for tuple index", index)]
     InvalidIntegerTupleIndex { span: Span, index: &'a str },
     #[error("invalid value \"{}\" for tuple index", index)]
@@ -126,6 +128,7 @@ impl<'a> CompileError<'a> {
                 ParseError::ExpectedFound { span, .. } => span.clone(),
                 ParseError::KeywordAsIdent { span, .. } => span.clone(),
                 ParseError::UntypedVariable { span, .. } => span.clone(),
+                ParseError::EmptyArrayExpr { span } => span.clone(),
                 ParseError::InvalidIntegerTupleIndex { span, .. } => span.clone(),
                 ParseError::InvalidTupleIndex { span, .. } => span.clone(),
                 ParseError::EmptyTupleExpr { span } => span.clone(),

--- a/yurtc/src/lexer.rs
+++ b/yurtc/src/lexer.rs
@@ -57,6 +57,10 @@ pub(super) enum Token<'sc> {
     ParenOpen,
     #[token(")")]
     ParenClose,
+    #[token("[")]
+    BracketOpen,
+    #[token("]")]
+    BracketClose,
     #[token("->")]
     Arrow,
     #[token("=>")]
@@ -173,6 +177,8 @@ impl<'sc> fmt::Display for Token<'sc> {
             Token::BraceClose => write!(f, "}}"),
             Token::ParenOpen => write!(f, "("),
             Token::ParenClose => write!(f, ")"),
+            Token::BracketOpen => write!(f, "["),
+            Token::BracketClose => write!(f, "]"),
             Token::Arrow => write!(f, "->"),
             Token::HeavyArrow => write!(f, "=>"),
             Token::Dot => write!(f, "."),

--- a/yurtc/src/lexer/tests.rs
+++ b/yurtc/src/lexer/tests.rs
@@ -25,6 +25,8 @@ fn control_tokens() {
     assert_eq!(lex_one_success("}"), Token::BraceClose);
     assert_eq!(lex_one_success("("), Token::ParenOpen);
     assert_eq!(lex_one_success(")"), Token::ParenClose);
+    assert_eq!(lex_one_success("["), Token::BracketOpen);
+    assert_eq!(lex_one_success("]"), Token::BracketClose);
     assert_eq!(lex_one_success("->"), Token::Arrow);
     assert_eq!(lex_one_success("=>"), Token::HeavyArrow);
     assert_eq!(lex_one_success("."), Token::Dot);

--- a/yurtc/src/parser.rs
+++ b/yurtc/src/parser.rs
@@ -114,9 +114,9 @@ fn use_statement<'sc>() -> impl Parser<Token<'sc>, ast::Decl, Error = ParseError
 }
 
 fn let_decl<'sc>(
-    expr: impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone,
+    expr: impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone + 'sc,
 ) -> impl Parser<Token<'sc>, ast::Decl, Error = ParseError<'sc>> + Clone {
-    let type_spec = just(Token::Colon).ignore_then(type_());
+    let type_spec = just(Token::Colon).ignore_then(type_(expr.clone()));
     let init = just(Token::Eq).ignore_then(expr);
     just(Token::Let)
         .ignore_then(ident())
@@ -160,9 +160,9 @@ fn solve_decl<'sc>() -> impl Parser<Token<'sc>, ast::Decl, Error = ParseError<'s
 }
 
 fn fn_decl<'sc>(
-    expr: impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone,
+    expr: impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone + 'sc,
 ) -> impl Parser<Token<'sc>, ast::Decl, Error = ParseError<'sc>> + Clone {
-    let type_spec = just(Token::Colon).ignore_then(type_());
+    let type_spec = just(Token::Colon).ignore_then(type_(expr.clone()));
 
     let params = ident()
         .then(type_spec)
@@ -170,7 +170,7 @@ fn fn_decl<'sc>(
         .allow_trailing()
         .delimited_by(just(Token::ParenOpen), just(Token::ParenClose));
 
-    let return_type = just(Token::Arrow).ignore_then(type_());
+    let return_type = just(Token::Arrow).ignore_then(type_(expr.clone()));
 
     just(Token::Fn)
         .ignore_then(ident())
@@ -186,7 +186,7 @@ fn fn_decl<'sc>(
 }
 
 fn code_block_expr<'sc>(
-    expr: impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone,
+    expr: impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone + 'sc,
 ) -> impl Parser<Token<'sc>, ast::Block, Error = ParseError<'sc>> + Clone {
     let code_block_body = choice((let_decl(expr.clone()), constraint_decl(expr.clone())))
         .repeated()
@@ -216,7 +216,7 @@ fn unary_op<'sc>(
 }
 
 fn if_expr<'sc>(
-    expr: impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone,
+    expr: impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone + 'sc,
 ) -> impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone {
     let then_block = code_block_expr(expr.clone());
     let else_block = just(Token::Else).ignore_then(code_block_expr(expr.clone()));
@@ -269,15 +269,30 @@ fn cond_expr<'sc>(
 
 fn expr<'sc>() -> impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone {
     recursive(|expr| {
-        let args = expr
+        let call_args = expr
             .clone()
             .separated_by(just(Token::Comma))
             .allow_trailing()
             .delimited_by(just(Token::ParenOpen), just(Token::ParenClose));
 
         let call = ident_path()
-            .then(args.clone())
+            .then(call_args.clone())
             .map(|(name, args)| ast::Expr::Call { name, args });
+
+        let array_elements = expr
+            .clone()
+            .separated_by(just(Token::Comma))
+            .allow_trailing()
+            .delimited_by(just(Token::BracketOpen), just(Token::BracketClose));
+
+        let array = array_elements
+            .validate(|array_elements, span, emit| {
+                if array_elements.is_empty() {
+                    emit(ParseError::EmptyArrayExpr { span })
+                }
+                array_elements
+            })
+            .map(ast::Expr::Array);
 
         let tuple_fields = (ident().then_ignore(just(Token::Colon)))
             .or_not()
@@ -306,6 +321,7 @@ fn expr<'sc>() -> impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + 
             if_expr(expr.clone()),
             cond_expr(expr.clone()),
             call,
+            array,
             tuple,
             parens,
             ident_path().map(ast::Expr::Ident),
@@ -317,10 +333,33 @@ fn expr<'sc>() -> impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + 
             and_or_op(
                 Token::DoubleAmpersand,
                 ast::BinaryOp::LogicalAnd,
-                comparison_op(additive_op(multiplicative_op(tuple_field_access(atom)))),
+                comparison_op(additive_op(multiplicative_op(tuple_field_access(
+                    array_element_access(atom, expr.clone()),
+                )))),
             ),
         )
     })
+}
+
+fn array_element_access<'sc, P>(
+    parser: P,
+    expr: impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone,
+) -> impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone
+where
+    P: Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone,
+{
+    // Multi-dimensional arrays have their innermost dimension on the far right. Hence, we need
+    // a `foldr` here instead of a `foldl`. This mirrors the behavior of the array type parser.
+    parser
+        .then(
+            expr.delimited_by(just(Token::BracketOpen), just(Token::BracketClose))
+                .repeated(),
+        )
+        .map(|(expr, indices)| (indices, expr))
+        .foldr(|index, expr| ast::Expr::ArrayElementAccess {
+            array: Box::new(expr),
+            index: Box::new(index),
+        })
 }
 
 fn tuple_field_access<'sc, P>(
@@ -513,7 +552,9 @@ fn ident_path<'sc>() -> impl Parser<Token<'sc>, ast::Ident, Error = ParseError<'
         })
 }
 
-fn type_<'sc>() -> impl Parser<Token<'sc>, ast::Type, Error = ParseError<'sc>> + Clone {
+fn type_<'sc>(
+    expr: impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone + 'sc,
+) -> impl Parser<Token<'sc>, ast::Type, Error = ParseError<'sc>> + Clone {
     recursive(|type_| {
         let tuple = (ident().then_ignore(just(Token::Colon)))
             .or_not()
@@ -528,13 +569,29 @@ fn type_<'sc>() -> impl Parser<Token<'sc>, ast::Type, Error = ParseError<'sc>> +
                 args
             });
 
-        choice((
+        let type_atom = choice((
             just(Token::Real).to(ast::Type::Real),
             just(Token::Int).to(ast::Type::Int),
             just(Token::Bool).to(ast::Type::Bool),
             just(Token::String).to(ast::Type::String),
             tuple.map(ast::Type::Tuple),
-        ))
+        ));
+
+        // Multi-dimensional arrays have their innermost dimension on the far right. Hence, we need
+        // a `foldr` here instead of a `foldl`. For example, `int[3][5]` is actually an array of
+        // size 3 that contains arrays of size 5 of `int`s.
+        type_atom
+            .clone()
+            .then(
+                expr//array_range
+                    .delimited_by(just(Token::BracketOpen), just(Token::BracketClose))
+                    .repeated(),
+            )
+            .map(|(type_atom, array_range)| (array_range, type_atom))
+            .foldr(|range, ty| ast::Type::Array {
+                ty: Box::new(ty),
+                range,
+            })
     })
 }
 

--- a/yurtc/src/parser/tests.rs
+++ b/yurtc/src/parser/tests.rs
@@ -35,19 +35,28 @@ fn check(actual: &str, expect: expect_test::Expect) {
 
 #[test]
 fn types() {
-    check(&run_parser!(type_(), "int"), expect_test::expect!["Int"]);
-    check(&run_parser!(type_(), "real"), expect_test::expect!["Real"]);
-    check(&run_parser!(type_(), "bool"), expect_test::expect!["Bool"]);
     check(
-        &run_parser!(type_(), "string"),
+        &run_parser!(type_(expr()), "int"),
+        expect_test::expect!["Int"],
+    );
+    check(
+        &run_parser!(type_(expr()), "real"),
+        expect_test::expect!["Real"],
+    );
+    check(
+        &run_parser!(type_(expr()), "bool"),
+        expect_test::expect!["Bool"],
+    );
+    check(
+        &run_parser!(type_(expr()), "string"),
         expect_test::expect!["String"],
     );
     check(
-        &run_parser!(type_(), "{int, real, string}"),
+        &run_parser!(type_(expr()), "{int, real, string}"),
         expect_test::expect!["Tuple([(None, Int), (None, Real), (None, String)])"],
     );
     check(
-        &run_parser!(type_(), "{int, {real, int}, string}"),
+        &run_parser!(type_(expr()), "{int, {real, int}, string}"),
         expect_test::expect![
             "Tuple([(None, Int), (None, Tuple([(None, Real), (None, Int)])), (None, String)])"
         ],
@@ -634,7 +643,7 @@ fn parens_exprs() {
     check(
         &run_parser!(expr(), "()"),
         expect_test::expect![[r#"
-            @1..2: found ")" but expected "::", "::", "!", "+", "-", "{", "{", "(", "if",  or "cond"
+            @1..2: found ")" but expected "::", "::", "!", "+", "-", "{", "{", "(", "[", "if",  or "cond"
         "#]],
     );
     check(
@@ -827,6 +836,124 @@ fn if_exprs() {
 }
 
 #[test]
+fn array_type() {
+    check(
+        &run_parser!(type_(expr()), r#"int[5]"#),
+        expect_test::expect!["Array { ty: Int, range: Immediate(Int(5)) }"],
+    );
+
+    check(
+        &run_parser!(type_(expr()), r#"int[N]"#),
+        expect_test::expect![[
+            r#"Array { ty: Int, range: Ident(Ident { path: ["N"], is_absolute: false }) }"#
+        ]],
+    );
+
+    check(
+        &run_parser!(
+            type_(expr()),
+            r#"string[foo()][{ 7 }][if true { 1 } else { 2 }"#
+        ),
+        expect_test::expect![[
+            r#"Array { ty: Array { ty: String, range: Block(Block { statements: [], final_expr: Immediate(Int(7)) }) }, range: Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] } }"#
+        ]],
+    );
+
+    check(
+        &run_parser!(type_(expr()), r#"real[N][9][M][3]"#),
+        expect_test::expect![[
+            r#"Array { ty: Array { ty: Array { ty: Array { ty: Real, range: Immediate(Int(3)) }, range: Ident(Ident { path: ["M"], is_absolute: false }) }, range: Immediate(Int(9)) }, range: Ident(Ident { path: ["N"], is_absolute: false }) }"#
+        ]],
+    );
+
+    check(
+        &run_parser!(type_(expr()), r#"{int, { real, string }}[N][9]"#),
+        expect_test::expect![[
+            r#"Array { ty: Array { ty: Tuple([(None, Int), (None, Tuple([(None, Real), (None, String)]))]), range: Immediate(Int(9)) }, range: Ident(Ident { path: ["N"], is_absolute: false }) }"#
+        ]],
+    );
+
+    check(
+        &run_parser!(let_decl(expr()), r#"let a: int[];"#),
+        expect_test::expect![[r#"
+            @11..12: found "]" but expected "::", "::", "!", "+", "-", "{", "{", "(", "[", "if",  or "cond"
+        "#]],
+    );
+}
+#[test]
+fn array_expressions() {
+    check(
+        &run_parser!(expr(), r#"[5]"#),
+        expect_test::expect!["Array([Immediate(Int(5))])"],
+    );
+
+    check(
+        &run_parser!(expr(), r#"[5,]"#),
+        expect_test::expect!["Array([Immediate(Int(5))])"],
+    );
+
+    check(
+        &run_parser!(expr(), r#"[5, 4]"#),
+        expect_test::expect!["Array([Immediate(Int(5)), Immediate(Int(4))])"],
+    );
+
+    check(
+        &run_parser!(expr(), r#"[[ 1 ],]"#),
+        expect_test::expect!["Array([Array([Immediate(Int(1))])])"],
+    );
+
+    check(
+        &run_parser!(expr(), r#"[[1, 2], 3]"#), // This should fail in semantic analysis
+        expect_test::expect![
+            "Array([Array([Immediate(Int(1)), Immediate(Int(2))]), Immediate(Int(3))])"
+        ],
+    );
+
+    check(
+        &run_parser!(expr(), r#"[[1, 2], [3, 4]]"#),
+        expect_test::expect!["Array([Array([Immediate(Int(1)), Immediate(Int(2))]), Array([Immediate(Int(3)), Immediate(Int(4))])])"],
+    );
+    check(
+        &run_parser!(
+            expr(),
+            r#"[[foo(), { 2 }], [if true { 1 } else { 2 }, t.0]]"#
+        ),
+        expect_test::expect![[
+            r#"Array([Array([Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] }, Block(Block { statements: [], final_expr: Immediate(Int(2)) })]), Array([If(IfExpr { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }), TupleFieldAccess { tuple: Ident(Ident { path: ["t"], is_absolute: false }), field: Left(0) }])])"#
+        ]],
+    );
+}
+
+#[test]
+fn array_field_accesss() {
+    check(
+        &run_parser!(expr(), r#"a[5]"#),
+        expect_test::expect![[
+            r#"ArrayElementAccess { array: Ident(Ident { path: ["a"], is_absolute: false }), index: Immediate(Int(5)) }"#
+        ]],
+    );
+
+    check(
+        &run_parser!(expr(), r#"{ a }[N][foo()][M][4]"#),
+        expect_test::expect![[
+            r#"ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: Block(Block { statements: [], final_expr: Ident(Ident { path: ["a"], is_absolute: false }) }), index: Immediate(Int(4)) }, index: Ident(Ident { path: ["M"], is_absolute: false }) }, index: Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] } }, index: Ident(Ident { path: ["N"], is_absolute: false }) }"#
+        ]],
+    );
+    check(
+        &run_parser!(expr(), r#"foo()[{ M }][if true { 1 } else { 3 }]"#),
+        expect_test::expect![[
+            r#"ArrayElementAccess { array: ArrayElementAccess { array: Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] }, index: If(IfExpr { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } }) }, index: Block(Block { statements: [], final_expr: Ident(Ident { path: ["M"], is_absolute: false }) }) }"#
+        ]],
+    );
+    check(
+        &run_parser!(let_decl(expr()), r#"let x = a[];"#),
+        expect_test::expect![[r#"
+            @10..11: found "]" but expected "::", "::", "!", "+", "-", "{", "{", "(", "[", "if",  or "cond"
+        "#]],
+    );
+}
+
+#[test]
 fn tuple_expressions() {
     check(
         &run_parser!(expr(), r#"{0}"#), // This is not a tuple. It is a code block expr.
@@ -892,7 +1019,10 @@ fn tuple_expressions() {
             r#"Tuple([(Some("x"), Block(Block { statements: [], final_expr: Immediate(Int(42)) })), (Some("y"), If(IfExpr { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: Immediate(Int(2)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } })), (Some("z"), Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] })])"#
         ]],
     );
+}
 
+#[test]
+fn tuple_field_accesses() {
     check(
         &run_parser!(expr(), r#"t.0 + t.9999999 + t.x"#),
         expect_test::expect![[
@@ -1089,7 +1219,7 @@ fn cond_exprs() {
     check(
         &run_parser!(cond_expr(expr()), r#"cond { a => b, }"#),
         expect_test::expect![[r#"
-            @15..16: found "}" but expected "::", "::", "!", "+", "-", "{", "{", "(", "if", "else",  or "cond"
+            @15..16: found "}" but expected "::", "::", "!", "+", "-", "{", "{", "(", "[", "if", "else",  or "cond"
         "#]],
     );
 
@@ -1144,7 +1274,7 @@ fn fn_errors() {
     check(
         &run_parser!(yurt_program(), "fn foo() -> real {}"),
         expect_test::expect![[r#"
-            @18..19: found "}" but expected "::", "::", "!", "+", "-", "{", "{", "(", "if", "cond", "let",  or "constraint"
+            @18..19: found "}" but expected "::", "::", "!", "+", "-", "{", "{", "(", "[", "if", "cond", "let",  or "constraint"
         "#]],
     );
 }

--- a/yurtc/tests/basic_tests/golf.yrt
+++ b/yurtc/tests/basic_tests/golf.yrt
@@ -1,46 +1,29 @@
 // Generate a random 18-hole golf course.
 
-let h1: int;
-let h2: int;
-let h3: int;
-let h4: int;
-let h5: int;
-let h6: int;
-let h7: int;
-let h8: int;
-let h9: int;
-let h10: int;
-let h11: int;
-let h12: int;
-let h13: int;
-let h14: int;
-let h15: int;
-let h16: int;
-let h17: int;
-let h18: int;
+let h1: int[18];
 
-constraint h1 >= 3 && h1 <= 5;
-constraint h2 >= 3 && h2 <= 5;
-constraint h3 >= 3 && h3 <= 5;
-constraint h4 >= 3 && h4 <= 5;
-constraint h5 >= 3 && h5 <= 5;
-constraint h6 >= 3 && h6 <= 5;
-constraint h7 >= 3 && h7 <= 5;
-constraint h8 >= 3 && h8 <= 5;
-constraint h9 >= 3 && h9 <= 5;
-constraint h10 >= 3 && h10 <= 5;
-constraint h11 >= 3 && h11 <= 5;
-constraint h12 >= 3 && h12 <= 5;
-constraint h13 >= 3 && h13 <= 5;
-constraint h14 >= 3 && h14 <= 5;
-constraint h15 >= 3 && h15 <= 5;
-constraint h16 >= 3 && h16 <= 5;
-constraint h17 >= 3 && h17 <= 5;
-constraint h18 >= 3 && h18 <= 5;
+constraint h[0] >= 3 && h[0] <= 5;
+constraint h[1] >= 3 && h[1] <= 5;
+constraint h[2] >= 3 && h[2] <= 5;
+constraint h[3] >= 3 && h[3] <= 5;
+constraint h[4] >= 3 && h[4] <= 5;
+constraint h[5] >= 3 && h[5] <= 5;
+constraint h[6] >= 3 && h[6] <= 5;
+constraint h[7] >= 3 && h[7] <= 5;
+constraint h[8] >= 3 && h[8] <= 5;
+constraint h[9] >= 3 && h[9] <= 5;
+constraint h[10] >= 3 && h[10] <= 5;
+constraint h[11] >= 3 && h[11] <= 5;
+constraint h[12] >= 3 && h[12] <= 5;
+constraint h[13] >= 3 && h[13] <= 5;
+constraint h[14] >= 3 && h[14] <= 5;
+constraint h[15] >= 3 && h[15] <= 5;
+constraint h[16] >= 3 && h[16] <= 5;
+constraint h[17] >= 3 && h[17] <= 5;
 
-let sum: int = h1 + h2 + h3 + h4 + h5 + h6 + h7
-             + h8 + h9 + h10 + h11 + h12 + h13 + h14
-             + h15 + h16 + h17 + h18;
+let sum: int = h[0] + h[1] + h[2] + h[3] + h[4] + h[5] + h[6]
+             + h[7] + h[8] + h[9] + h[10] + h[11] + h[12] + h[13]
+             + h[14] + h[15] + h[16] + h[17];
 
 constraint sum == 72;
 


### PR DESCRIPTION
Closes #131 

Still need to write in the specs that the range of an array could be an `enum`, but will do that as part of the `enum` PR.