### PR TITLE
Promote `Expr` out of `ast` and into its own module.

### DIFF
--- a/yurtc/src/ast.rs
+++ b/yurtc/src/ast.rs
@@ -1,6 +1,7 @@
-use crate::error::Span;
+use crate::{error::Span, expr::Expr as E, types::Type as T};
 
-use itertools::Either;
+pub(super) type Expr = E<Ident, Block>;
+pub(super) type Type = T<Ident, Expr>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) enum Decl {
@@ -85,107 +86,8 @@ pub(super) struct Ident {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(super) enum Type {
-    Real,
-    Int,
-    Bool,
-    String,
-    Array { ty: Box<Type>, range: Expr },
-    Tuple(Vec<(Option<String>, Type)>),
-    CustomType(Ident),
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub(super) enum Expr {
-    Immediate(Immediate),
-    Ident(Ident),
-    UnaryOp {
-        op: UnaryOp,
-        expr: Box<Expr>,
-    },
-    BinaryOp {
-        op: BinaryOp,
-        lhs: Box<Expr>,
-        rhs: Box<Expr>,
-    },
-    Call {
-        name: Ident,
-        args: Vec<Expr>,
-    },
-    Block(Block),
-    If(IfExpr),
-    Cond(CondExpr),
-    Array(Vec<Expr>),
-    ArrayElementAccess {
-        array: Box<Expr>,
-        index: Box<Expr>,
-    },
-    Tuple(Vec<(Option<String>, Expr)>),
-    TupleFieldAccess {
-        tuple: Box<Expr>,
-        field: Either<usize, String>,
-    },
-    Cast {
-        value: Box<Expr>,
-        ty: Box<Type>,
-    },
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub(super) enum UnaryOp {
-    Pos,
-    Neg,
-    Not,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub(super) enum BinaryOp {
-    Mul,
-    Div,
-    Add,
-    Sub,
-    Mod,
-    LessThan,
-    LessThanOrEqual,
-    GreaterThan,
-    GreaterThanOrEqual,
-    Equal,
-    NotEqual,
-    LogicalAnd,
-    LogicalOr,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub(super) enum Immediate {
-    Real(f64),
-    Int(i64),
-    BigInt(num_bigint::BigInt),
-    Bool(bool),
-    String(String),
-}
-
-#[derive(Clone, Debug, PartialEq)]
 pub(super) enum SolveFunc {
     Satisfy,
     Minimize(Ident),
     Maximize(Ident),
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub(super) struct IfExpr {
-    pub(super) condition: Box<Expr>,
-    pub(super) then_block: Block,
-    pub(super) else_block: Block,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub(super) struct CondBranch {
-    pub(super) condition: Box<Expr>,
-    pub(super) result: Box<Expr>,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub(super) struct CondExpr {
-    pub(super) branches: Vec<CondBranch>,
-    pub(super) else_result: Box<Expr>,
 }

--- a/yurtc/src/expr.rs
+++ b/yurtc/src/expr.rs
@@ -1,0 +1,81 @@
+#[derive(Clone, Debug, PartialEq)]
+pub(super) enum Expr<Ident, BlockExpr> {
+    Immediate(Immediate),
+    Ident(Ident),
+    UnaryOp {
+        op: UnaryOp,
+        expr: Box<Self>,
+    },
+    BinaryOp {
+        op: BinaryOp,
+        lhs: Box<Self>,
+        rhs: Box<Self>,
+    },
+    Call {
+        name: Ident,
+        args: Vec<Self>,
+    },
+    Block(BlockExpr),
+    If {
+        condition: Box<Self>,
+        then_block: BlockExpr,
+        else_block: BlockExpr,
+    },
+    Cond {
+        branches: Vec<CondBranch<Self>>,
+        else_result: Box<Self>,
+    },
+    Array(Vec<Self>),
+    ArrayElementAccess {
+        array: Box<Self>,
+        index: Box<Self>,
+    },
+    Tuple(Vec<(Option<String>, Self)>),
+    TupleFieldAccess {
+        tuple: Box<Self>,
+        field: itertools::Either<usize, String>,
+    },
+    Cast {
+        value: Box<Self>,
+        ty: Box<super::types::Type<Ident, Self>>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) enum Immediate {
+    Real(f64),
+    Int(i64),
+    BigInt(num_bigint::BigInt),
+    Bool(bool),
+    String(String),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct CondBranch<E> {
+    pub(super) condition: Box<E>,
+    pub(super) result: Box<E>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) enum UnaryOp {
+    Pos,
+    Neg,
+    Not,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) enum BinaryOp {
+    Mul,
+    Div,
+    Add,
+    Sub,
+    Mod,
+    LessThan,
+    LessThanOrEqual,
+    GreaterThan,
+    GreaterThanOrEqual,
+    Equal,
+    NotEqual,
+    LogicalAnd,
+    LogicalOr,
+}

--- a/yurtc/src/main.rs
+++ b/yurtc/src/main.rs
@@ -2,8 +2,10 @@ mod ast;
 
 #[macro_use]
 mod error;
+mod expr;
 mod lexer;
 mod parser;
+mod types;
 
 fn main() -> anyhow::Result<()> {
     let srcs = parse_cli();

--- a/yurtc/src/parser/tests.rs
+++ b/yurtc/src/parser/tests.rs
@@ -661,7 +661,7 @@ fn parens_exprs() {
     check(
         &run_parser!(expr(), "(if a < b { 1 } else { 2 })"),
         expect_test::expect![[
-            r#"If(IfExpr { condition: BinaryOp { op: LessThan, lhs: Ident(Ident { path: ["a"], is_absolute: false }), rhs: Ident(Ident { path: ["b"], is_absolute: false }) }, then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } })"#
+            r#"If { condition: BinaryOp { op: LessThan, lhs: Ident(Ident { path: ["a"], is_absolute: false }), rhs: Ident(Ident { path: ["b"], is_absolute: false }) }, then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }"#
         ]],
     );
     check(
@@ -879,21 +879,21 @@ fn if_exprs() {
     check(
         &run_parser!(if_expr(expr()), "if c { 1 } else { 0 }"),
         expect_test::expect![[
-            r#"If(IfExpr { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } })"#
+            r#"If { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } }"#
         ]],
     );
 
     check(
         &run_parser!(if_expr(expr()), "if c { if c { 1 } else { 0 } } else { 2 }"),
         expect_test::expect![[
-            r#"If(IfExpr { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: If(IfExpr { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } }) }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } })"#
+            r#"If { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: If { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } } }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }"#
         ]],
     );
 
     check(
         &run_parser!(if_expr(expr()), "if c { if c { 1 } else { 0 } } else { 2 }"),
         expect_test::expect![[
-            r#"If(IfExpr { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: If(IfExpr { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } }) }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } })"#
+            r#"If { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: If { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } } }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }"#
         ]],
     );
 }
@@ -990,7 +990,7 @@ fn array_expressions() {
             r#"[[foo(), { 2 }], [if true { 1 } else { 2 }, t.0]]"#
         ),
         expect_test::expect![[
-            r#"Array([Array([Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] }, Block(Block { statements: [], final_expr: Immediate(Int(2)) })]), Array([If(IfExpr { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }), TupleFieldAccess { tuple: Ident(Ident { path: ["t"], is_absolute: false }), field: Left(0) }])])"#
+            r#"Array([Array([Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] }, Block(Block { statements: [], final_expr: Immediate(Int(2)) })]), Array([If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }, TupleFieldAccess { tuple: Ident(Ident { path: ["t"], is_absolute: false }), field: Left(0) }])])"#
         ]],
     );
 }
@@ -1014,7 +1014,7 @@ fn array_field_accesss() {
     check(
         &run_parser!(expr(), r#"foo()[{ M }][if true { 1 } else { 3 }]"#),
         expect_test::expect![[
-            r#"ArrayElementAccess { array: ArrayElementAccess { array: Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] }, index: If(IfExpr { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } }) }, index: Block(Block { statements: [], final_expr: Ident(Ident { path: ["M"], is_absolute: false }) }) }"#
+            r#"ArrayElementAccess { array: ArrayElementAccess { array: Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] }, index: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } } }, index: Block(Block { statements: [], final_expr: Ident(Ident { path: ["M"], is_absolute: false }) }) }"#
         ]],
     );
 
@@ -1086,7 +1086,7 @@ fn tuple_expressions() {
     check(
         &run_parser!(expr(), r#"{ { 42 }, if c { 2 } else { 3 }, foo() }"#),
         expect_test::expect![[
-            r#"Tuple([(None, Block(Block { statements: [], final_expr: Immediate(Int(42)) })), (None, If(IfExpr { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: Immediate(Int(2)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } })), (None, Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] })])"#
+            r#"Tuple([(None, Block(Block { statements: [], final_expr: Immediate(Int(42)) })), (None, If { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: Immediate(Int(2)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } }), (None, Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] })])"#
         ]],
     );
 
@@ -1096,7 +1096,7 @@ fn tuple_expressions() {
             r#"{ x: { 42 }, y: if c { 2 } else { 3 }, z: foo() }"#
         ),
         expect_test::expect![[
-            r#"Tuple([(Some("x"), Block(Block { statements: [], final_expr: Immediate(Int(42)) })), (Some("y"), If(IfExpr { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: Immediate(Int(2)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } })), (Some("z"), Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] })])"#
+            r#"Tuple([(Some("x"), Block(Block { statements: [], final_expr: Immediate(Int(42)) })), (Some("y"), If { condition: Ident(Ident { path: ["c"], is_absolute: false }), then_block: Block { statements: [], final_expr: Immediate(Int(2)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } }), (Some("z"), Call { name: Ident { path: ["foo"], is_absolute: false }, args: [] })])"#
         ]],
     );
 }
@@ -1178,13 +1178,13 @@ fn tuple_field_accesses() {
 
     check(
         &run_parser!(expr(), r#"if true { {0, 0} } else { {0, 0} }.0"#),
-        expect_test::expect!["TupleFieldAccess { tuple: If(IfExpr { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) }, else_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) } }), field: Left(0) }"],
+        expect_test::expect!["TupleFieldAccess { tuple: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) }, else_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) } }, field: Left(0) }"],
     );
 
     check(
         &run_parser!(expr(), r#"if true { {0, 0} } else { {0, 0} }.x"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: If(IfExpr { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) }, else_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) } }), field: Right("x") }"#
+            r#"TupleFieldAccess { tuple: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) }, else_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) } }, field: Right("x") }"#
         ]],
     );
 
@@ -1261,28 +1261,28 @@ fn cond_exprs() {
     check(
         &run_parser!(cond_expr(expr()), r#"cond { else => a }"#),
         expect_test::expect![[
-            r#"Cond(CondExpr { branches: [], else_result: Ident(Ident { path: ["a"], is_absolute: false }) })"#
+            r#"Cond { branches: [], else_result: Ident(Ident { path: ["a"], is_absolute: false }) }"#
         ]],
     );
 
     check(
         &run_parser!(cond_expr(expr()), r#"cond { else => { a } }"#),
         expect_test::expect![[
-            r#"Cond(CondExpr { branches: [], else_result: Block(Block { statements: [], final_expr: Ident(Ident { path: ["a"], is_absolute: false }) }) })"#
+            r#"Cond { branches: [], else_result: Block(Block { statements: [], final_expr: Ident(Ident { path: ["a"], is_absolute: false }) }) }"#
         ]],
     );
 
     check(
         &run_parser!(cond_expr(expr()), r#"cond { a => b, else => c }"#),
         expect_test::expect![[
-            r#"Cond(CondExpr { branches: [CondBranch { condition: Ident(Ident { path: ["a"], is_absolute: false }), result: Ident(Ident { path: ["b"], is_absolute: false }) }], else_result: Ident(Ident { path: ["c"], is_absolute: false }) })"#
+            r#"Cond { branches: [CondBranch { condition: Ident(Ident { path: ["a"], is_absolute: false }), result: Ident(Ident { path: ["b"], is_absolute: false }) }], else_result: Ident(Ident { path: ["c"], is_absolute: false }) }"#
         ]],
     );
 
     check(
         &run_parser!(cond_expr(expr()), r#"cond { a => { b }, else => c, }"#),
         expect_test::expect![[
-            r#"Cond(CondExpr { branches: [CondBranch { condition: Ident(Ident { path: ["a"], is_absolute: false }), result: Block(Block { statements: [], final_expr: Ident(Ident { path: ["b"], is_absolute: false }) }) }], else_result: Ident(Ident { path: ["c"], is_absolute: false }) })"#
+            r#"Cond { branches: [CondBranch { condition: Ident(Ident { path: ["a"], is_absolute: false }), result: Block(Block { statements: [], final_expr: Ident(Ident { path: ["b"], is_absolute: false }) }) }], else_result: Ident(Ident { path: ["c"], is_absolute: false }) }"#
         ]],
     );
 
@@ -1292,7 +1292,7 @@ fn cond_exprs() {
             r#"cond { a => b, { true } => d, else => f, }"#
         ),
         expect_test::expect![[
-            r#"Cond(CondExpr { branches: [CondBranch { condition: Ident(Ident { path: ["a"], is_absolute: false }), result: Ident(Ident { path: ["b"], is_absolute: false }) }, CondBranch { condition: Block(Block { statements: [], final_expr: Immediate(Bool(true)) }), result: Ident(Ident { path: ["d"], is_absolute: false }) }], else_result: Ident(Ident { path: ["f"], is_absolute: false }) })"#
+            r#"Cond { branches: [CondBranch { condition: Ident(Ident { path: ["a"], is_absolute: false }), result: Ident(Ident { path: ["b"], is_absolute: false }) }, CondBranch { condition: Block(Block { statements: [], final_expr: Immediate(Bool(true)) }), result: Ident(Ident { path: ["d"], is_absolute: false }) }], else_result: Ident(Ident { path: ["f"], is_absolute: false }) }"#
         ]],
     );
 
@@ -1505,7 +1505,7 @@ fn contract_test() {
             "contract Foo(if true {0} else {1}) {}"
         ),
         expect_test::expect![[
-            r#"Contract { name: "Foo", id: If(IfExpr { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(0)) }, else_block: Block { statements: [], final_expr: Immediate(Int(1)) } }), interfaces: [], functions: [], name_span: 9..12 }"#
+            r#"Contract { name: "Foo", id: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(0)) }, else_block: Block { statements: [], final_expr: Immediate(Int(1)) } }, interfaces: [], functions: [], name_span: 9..12 }"#
         ]],
     );
 

--- a/yurtc/src/types.rs
+++ b/yurtc/src/types.rs
@@ -1,0 +1,10 @@
+#[derive(Clone, Debug, PartialEq)]
+pub(super) enum Type<Ident, Expr> {
+    Bool,
+    Int,
+    Real,
+    String,
+    Array { ty: Box<Self>, range: Expr },
+    Tuple(Vec<(Option<String>, Self)>),
+    CustomType(Ident),
+}


### PR DESCRIPTION
This is to allow it to be shared between the AST and the intermediate & final intent data structures.

## Why?

While working on the framework for semantic analysis and optimisation I realised that expressions are a big part of the intermediate data structure and it pretty much can be used unchanged from the AST, although there are some minor differences, outlined below.  So instead of explicitly using `ast::` data structures in the intermediate `Intent`s I think it's nicer to have `Expr` (and consequently `Type`) out in its own module to be shared between the `ast` and forthcoming `intent` modules.

## What?

So this change actually does very little, it's just a refactor.  I did remove some small structs like `IfExpr` and inlined them into `Expr`, so the tests have changed slightly.

## Details and design decisions.

`Expr` has both `Ident` and `Block` parameterised.  This is because in the AST the `Ident`s are `Vec<String>` and may be still relative to the current module.  For semantic analysis all symbols will be canonicalised into absolute paths and should be represented simply as a `String`.

`Block`s are a bit of a pain because they are (currently) expressions which contain non-expression `let` and `constraint` declarations.  In the future if we switch functions to being macros then blocks used as macro bodies need not be expressions at all.  But we also use `Block`s for e.g., if-expressions and so they must remain proper expressions in this case.  We will need to make a distinction between blocks which are and aren't strictly expressions in the future.

Also, during conversion to `Intent` after canonicalisation, proper `Block` expressions will be exploded, putting any declarations among top-level peers and just using the final expression from the `Block` as the 'block expression'.  So the `Block` parameter to `Expr` will be just `Expr`.

I've done this now, rather than as a part of my main PR because whenever one moves giant swathes of code to new files it's always a pain if it causes merge conflicts for other branches.
