### PR TITLE
Enums + array interaction

### DIFF
--- a/yurtc/src/ast.rs
+++ b/yurtc/src/ast.rs
@@ -92,7 +92,7 @@ pub(super) enum Type {
     String,
     Array { ty: Box<Type>, range: Expr },
     Tuple(Vec<(Option<String>, Type)>),
-    CustomType(String),
+    CustomType(Ident),
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/yurtc/src/parser.rs
+++ b/yurtc/src/parser.rs
@@ -688,7 +688,7 @@ fn type_<'sc>(
             just(Token::Bool).to(ast::Type::Bool),
             just(Token::String).to(ast::Type::String),
             tuple.map(ast::Type::Tuple),
-            ident().map(ast::Type::CustomType),
+            ident_path().map(ast::Type::CustomType),
         ))
         .boxed();
 
@@ -698,15 +698,15 @@ fn type_<'sc>(
         type_atom
             .clone()
             .then(
-                expr//array_range
-                    .delimited_by(just(Token::BracketOpen), just(Token::BracketClose))
+                expr.delimited_by(just(Token::BracketOpen), just(Token::BracketClose))
                     .repeated(),
             )
             .map(|(type_atom, array_range)| (array_range, type_atom))
             .foldr(|range, ty| ast::Type::Array {
                 ty: Box::new(ty),
                 range,
-            }).boxed()
+            })
+            .boxed()
     })
 }
 

--- a/yurtc/tests/basic_tests/arrays.yrt
+++ b/yurtc/tests/basic_tests/arrays.yrt
@@ -1,0 +1,12 @@
+let a: real[5];
+let a1 = a[1];
+
+enum Colour = Red | Green | Blue;
+let b: real[Colour][3];
+let b_r_2 = b[Colour::Red][2];
+
+fn nums() -> int[4] {
+    [0, 1, 2, 3]
+}
+
+let one = nums()[1];

--- a/yurtc/tests/basic_tests/aust.yrt
+++ b/yurtc/tests/basic_tests/aust.yrt
@@ -1,22 +1,14 @@
-// Colouring Australia using nc colours
+// Colouring Australia using 3 colours
 
-let nc: int = 3;
+enum Colour = Red | Green | Blue;
 
-let wa: int;
-let nt: int;
-let sa: int;
-let q: int;
-let nsw: int;
-let v: int;
-let t: int;
-
-constraint wa >= 1 && wa <= nc;
-constraint nt >= 1 &&  nt <= nc;
-constraint sa >= 1 && sa <= nc;
-constraint q >= 1 && q <= nc;
-constraint nsw >= 1 && nsw <= nc;
-constraint v >= 1 && v <= nc;
-constraint t >= 1 && t <= nc;
+let wa: Colour;
+let nt: Colour;
+let sa: Colour;
+let q: Colour;
+let nsw: Colour;
+let v: Colour;
+let t: Colour;
 
 // Make sure that no two neighboring states/territories share a colour
 constraint wa != nt;


### PR DESCRIPTION
Closes #173 

Summary of changes:

* Spec: allow array types to an enum type as a size.
* Spec: allow array index expression to have an enum variants as an index.
* Spec: move `enum-decl` to items and add some more information.
* Spec+ Parser: change `custom-ty` to `enum-ty` (for now) and allow it to be a path instead of just an identifier.
* Spec: Removed "transition items" from the spec, to be replaced by something else soon.
* Testing: added and updated some tests.