### PR TITLE
Spec and implement the `in` keyword for containers

### DIFF
--- a/specs/src/lang/language_primitives.md
+++ b/specs/src/lang/language_primitives.md
@@ -238,6 +238,7 @@ Expressions represent values and have the following syntax:
          | <cond-expr>
          | <call-expr>
          | <cast-expr>
+         | <in-expr>
 ```
 
 Expressions can be composed from sub-expressions with operators. All unary and binary operators are described in [Operators
@@ -509,6 +510,32 @@ let d = MyEnum::V1 as int; // `d` is equal to `1`.
 - `false` casts to `0`.
 - `true` casts to `1`.
 
+#### "In" Expressions
+
+"In" expressions are used to detect whether a value belongs to an array. They have the following syntax:
+
+```ebnf
+<in-expr> ::= <expr> "in" <expr>
+```
+
+An "in" expression returns a `bool` that indicates whether the left-hand side belongs to the right-hand side. For example, in `let x: bool = 5 in [3, 4, 5];`, `x` should be `true`.
+
+The right-hand side of an "in" expression must be an array and the type of the left-hand side must match the array elements type. Otherwise, a compiler error should be emitted.
+
+A value belongs to an array if and only if it is "equal" to one of its entries. Equality for various types is defined as follows:
+
+| Type     | Equality Criterion                                       |
+| -------- | -------------------------------------------------------- |
+| `int`    | Identical values                                         |
+| `real`   | Identical values                                         |
+| `bool`   | Identical values                                         |
+| `string` | Identical lengths and characters in the same order       |
+| `enum`   | Identical variants                                       |
+| array    | Identical lengths and _equal_ elements in the same order |
+| array    | Identical lengths and _equal_ elements in the same order |
+
+Note that two values of different types cannot be compared and should result in a compile error.
+
 #### Expression Precedence
 
 The precedence of Yurt operators and expressions is ordered as follows, going from strong to weak. Binary Operators at the same precedence level are grouped in the order given by their associativity.
@@ -520,6 +547,7 @@ The precedence of Yurt operators and expressions is ordered as follows, going fr
 | Function calls, array indexing   |                      |
 | Unary `-`, Unary `+`, `!`        |                      |
 | `as`                             | left to right        |
+| `in`                             | left to right        |
 | `*`, `/`, `%`                    | left to right        |
 | Binary `+`, Binary `-`           | left to right        |
 | `==`, `!=`, `<`, `>`, `<=`, `>=` | Requires parentheses |

--- a/yurtc/src/expr.rs
+++ b/yurtc/src/expr.rs
@@ -39,6 +39,10 @@ pub(super) enum Expr<Ident, BlockExpr> {
         value: Box<Self>,
         ty: Box<super::types::Type<Ident, Self>>,
     },
+    In {
+        value: Box<Self>,
+        collection: Box<Self>,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/yurtc/src/lexer.rs
+++ b/yurtc/src/lexer.rs
@@ -120,6 +120,9 @@ pub(super) enum Token<'sc> {
     #[token("implements")]
     Implements,
 
+    #[token("in")]
+    In,
+
     #[regex(r"[A-Za-z_][A-Za-z_0-9]*", |lex| lex.slice())]
     Ident(&'sc str),
     #[regex(r"[0-9]+\.[0-9]+([Ee][-+]?[0-9]+)?|[0-9]+[Ee][-+]?[0-9]+", |lex| lex.slice())]
@@ -164,6 +167,7 @@ pub(super) static KEYWORDS: &[Token] = &[
     Token::Interface,
     Token::Contract,
     Token::Implements,
+    Token::In,
 ];
 
 impl<'sc> fmt::Display for Token<'sc> {
@@ -220,6 +224,7 @@ impl<'sc> fmt::Display for Token<'sc> {
             Token::Interface => write!(f, "interface"),
             Token::Contract => write!(f, "contract"),
             Token::Implements => write!(f, "implements"),
+            Token::In => write!(f, "in"),
             Token::Ident(ident) => write!(f, "{ident}"),
             Token::RealLiteral(ident) => write!(f, "{ident}"),
             Token::IntLiteral(ident) => write!(f, "{ident}"),

--- a/yurtc/src/lexer/tests.rs
+++ b/yurtc/src/lexer/tests.rs
@@ -172,6 +172,11 @@ fn r#as() {
 }
 
 #[test]
+fn r#in() {
+    assert_eq!(lex_one_success("in"), Token::In);
+}
+
+#[test]
 fn blockchain_items() {
     assert_eq!(lex_one_success("interface"), Token::Interface);
     assert_eq!(lex_one_success("contract"), Token::Contract);

--- a/yurtc/src/parser.rs
+++ b/yurtc/src/parser.rs
@@ -428,19 +428,22 @@ fn expr<'sc>() -> impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + 
         ))
         .boxed();
 
-        and_or_op(
-            Token::DoublePipe,
-            expr::BinaryOp::LogicalOr,
-            and_or_op(
-                Token::DoubleAmpersand,
-                expr::BinaryOp::LogicalAnd,
-                comparison_op(additive_op(multiplicative_op(cast(
-                    tuple_field_access(array_element_access(atom, expr.clone())),
-                    expr.clone(),
-                )))),
-            ),
-        )
-        .boxed()
+        // This order enforces the procedence rules in Yurt expressions
+        let array_element_access = array_element_access(atom, expr.clone());
+        let tuple_field_access = tuple_field_access(array_element_access);
+        let cast = cast(tuple_field_access, expr.clone());
+        let in_expr = in_expr(cast, expr.clone());
+        let multiplicative_op = multiplicative_op(in_expr);
+        let additive_op = additive_op(multiplicative_op);
+        let comparison_op = comparison_op(additive_op);
+        let and = and_or_op(
+            Token::DoubleAmpersand,
+            expr::BinaryOp::LogicalAnd,
+            comparison_op,
+        );
+        let or = and_or_op(Token::DoublePipe, expr::BinaryOp::LogicalOr, and);
+
+        or.boxed()
     })
 }
 
@@ -545,6 +548,22 @@ where
         .foldl(|value, ty| ast::Expr::Cast {
             value: Box::new(value),
             ty: Box::new(ty),
+        })
+        .boxed()
+}
+
+fn in_expr<'sc, P>(
+    parser: P,
+    expr: impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone + 'sc,
+) -> impl Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone
+where
+    P: Parser<Token<'sc>, ast::Expr, Error = ParseError<'sc>> + Clone + 'sc,
+{
+    parser
+        .then(just(Token::In).ignore_then(expr).repeated())
+        .foldl(|value, collection| ast::Expr::In {
+            value: Box::new(value),
+            collection: Box::new(collection),
         })
         .boxed()
 }

--- a/yurtc/src/parser/tests.rs
+++ b/yurtc/src/parser/tests.rs
@@ -1344,6 +1344,44 @@ fn casting() {
 }
 
 #[test]
+fn in_expr() {
+    check(
+        &run_parser!(expr(), r#"x in { 1, 2 }"#),
+        expect_test::expect![[
+            r#"In { value: Ident(Ident { path: ["x"], is_absolute: false }), collection: Tuple([(None, Immediate(Int(1))), (None, Immediate(Int(2)))]) }"#
+        ]],
+    );
+
+    check(
+        &run_parser!(expr(), r#"x in [ 1, 2 ] in { true, false }"#),
+        expect_test::expect![[
+            r#"In { value: Ident(Ident { path: ["x"], is_absolute: false }), collection: In { value: Array([Immediate(Int(1)), Immediate(Int(2))]), collection: Tuple([(None, Immediate(Bool(true))), (None, Immediate(Bool(false)))]) } }"#
+        ]],
+    );
+
+    check(
+        &run_parser!(expr(), r#"x as int in { 1, 2 }"#),
+        expect_test::expect![[
+            r#"In { value: Cast { value: Ident(Ident { path: ["x"], is_absolute: false }), ty: Int }, collection: Tuple([(None, Immediate(Int(1))), (None, Immediate(Int(2)))]) }"#
+        ]],
+    );
+
+    check(
+        &run_parser!(expr(), r#"[1] in foo() in [[1]]"#),
+        expect_test::expect![[
+            r#"In { value: Array([Immediate(Int(1))]), collection: In { value: Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] }, collection: Array([Array([Immediate(Int(1))])]) } }"#
+        ]],
+    );
+
+    check(
+        &run_parser!(let_decl(expr()), r#"let x = 5 in;"#),
+        expect_test::expect![[r#"
+            @12..13: found ";" but expected "::", "::", "!", "+", "-", "{", "{", "(", "[", "if",  or "cond"
+        "#]],
+    );
+}
+
+#[test]
 fn basic_program() {
     let src = r#"
 let low_val: real = 1.23;


### PR DESCRIPTION
Closes #155 

Once ranges are added, then we can allow them as a RHS for an "in" expression.