### PR TITLE
Turn `String` to `Ident` and `Ident` to `Path` in the AST

### DIFF
--- a/yurtc/src/ast.rs
+++ b/yurtc/src/ast.rs
@@ -5,11 +5,11 @@ use crate::{
     types::{EnumDecl, FnSig as F, Type as T},
 };
 
-pub(super) type Expr = E<Ident, Block>;
-pub(super) type Type = T<Ident, Expr>;
+pub(super) type Expr = E<Path, Block>;
+pub(super) type Type = T<Path, Expr>;
 pub(super) type FnSig = F<Type>;
 pub(super) type InterfaceDecl = ID<Type>;
-pub(super) type ContractDecl = CD<Ident, Expr, Type>;
+pub(super) type ContractDecl = CD<Path, Expr, Type>;
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) enum Decl {
@@ -19,13 +19,13 @@ pub(super) enum Decl {
         span: Span,
     },
     Let {
-        name: String,
+        name: Ident,
         ty: Option<Type>,
         init: Option<Expr>,
         span: Span,
     },
     State {
-        name: String,
+        name: Ident,
         ty: Option<Type>,
         init: Expr,
         span: Span,
@@ -37,6 +37,7 @@ pub(super) enum Decl {
     Fn {
         fn_sig: FnSig,
         body: Block,
+        span: Span,
     },
     Solve {
         directive: SolveFunc,
@@ -47,27 +48,17 @@ pub(super) enum Decl {
     Contract(ContractDecl),
     Extern {
         functions: Vec<FnSig>,
-        extern_keyword_span: Span,
+        span: Span,
     },
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) enum UseTree {
     Glob,
-    Name {
-        name: String,
-    },
-    Path {
-        prefix: String,
-        suffix: Box<UseTree>,
-    },
-    Group {
-        imports: Vec<UseTree>,
-    },
-    Alias {
-        name: String,
-        alias: String,
-    },
+    Name { name: Ident },
+    Path { prefix: Ident, suffix: Box<UseTree> },
+    Group { imports: Vec<UseTree> },
+    Alias { name: Ident, alias: Ident },
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -78,7 +69,13 @@ pub(super) struct Block {
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct Ident {
-    pub(super) path: Vec<String>,
+    pub(super) name: String,
+    pub(super) span: Span,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct Path {
+    pub(super) path: Vec<Ident>,
     pub(super) is_absolute: bool,
     pub(super) span: Span,
 }
@@ -86,6 +83,6 @@ pub(super) struct Ident {
 #[derive(Clone, Debug, PartialEq)]
 pub(super) enum SolveFunc {
     Satisfy,
-    Minimize(Ident),
-    Maximize(Ident),
+    Minimize(Path),
+    Maximize(Path),
 }

--- a/yurtc/src/contract.rs
+++ b/yurtc/src/contract.rs
@@ -1,17 +1,17 @@
-use crate::{error::Span, types::FnSig};
+use crate::{ast::Ident, error::Span, types::FnSig};
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct InterfaceDecl<Type> {
-    pub(super) name: String,
+    pub(super) name: Ident,
     pub(super) functions: Vec<FnSig<Type>>,
-    pub(super) name_span: Span,
+    pub(super) span: Span,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(super) struct ContractDecl<Ident, Expr, Type> {
-    pub(super) name: String,
+pub(super) struct ContractDecl<Path, Expr, Type> {
+    pub(super) name: Ident,
     pub(super) id: Expr,
-    pub(super) interfaces: Vec<Ident>,
+    pub(super) interfaces: Vec<Path>,
     pub(super) functions: Vec<FnSig<Type>>,
-    pub(super) name_span: Span,
+    pub(super) span: Span,
 }

--- a/yurtc/src/expr.rs
+++ b/yurtc/src/expr.rs
@@ -1,7 +1,9 @@
+use crate::ast::Ident;
+
 #[derive(Clone, Debug, PartialEq)]
-pub(super) enum Expr<Ident, BlockExpr> {
+pub(super) enum Expr<Path, BlockExpr> {
     Immediate(Immediate),
-    Ident(Ident),
+    Path(Path),
     UnaryOp {
         op: UnaryOp,
         expr: Box<Self>,
@@ -12,7 +14,7 @@ pub(super) enum Expr<Ident, BlockExpr> {
         rhs: Box<Self>,
     },
     Call {
-        name: Ident,
+        name: Path,
         args: Vec<Self>,
     },
     Block(BlockExpr),
@@ -30,14 +32,14 @@ pub(super) enum Expr<Ident, BlockExpr> {
         array: Box<Self>,
         index: Box<Self>,
     },
-    Tuple(Vec<(Option<String>, Self)>),
+    Tuple(Vec<(Option<Ident>, Self)>),
     TupleFieldAccess {
         tuple: Box<Self>,
-        field: itertools::Either<usize, String>,
+        field: itertools::Either<usize, Ident>,
     },
     Cast {
         value: Box<Self>,
-        ty: Box<super::types::Type<Ident, Self>>,
+        ty: Box<super::types::Type<Path, Self>>,
     },
     In {
         value: Box<Self>,
@@ -60,7 +62,7 @@ pub(super) struct CondBranch<E> {
     pub(super) result: Box<E>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum UnaryOp {
     Pos,
     Neg,
@@ -68,7 +70,7 @@ pub enum UnaryOp {
     NextState,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BinaryOp {
     Mul,
     Div,

--- a/yurtc/src/intent.rs
+++ b/yurtc/src/intent.rs
@@ -44,7 +44,7 @@ pub struct Variable {
 #[derive(Debug)]
 pub enum Expression {
     Immediate(expr::Immediate),
-    Ident(Path),
+    Path(Path),
     UnaryOp {
         op: expr::UnaryOp,
         expr: Box<Self>,

--- a/yurtc/src/intent/intermediate.rs
+++ b/yurtc/src/intent/intermediate.rs
@@ -82,10 +82,14 @@ use crate::expr;
 #[test]
 fn single_let() {
     let ast = vec![ast::Decl::Let {
-        name: "foo".to_owned(),
+        // `let foo: real;`
+        name: ast::Ident {
+            name: "foo".to_owned(),
+            span: 4..7,
+        },
         ty: Some(ast::Type::Real),
         init: None,
-        span: 0..3,
+        span: 0..14,
     }];
 
     assert!(IntermediateIntent::from_ast(&ast).is_ok());
@@ -95,16 +99,24 @@ fn single_let() {
 fn double_let_clash() {
     let ast = vec![
         ast::Decl::Let {
-            name: "foo".to_owned(),
+            // `let foo: real;`
+            name: ast::Ident {
+                name: "foo".to_owned(),
+                span: 4..7,
+            },
             ty: Some(ast::Type::Real),
             init: None,
-            span: 0..3,
+            span: 0..14,
         },
         ast::Decl::Let {
-            name: "foo".to_owned(),
+            // `let foo: real;`
+            name: ast::Ident {
+                name: "foo".to_owned(),
+                span: 19..22,
+            },
             ty: Some(ast::Type::Real),
             init: None,
-            span: 3..6,
+            span: 15..29,
         },
     ];
 
@@ -114,7 +126,7 @@ fn double_let_clash() {
     assert!(res.is_err_and(|e| {
         assert_eq!(
             format!("{e:?}"),
-            r#"NameClash { sym: "foo", span: 3..6, prev_span: 0..3 }"#
+            r#"NameClash { sym: "foo", span: 19..22, prev_span: 4..7 }"#
         );
         true
     }));
@@ -124,22 +136,31 @@ fn double_let_clash() {
 fn let_fn_clash() {
     let ast = vec![
         ast::Decl::Let {
-            name: "bar".to_owned(),
+            // `let bar: real;`
+            name: ast::Ident {
+                name: "bar".to_owned(),
+                span: 4..7,
+            },
             ty: Some(ast::Type::Real),
             init: None,
-            span: 0..3,
+            span: 0..14,
         },
         ast::Decl::Fn {
             fn_sig: ast::FnSig {
-                name: "bar".to_owned(),
+                // `fn bar() -> bool { false }`
+                name: ast::Ident {
+                    name: "bar".to_owned(),
+                    span: 18..21,
+                },
                 params: Vec::new(),
                 return_type: ast::Type::Bool,
-                span: 3..6,
+                span: 15..31,
             },
             body: ast::Block {
                 statements: Vec::new(),
                 final_expr: Box::new(ast::Expr::Immediate(expr::Immediate::Bool(false))),
             },
+            span: 15..41,
         },
     ];
 
@@ -148,7 +169,7 @@ fn let_fn_clash() {
     assert!(res.is_err_and(|e| {
         assert_eq!(
             format!("{e:?}"),
-            r#"NameClash { sym: "bar", span: 3..6, prev_span: 0..3 }"#
+            r#"NameClash { sym: "bar", span: 18..21, prev_span: 4..7 }"#
         );
         true
     }));

--- a/yurtc/src/intent/intermediate/compile.rs
+++ b/yurtc/src/intent/intermediate/compile.rs
@@ -76,7 +76,7 @@ fn convert_directive(directives: Vec<(Solve, Span)>) -> super::Result<Solve> {
 fn convert_expr(expr: Expr, span: &Span) -> super::Result<Expression> {
     match expr {
         super::Expr::Immediate(imm) => Ok(Expression::Immediate(imm)),
-        super::Expr::Ident(id) => Ok(Expression::Ident(id)),
+        super::Expr::Path(id) => Ok(Expression::Path(id)),
         super::Expr::UnaryOp { op, expr } => {
             convert_expr(*expr, span).map(|expr| Expression::UnaryOp {
                 op,

--- a/yurtc/src/parser/tests.rs
+++ b/yurtc/src/parser/tests.rs
@@ -64,7 +64,7 @@ fn types() {
     check(
         &run_parser!(type_(expr()), "custom_type"),
         expect_test::expect![[
-            r#"CustomType(Ident { path: ["custom_type"], is_absolute: false, span: 0..11 })"#
+            r#"CustomType(Path { path: [Ident { name: "custom_type", span: 0..11 }], is_absolute: false, span: 0..11 })"#
         ]],
     );
 }
@@ -116,42 +116,42 @@ fn use_statements() {
     check(
         &run_parser!(yurt_program(), "use a; use ::a; use ::a as b;"),
         expect_test::expect![[
-            r#"[Use { is_absolute: false, use_tree: Name { name: "a" }, span: 0..6 }, Use { is_absolute: true, use_tree: Name { name: "a" }, span: 7..15 }, Use { is_absolute: true, use_tree: Alias { name: "a", alias: "b" }, span: 16..29 }]"#
+            r#"[Use { is_absolute: false, use_tree: Name { name: Ident { name: "a", span: 4..5 } }, span: 0..6 }, Use { is_absolute: true, use_tree: Name { name: Ident { name: "a", span: 13..14 } }, span: 7..15 }, Use { is_absolute: true, use_tree: Alias { name: Ident { name: "a", span: 22..23 }, alias: Ident { name: "b", span: 27..28 } }, span: 16..29 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use a::b; use ::a::b; use ::a::b as c;"),
         expect_test::expect![[
-            r#"[Use { is_absolute: false, use_tree: Path { prefix: "a", suffix: Name { name: "b" } }, span: 0..9 }, Use { is_absolute: true, use_tree: Path { prefix: "a", suffix: Name { name: "b" } }, span: 10..21 }, Use { is_absolute: true, use_tree: Path { prefix: "a", suffix: Alias { name: "b", alias: "c" } }, span: 22..38 }]"#
+            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: 4..5 }, suffix: Name { name: Ident { name: "b", span: 7..8 } } }, span: 0..9 }, Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 16..17 }, suffix: Name { name: Ident { name: "b", span: 19..20 } } }, span: 10..21 }, Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 28..29 }, suffix: Alias { name: Ident { name: "b", span: 31..32 }, alias: Ident { name: "c", span: 36..37 } } }, span: 22..38 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use a::{b, c as d};"),
         expect_test::expect![[
-            r#"[Use { is_absolute: false, use_tree: Path { prefix: "a", suffix: Group { imports: [Name { name: "b" }, Alias { name: "c", alias: "d" }] } }, span: 0..19 }]"#
+            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: 4..5 }, suffix: Group { imports: [Name { name: Ident { name: "b", span: 8..9 } }, Alias { name: Ident { name: "c", span: 11..12 }, alias: Ident { name: "d", span: 16..17 } }] } }, span: 0..19 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use ::a::{*, c as d};"),
         expect_test::expect![[
-            r#"[Use { is_absolute: true, use_tree: Path { prefix: "a", suffix: Group { imports: [Glob, Alias { name: "c", alias: "d" }] } }, span: 0..21 }]"#
+            r#"[Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 6..7 }, suffix: Group { imports: [Glob, Alias { name: Ident { name: "c", span: 13..14 }, alias: Ident { name: "d", span: 18..19 } }] } }, span: 0..21 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use ::a::{*, c as d};"),
         expect_test::expect![[
-            r#"[Use { is_absolute: true, use_tree: Path { prefix: "a", suffix: Group { imports: [Glob, Alias { name: "c", alias: "d" }] } }, span: 0..21 }]"#
+            r#"[Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 6..7 }, suffix: Group { imports: [Glob, Alias { name: Ident { name: "c", span: 13..14 }, alias: Ident { name: "d", span: 18..19 } }] } }, span: 0..21 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use a::{{*}, {c as d, { e as f, * }}};"),
         expect_test::expect![[
-            r#"[Use { is_absolute: false, use_tree: Path { prefix: "a", suffix: Group { imports: [Group { imports: [Glob] }, Group { imports: [Alias { name: "c", alias: "d" }, Group { imports: [Alias { name: "e", alias: "f" }, Glob] }] }] } }, span: 0..38 }]"#
+            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: 4..5 }, suffix: Group { imports: [Group { imports: [Glob] }, Group { imports: [Alias { name: Ident { name: "c", span: 14..15 }, alias: Ident { name: "d", span: 19..20 } }, Group { imports: [Alias { name: Ident { name: "e", span: 24..25 }, alias: Ident { name: "f", span: 29..30 } }, Glob] }] }] } }, span: 0..38 }]"#
         ]],
     );
 
@@ -203,67 +203,73 @@ fn let_decls() {
     check(
         &run_parser!(let_decl(expr()), "let blah = 1.0;"),
         expect_test::expect![[
-            r#"Let { name: "blah", ty: None, init: Some(Immediate(Real(1.0))), span: 0..15 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate(Real(1.0))), span: 0..15 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: real = 1.0;"),
         expect_test::expect![[
-            r#"Let { name: "blah", ty: Some(Real), init: Some(Immediate(Real(1.0))), span: 0..21 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Real), init: Some(Immediate(Real(1.0))), span: 0..21 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: real;"),
-        expect_test::expect![[r#"Let { name: "blah", ty: Some(Real), init: None, span: 0..15 }"#]],
+        expect_test::expect![[
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Real), init: None, span: 0..15 }"#
+        ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah = 1;"),
         expect_test::expect![[
-            r#"Let { name: "blah", ty: None, init: Some(Immediate(Int(1))), span: 0..13 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate(Int(1))), span: 0..13 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: int = 1;"),
         expect_test::expect![[
-            r#"Let { name: "blah", ty: Some(Int), init: Some(Immediate(Int(1))), span: 0..18 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Int), init: Some(Immediate(Int(1))), span: 0..18 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: int;"),
-        expect_test::expect![[r#"Let { name: "blah", ty: Some(Int), init: None, span: 0..14 }"#]],
+        expect_test::expect![[
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Int), init: None, span: 0..14 }"#
+        ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah = true;"),
         expect_test::expect![[
-            r#"Let { name: "blah", ty: None, init: Some(Immediate(Bool(true))), span: 0..16 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate(Bool(true))), span: 0..16 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: bool = false;"),
         expect_test::expect![[
-            r#"Let { name: "blah", ty: Some(Bool), init: Some(Immediate(Bool(false))), span: 0..23 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Bool), init: Some(Immediate(Bool(false))), span: 0..23 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: bool;"),
-        expect_test::expect![[r#"Let { name: "blah", ty: Some(Bool), init: None, span: 0..15 }"#]],
+        expect_test::expect![[
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Bool), init: None, span: 0..15 }"#
+        ]],
     );
     check(
         &run_parser!(let_decl(expr()), r#"let blah = "hello";"#),
         expect_test::expect![[
-            r#"Let { name: "blah", ty: None, init: Some(Immediate(String("hello"))), span: 0..19 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate(String("hello"))), span: 0..19 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), r#"let blah: string = "hello";"#),
         expect_test::expect![[
-            r#"Let { name: "blah", ty: Some(String), init: Some(Immediate(String("hello"))), span: 0..27 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(String), init: Some(Immediate(String("hello"))), span: 0..27 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), r#"let blah: string;"#),
         expect_test::expect![[
-            r#"Let { name: "blah", ty: Some(String), init: None, span: 0..17 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(String), init: None, span: 0..17 }"#
         ]],
     );
 }
@@ -274,7 +280,7 @@ fn constraint_decls() {
     check(
         &run_parser!(constraint_decl(expr()), "constraint blah;"),
         expect_test::expect![[
-            r#"Constraint { expr: Ident(Ident { path: ["blah"], is_absolute: false, span: 11..15 }), span: 0..16 }"#
+            r#"Constraint { expr: Path(Path { path: [Ident { name: "blah", span: 11..15 }], is_absolute: false, span: 11..15 }), span: 0..16 }"#
         ]],
     );
 }
@@ -288,13 +294,13 @@ fn solve_decls() {
     check(
         &run_parser!(solve_decl(), "solve minimize foo;"),
         expect_test::expect![[
-            r#"Solve { directive: Minimize(Ident { path: ["foo"], is_absolute: false, span: 15..18 }), span: 0..19 }"#
+            r#"Solve { directive: Minimize(Path { path: [Ident { name: "foo", span: 15..18 }], is_absolute: false, span: 15..18 }), span: 0..19 }"#
         ]],
     );
     check(
         &run_parser!(solve_decl(), "solve maximize foo;"),
         expect_test::expect![[
-            r#"Solve { directive: Maximize(Ident { path: ["foo"], is_absolute: false, span: 15..18 }), span: 0..19 }"#
+            r#"Solve { directive: Maximize(Path { path: [Ident { name: "foo", span: 15..18 }], is_absolute: false, span: 15..18 }), span: 0..19 }"#
         ]],
     );
 
@@ -314,7 +320,9 @@ fn basic_exprs() {
     );
     check(
         &run_parser!(expr(), "foo"),
-        expect_test::expect![[r#"Ident(Ident { path: ["foo"], is_absolute: false, span: 0..3 })"#]],
+        expect_test::expect![[
+            r#"Path(Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 })"#
+        ]],
     );
 }
 
@@ -323,19 +331,19 @@ fn unary_op_exprs() {
     check(
         &run_parser!(expr(), "!a"),
         expect_test::expect![[
-            r#"UnaryOp { op: Not, expr: Ident(Ident { path: ["a"], is_absolute: false, span: 1..2 }) }"#
+            r#"UnaryOp { op: Not, expr: Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 }) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "+a"),
         expect_test::expect![[
-            r#"UnaryOp { op: Pos, expr: Ident(Ident { path: ["a"], is_absolute: false, span: 1..2 }) }"#
+            r#"UnaryOp { op: Pos, expr: Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 }) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "-a"),
         expect_test::expect![[
-            r#"UnaryOp { op: Neg, expr: Ident(Ident { path: ["a"], is_absolute: false, span: 1..2 }) }"#
+            r#"UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 }) }"#
         ]],
     );
     check(
@@ -395,7 +403,7 @@ fn unary_op_exprs() {
     check(
         &run_parser!(expr(), "+ {- x} '  '  "),
         expect_test::expect![[
-            r#"UnaryOp { op: Pos, expr: UnaryOp { op: NextState, expr: UnaryOp { op: NextState, expr: Block(Block { statements: [], final_expr: UnaryOp { op: Neg, expr: Ident(Ident { path: ["x"], is_absolute: false, span: 5..6 }) } }) } } }"#
+            r#"UnaryOp { op: Pos, expr: UnaryOp { op: NextState, expr: UnaryOp { op: NextState, expr: Block(Block { statements: [], final_expr: UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "x", span: 5..6 }], is_absolute: false, span: 5..6 }) } }) } } }"#
         ]],
     );
 }
@@ -405,99 +413,99 @@ fn binary_op_exprs() {
     check(
         &run_parser!(expr(), "a * 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Mul, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a / 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Div, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Div, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a % 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Mod, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Mod, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a + 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Add, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a - 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Sub, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Sub, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a+2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Add, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a-2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Sub, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Sub, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a < 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a > 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: GreaterThan, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a <= 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThanOrEqual, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: LessThanOrEqual, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a >= 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: GreaterThanOrEqual, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: GreaterThanOrEqual, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a == 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Equal, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Equal, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a != 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: NotEqual, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: NotEqual, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a && b"),
         expect_test::expect![[
-            r#"BinaryOp { op: LogicalAnd, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Ident(Ident { path: ["b"], is_absolute: false, span: 5..6 }) }"#
+            r#"BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }) }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "a || b"),
         expect_test::expect![[
-            r#"BinaryOp { op: LogicalOr, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: Ident(Ident { path: ["b"], is_absolute: false, span: 5..6 }) }"#
+            r#"BinaryOp { op: LogicalOr, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }) }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "a || b && c || d && !e"),
         expect_test::expect![[
-            r#"BinaryOp { op: LogicalOr, lhs: BinaryOp { op: LogicalOr, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: BinaryOp { op: LogicalAnd, lhs: Ident(Ident { path: ["b"], is_absolute: false, span: 5..6 }), rhs: Ident(Ident { path: ["c"], is_absolute: false, span: 10..11 }) } }, rhs: BinaryOp { op: LogicalAnd, lhs: Ident(Ident { path: ["d"], is_absolute: false, span: 15..16 }), rhs: UnaryOp { op: Not, expr: Ident(Ident { path: ["e"], is_absolute: false, span: 21..22 }) } } }"#
+            r#"BinaryOp { op: LogicalOr, lhs: BinaryOp { op: LogicalOr, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }), rhs: Path(Path { path: [Ident { name: "c", span: 10..11 }], is_absolute: false, span: 10..11 }) } }, rhs: BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "d", span: 15..16 }], is_absolute: false, span: 15..16 }), rhs: UnaryOp { op: Not, expr: Path(Path { path: [Ident { name: "e", span: 21..22 }], is_absolute: false, span: 21..22 }) } } }"#
         ]],
     );
 }
@@ -507,49 +515,49 @@ fn complex_exprs() {
     check(
         &run_parser!(expr(), "2 * b * 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: Immediate(Int(2)), rhs: Ident(Ident { path: ["b"], is_absolute: false, span: 4..5 }) }, rhs: Immediate(Int(3)) }"#
+            r#"BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: Immediate(Int(2)), rhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }) }, rhs: Immediate(Int(3)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 < b * 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: Immediate(Int(2)), rhs: BinaryOp { op: Mul, lhs: Ident(Ident { path: ["b"], is_absolute: false, span: 4..5 }), rhs: Immediate(Int(3)) } }"#
+            r#"BinaryOp { op: LessThan, lhs: Immediate(Int(2)), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), rhs: Immediate(Int(3)) } }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2.0 > b * 3.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: GreaterThan, lhs: Immediate(Real(2.0)), rhs: BinaryOp { op: Mul, lhs: Ident(Ident { path: ["b"], is_absolute: false, span: 6..7 }), rhs: Immediate(Real(3.0)) } }"#
+            r#"BinaryOp { op: GreaterThan, lhs: Immediate(Real(2.0)), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: 6..7 }], is_absolute: false, span: 6..7 }), rhs: Immediate(Real(3.0)) } }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2.0 * b < 3.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: Mul, lhs: Immediate(Real(2.0)), rhs: Ident(Ident { path: ["b"], is_absolute: false, span: 6..7 }) }, rhs: Immediate(Real(3.0)) }"#
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: Mul, lhs: Immediate(Real(2.0)), rhs: Path(Path { path: [Ident { name: "b", span: 6..7 }], is_absolute: false, span: 6..7 }) }, rhs: Immediate(Real(3.0)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 > b < 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: GreaterThan, lhs: Immediate(Int(2)), rhs: Ident(Ident { path: ["b"], is_absolute: false, span: 4..5 }) }, rhs: Immediate(Int(3)) }"#
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: GreaterThan, lhs: Immediate(Int(2)), rhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }) }, rhs: Immediate(Int(3)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 != b < 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: NotEqual, lhs: Immediate(Int(2)), rhs: Ident(Ident { path: ["b"], is_absolute: false, span: 5..6 }) }, rhs: Immediate(Int(3)) }"#
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: NotEqual, lhs: Immediate(Int(2)), rhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }) }, rhs: Immediate(Int(3)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 < b != 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: NotEqual, lhs: BinaryOp { op: LessThan, lhs: Immediate(Int(2)), rhs: Ident(Ident { path: ["b"], is_absolute: false, span: 4..5 }) }, rhs: Immediate(Int(3)) }"#
+            r#"BinaryOp { op: NotEqual, lhs: BinaryOp { op: LessThan, lhs: Immediate(Int(2)), rhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }) }, rhs: Immediate(Int(3)) }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a > b * c < d"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: GreaterThan, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), rhs: BinaryOp { op: Mul, lhs: Ident(Ident { path: ["b"], is_absolute: false, span: 4..5 }), rhs: Ident(Ident { path: ["c"], is_absolute: false, span: 8..9 }) } }, rhs: Ident(Ident { path: ["d"], is_absolute: false, span: 12..13 }) }"#
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), rhs: Path(Path { path: [Ident { name: "c", span: 8..9 }], is_absolute: false, span: 8..9 }) } }, rhs: Path(Path { path: [Ident { name: "d", span: 12..13 }], is_absolute: false, span: 12..13 }) }"#
         ]],
     );
     check(
@@ -651,7 +659,7 @@ fn parens_exprs() {
     check(
         &run_parser!(expr(), "!(a < b)"),
         expect_test::expect![[
-            r#"UnaryOp { op: Not, expr: BinaryOp { op: LessThan, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 2..3 }), rhs: Ident(Ident { path: ["b"], is_absolute: false, span: 6..7 }) } }"#
+            r#"UnaryOp { op: Not, expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: 2..3 }], is_absolute: false, span: 2..3 }), rhs: Path(Path { path: [Ident { name: "b", span: 6..7 }], is_absolute: false, span: 6..7 }) } }"#
         ]],
     );
     check(
@@ -660,7 +668,9 @@ fn parens_exprs() {
     );
     check(
         &run_parser!(expr(), "(a)"),
-        expect_test::expect![[r#"Ident(Ident { path: ["a"], is_absolute: false, span: 1..2 })"#]],
+        expect_test::expect![[
+            r#"Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 })"#
+        ]],
     );
     check(
         &run_parser!(expr(), "()"),
@@ -671,13 +681,13 @@ fn parens_exprs() {
     check(
         &run_parser!(expr(), "(if a < b { 1 } else { 2 })"),
         expect_test::expect![[
-            r#"If { condition: BinaryOp { op: LessThan, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 4..5 }), rhs: Ident(Ident { path: ["b"], is_absolute: false, span: 8..9 }) }, then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }"#
+            r#"If { condition: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: 4..5 }], is_absolute: false, span: 4..5 }), rhs: Path(Path { path: [Ident { name: "b", span: 8..9 }], is_absolute: false, span: 8..9 }) }, then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }"#
         ]],
     );
     check(
         &run_parser!(expr(), "(foo(a, b, c))"),
         expect_test::expect![[
-            r#"Call { name: Ident { path: ["foo"], is_absolute: false, span: 1..4 }, args: [Ident(Ident { path: ["a"], is_absolute: false, span: 5..6 }), Ident(Ident { path: ["b"], is_absolute: false, span: 8..9 }), Ident(Ident { path: ["c"], is_absolute: false, span: 11..12 })] }"#
+            r#"Call { name: Path { path: [Ident { name: "foo", span: 1..4 }], is_absolute: false, span: 1..4 }, args: [Path(Path { path: [Ident { name: "a", span: 5..6 }], is_absolute: false, span: 5..6 }), Path(Path { path: [Ident { name: "b", span: 8..9 }], is_absolute: false, span: 8..9 }), Path(Path { path: [Ident { name: "c", span: 11..12 }], is_absolute: false, span: 11..12 })] }"#
         ]],
     );
 }
@@ -687,19 +697,19 @@ fn enums() {
     check(
         &run_parser!(enum_decl(), "enum MyEnum = Variant1 | Variant2;"),
         expect_test::expect![[
-            r#"Enum(EnumDecl { name: "MyEnum", variants: ["Variant1", "Variant2"], name_span: 5..11 })"#
+            r#"Enum(EnumDecl { name: Ident { name: "MyEnum", span: 5..11 }, variants: [Ident { name: "Variant1", span: 14..22 }, Ident { name: "Variant2", span: 25..33 }], span: 0..34 })"#
         ]],
     );
     check(
         &run_parser!(enum_decl(), "enum MyEnum = Variant1;"),
         expect_test::expect![[
-            r#"Enum(EnumDecl { name: "MyEnum", variants: ["Variant1"], name_span: 5..11 })"#
+            r#"Enum(EnumDecl { name: Ident { name: "MyEnum", span: 5..11 }, variants: [Ident { name: "Variant1", span: 14..22 }], span: 0..23 })"#
         ]],
     );
     check(
         &run_parser!(expr(), "MyEnum::Variant1;"),
         expect_test::expect![[
-            r#"Ident(Ident { path: ["MyEnum", "Variant1"], is_absolute: false, span: 0..16 })"#
+            r#"Path(Path { path: [Ident { name: "MyEnum", span: 0..6 }, Ident { name: "Variant1", span: 8..16 }], is_absolute: false, span: 0..16 })"#
         ]],
     );
     check(
@@ -710,7 +720,7 @@ fn enums() {
             "#
         ),
         expect_test::expect![[
-            r#"Let { name: "x", ty: None, init: Some(Ident(Ident { path: ["MyEnum", "Variant3"], is_absolute: false, span: 21..37 })), span: 13..38 }"#
+            r#"Let { name: Ident { name: "x", span: 17..18 }, ty: None, init: Some(Path(Path { path: [Ident { name: "MyEnum", span: 21..27 }, Ident { name: "Variant3", span: 29..37 }], is_absolute: false, span: 21..37 })), span: 13..38 }"#
         ]],
     );
     check(
@@ -721,7 +731,7 @@ fn enums() {
             "#
         ),
         expect_test::expect![[
-            r#"Let { name: "e", ty: Some(CustomType(Ident { path: ["path", "to", "MyEnum"], is_absolute: true, span: 20..38 })), init: None, span: 13..39 }"#
+            r#"Let { name: Ident { name: "e", span: 17..18 }, ty: Some(CustomType(Path { path: [Ident { name: "path", span: 22..26 }, Ident { name: "to", span: 28..30 }, Ident { name: "MyEnum", span: 32..38 }], is_absolute: true, span: 20..38 })), init: None, span: 13..39 }"#
         ]],
     );
 }
@@ -730,25 +740,28 @@ fn enums() {
 fn idents() {
     check(
         &run_parser!(ident(), "foobar"),
-        expect_test::expect![[r#""foobar""#]],
+        expect_test::expect![[r#"Ident { name: "foobar", span: 0..6 }"#]],
     );
     check(
         &run_parser!(ident(), "foo_bar"),
-        expect_test::expect![[r#""foo_bar""#]],
+        expect_test::expect![[r#"Ident { name: "foo_bar", span: 0..7 }"#]],
     );
     check(
         &run_parser!(ident(), "FOO_bar"),
-        expect_test::expect![[r#""FOO_bar""#]],
+        expect_test::expect![[r#"Ident { name: "FOO_bar", span: 0..7 }"#]],
     );
     check(
         &run_parser!(ident(), "__FOO"),
-        expect_test::expect![[r#""__FOO""#]],
+        expect_test::expect![[r#"Ident { name: "__FOO", span: 0..5 }"#]],
     );
     check(
         &run_parser!(ident(), "_2_FOO1"),
-        expect_test::expect![[r#""_2_FOO1""#]],
+        expect_test::expect![[r#"Ident { name: "_2_FOO1", span: 0..7 }"#]],
     );
-    check(&run_parser!(ident(), "_"), expect_test::expect![[r#""_""#]]);
+    check(
+        &run_parser!(ident(), "_"),
+        expect_test::expect![[r#"Ident { name: "_", span: 0..1 }"#]],
+    );
     check(
         &run_parser!(ident(), "12_ab"),
         expect_test::expect![[r#"
@@ -758,46 +771,52 @@ fn idents() {
     check(
         // Lexer will split this into 3 tokens, ident() will parse the first one.
         &run_parser!(ident(), "ab*cd"),
-        expect_test::expect![[r#""ab""#]],
+        expect_test::expect![[r#"Ident { name: "ab", span: 0..2 }"#]],
     );
 }
 
 #[test]
-fn ident_paths() {
+fn paths() {
     check(
-        &run_parser!(ident_path(), "foo::bar"),
-        expect_test::expect![[r#"Ident { path: ["foo", "bar"], is_absolute: false, span: 0..8 }"#]],
-    );
-    check(
-        &run_parser!(ident_path(), "_foo_::_bar"),
+        &run_parser!(path(), "foo::bar"),
         expect_test::expect![[
-            r#"Ident { path: ["_foo_", "_bar"], is_absolute: false, span: 0..11 }"#
+            r#"Path { path: [Ident { name: "foo", span: 0..3 }, Ident { name: "bar", span: 5..8 }], is_absolute: false, span: 0..8 }"#
         ]],
     );
     check(
-        &run_parser!(ident_path(), "_::_"),
-        expect_test::expect![[r#"Ident { path: ["_", "_"], is_absolute: false, span: 0..4 }"#]],
-    );
-    check(
-        &run_parser!(ident_path(), "t2::_3t::t4_::t"),
+        &run_parser!(path(), "_foo_::_bar"),
         expect_test::expect![[
-            r#"Ident { path: ["t2", "_3t", "t4_", "t"], is_absolute: false, span: 0..15 }"#
+            r#"Path { path: [Ident { name: "_foo_", span: 0..5 }, Ident { name: "_bar", span: 7..11 }], is_absolute: false, span: 0..11 }"#
         ]],
     );
     check(
-        &run_parser!(ident_path(), "::foo::bar"),
-        expect_test::expect![[r#"Ident { path: ["foo", "bar"], is_absolute: true, span: 0..10 }"#]],
+        &run_parser!(path(), "_::_"),
+        expect_test::expect![[
+            r#"Path { path: [Ident { name: "_", span: 0..1 }, Ident { name: "_", span: 3..4 }], is_absolute: false, span: 0..4 }"#
+        ]],
+    );
+    check(
+        &run_parser!(path(), "t2::_3t::t4_::t"),
+        expect_test::expect![[
+            r#"Path { path: [Ident { name: "t2", span: 0..2 }, Ident { name: "_3t", span: 4..7 }, Ident { name: "t4_", span: 9..12 }, Ident { name: "t", span: 14..15 }], is_absolute: false, span: 0..15 }"#
+        ]],
+    );
+    check(
+        &run_parser!(path(), "::foo::bar"),
+        expect_test::expect![[
+            r#"Path { path: [Ident { name: "foo", span: 2..5 }, Ident { name: "bar", span: 7..10 }], is_absolute: true, span: 0..10 }"#
+        ]],
     );
 
     // As long as these two produce an error... it should be expecting 'ident'.
     check(
-        &run_parser!(ident_path().then_ignore(end()), "foo::"),
+        &run_parser!(path().then_ignore(end()), "foo::"),
         expect_test::expect![[r#"
             @5..5: found end of input but expected something else
         "#]],
     );
     check(
-        &run_parser!(ident_path().then_ignore(end()), "::foo::"),
+        &run_parser!(path().then_ignore(end()), "::foo::"),
         expect_test::expect![[r#"
             @7..7: found end of input but expected something else
         "#]],
@@ -816,7 +835,7 @@ fn foo(x: real, y: real) -> real {
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Fn { fn_sig: FnSig { name: "foo", params: [("x", Real), ("y", Real)], return_type: Real, span: 1..33 }, body: Block { statements: [Let { name: "z", ty: None, init: Some(Immediate(Real(5.0))), span: 40..52 }], final_expr: Ident(Ident { path: ["z"], is_absolute: false, span: 57..58 }) } }]"#
+            r#"[Fn { fn_sig: FnSig { name: Ident { name: "foo", span: 4..7 }, params: [(Ident { name: "x", span: 8..9 }, Real), (Ident { name: "y", span: 17..18 }, Real)], return_type: Real, span: 1..33 }, body: Block { statements: [Let { name: Ident { name: "z", span: 44..45 }, ty: None, init: Some(Immediate(Real(5.0))), span: 40..52 }], final_expr: Path(Path { path: [Ident { name: "z", span: 57..58 }], is_absolute: false, span: 57..58 }) }, span: 1..60 }]"#
         ]],
     );
 }
@@ -830,14 +849,14 @@ let x = foo(a*3, c);
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Let { name: "x", ty: None, init: Some(Call { name: Ident { path: ["foo"], is_absolute: false, span: 9..12 }, args: [BinaryOp { op: Mul, lhs: Ident(Ident { path: ["a"], is_absolute: false, span: 13..14 }), rhs: Immediate(Int(3)) }, Ident(Ident { path: ["c"], is_absolute: false, span: 18..19 })] }), span: 1..21 }]"#
+            r#"[Let { name: Ident { name: "x", span: 5..6 }, ty: None, init: Some(Call { name: Path { path: [Ident { name: "foo", span: 9..12 }], is_absolute: false, span: 9..12 }, args: [BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "a", span: 13..14 }], is_absolute: false, span: 13..14 }), rhs: Immediate(Int(3)) }, Path(Path { path: [Ident { name: "c", span: 18..19 }], is_absolute: false, span: 18..19 })] }), span: 1..21 }]"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "A::B::foo(-a, b+c)"),
         expect_test::expect![[
-            r#"Call { name: Ident { path: ["A", "B", "foo"], is_absolute: false, span: 0..9 }, args: [UnaryOp { op: Neg, expr: Ident(Ident { path: ["a"], is_absolute: false, span: 11..12 }) }, BinaryOp { op: Add, lhs: Ident(Ident { path: ["b"], is_absolute: false, span: 14..15 }), rhs: Ident(Ident { path: ["c"], is_absolute: false, span: 16..17 }) }] }"#
+            r#"Call { name: Path { path: [Ident { name: "A", span: 0..1 }, Ident { name: "B", span: 3..4 }, Ident { name: "foo", span: 6..9 }], is_absolute: false, span: 0..9 }, args: [UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "a", span: 11..12 }], is_absolute: false, span: 11..12 }) }, BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "b", span: 14..15 }], is_absolute: false, span: 14..15 }), rhs: Path(Path { path: [Ident { name: "c", span: 16..17 }], is_absolute: false, span: 16..17 }) }] }"#
         ]],
     );
 }
@@ -847,14 +866,14 @@ fn code_blocks() {
     check(
         &run_parser!(let_decl(expr()), "let x = { 0 };"),
         expect_test::expect![[
-            r#"Let { name: "x", ty: None, init: Some(Block(Block { statements: [], final_expr: Immediate(Int(0)) })), span: 0..14 }"#
+            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Block(Block { statements: [], final_expr: Immediate(Int(0)) })), span: 0..14 }"#
         ]],
     );
 
     check(
         &run_parser!(let_decl(expr()), "let x = { constraint x > 0.0; 0.0 };"),
         expect_test::expect![[
-            r#"Let { name: "x", ty: None, init: Some(Block(Block { statements: [Constraint { expr: BinaryOp { op: GreaterThan, lhs: Ident(Ident { path: ["x"], is_absolute: false, span: 21..22 }), rhs: Immediate(Real(0.0)) }, span: 10..29 }], final_expr: Immediate(Real(0.0)) })), span: 0..36 }"#
+            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Block(Block { statements: [Constraint { expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "x", span: 21..22 }], is_absolute: false, span: 21..22 }), rhs: Immediate(Real(0.0)) }, span: 10..29 }], final_expr: Immediate(Real(0.0)) })), span: 0..36 }"#
         ]],
     );
 
@@ -864,14 +883,14 @@ fn code_blocks() {
             "constraint { constraint { true }; x > 0 };"
         ),
         expect_test::expect![[
-            r#"Constraint { expr: Block(Block { statements: [Constraint { expr: Block(Block { statements: [], final_expr: Immediate(Bool(true)) }), span: 13..33 }], final_expr: BinaryOp { op: GreaterThan, lhs: Ident(Ident { path: ["x"], is_absolute: false, span: 34..35 }), rhs: Immediate(Int(0)) } }), span: 0..42 }"#
+            r#"Constraint { expr: Block(Block { statements: [Constraint { expr: Block(Block { statements: [], final_expr: Immediate(Bool(true)) }), span: 13..33 }], final_expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "x", span: 34..35 }], is_absolute: false, span: 34..35 }), rhs: Immediate(Int(0)) } }), span: 0..42 }"#
         ]],
     );
 
     check(
         &run_parser!(let_decl(expr()), "let x = { 1.0 } * { 2.0 };"),
         expect_test::expect![[
-            r#"Let { name: "x", ty: None, init: Some(BinaryOp { op: Mul, lhs: Block(Block { statements: [], final_expr: Immediate(Real(1.0)) }), rhs: Block(Block { statements: [], final_expr: Immediate(Real(2.0)) }) }), span: 0..26 }"#
+            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(BinaryOp { op: Mul, lhs: Block(Block { statements: [], final_expr: Immediate(Real(1.0)) }), rhs: Block(Block { statements: [], final_expr: Immediate(Real(2.0)) }) }), span: 0..26 }"#
         ]],
     );
 
@@ -893,21 +912,21 @@ fn if_exprs() {
     check(
         &run_parser!(if_expr(expr()), "if c { 1 } else { 0 }"),
         expect_test::expect![[
-            r#"If { condition: Ident(Ident { path: ["c"], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } }"#
+            r#"If { condition: Path(Path { path: [Ident { name: "c", span: 3..4 }], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } }"#
         ]],
     );
 
     check(
         &run_parser!(if_expr(expr()), "if c { if c { 1 } else { 0 } } else { 2 }"),
         expect_test::expect![[
-            r#"If { condition: Ident(Ident { path: ["c"], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: If { condition: Ident(Ident { path: ["c"], is_absolute: false, span: 10..11 }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } } }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }"#
+            r#"If { condition: Path(Path { path: [Ident { name: "c", span: 3..4 }], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: If { condition: Path(Path { path: [Ident { name: "c", span: 10..11 }], is_absolute: false, span: 10..11 }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } } }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }"#
         ]],
     );
 
     check(
         &run_parser!(if_expr(expr()), "if c { if c { 1 } else { 0 } } else { 2 }"),
         expect_test::expect![[
-            r#"If { condition: Ident(Ident { path: ["c"], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: If { condition: Ident(Ident { path: ["c"], is_absolute: false, span: 10..11 }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } } }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }"#
+            r#"If { condition: Path(Path { path: [Ident { name: "c", span: 3..4 }], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: If { condition: Path(Path { path: [Ident { name: "c", span: 10..11 }], is_absolute: false, span: 10..11 }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } } }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }"#
         ]],
     );
 }
@@ -922,14 +941,14 @@ fn array_type() {
     check(
         &run_parser!(type_(expr()), r#"int[MyEnum]"#),
         expect_test::expect![[
-            r#"Array { ty: Int, range: Ident(Ident { path: ["MyEnum"], is_absolute: false, span: 4..10 }) }"#
+            r#"Array { ty: Int, range: Path(Path { path: [Ident { name: "MyEnum", span: 4..10 }], is_absolute: false, span: 4..10 }) }"#
         ]],
     );
 
     check(
         &run_parser!(type_(expr()), r#"int[N]"#),
         expect_test::expect![[
-            r#"Array { ty: Int, range: Ident(Ident { path: ["N"], is_absolute: false, span: 4..5 }) }"#
+            r#"Array { ty: Int, range: Path(Path { path: [Ident { name: "N", span: 4..5 }], is_absolute: false, span: 4..5 }) }"#
         ]],
     );
 
@@ -939,21 +958,21 @@ fn array_type() {
             r#"string[foo()][{ 7 }][if true { 1 } else { 2 }"#
         ),
         expect_test::expect![[
-            r#"Array { ty: Array { ty: String, range: Block(Block { statements: [], final_expr: Immediate(Int(7)) }) }, range: Call { name: Ident { path: ["foo"], is_absolute: false, span: 7..10 }, args: [] } }"#
+            r#"Array { ty: Array { ty: String, range: Block(Block { statements: [], final_expr: Immediate(Int(7)) }) }, range: Call { name: Path { path: [Ident { name: "foo", span: 7..10 }], is_absolute: false, span: 7..10 }, args: [] } }"#
         ]],
     );
 
     check(
         &run_parser!(type_(expr()), r#"real[N][9][M][3]"#),
         expect_test::expect![[
-            r#"Array { ty: Array { ty: Array { ty: Array { ty: Real, range: Immediate(Int(3)) }, range: Ident(Ident { path: ["M"], is_absolute: false, span: 11..12 }) }, range: Immediate(Int(9)) }, range: Ident(Ident { path: ["N"], is_absolute: false, span: 5..6 }) }"#
+            r#"Array { ty: Array { ty: Array { ty: Array { ty: Real, range: Immediate(Int(3)) }, range: Path(Path { path: [Ident { name: "M", span: 11..12 }], is_absolute: false, span: 11..12 }) }, range: Immediate(Int(9)) }, range: Path(Path { path: [Ident { name: "N", span: 5..6 }], is_absolute: false, span: 5..6 }) }"#
         ]],
     );
 
     check(
         &run_parser!(type_(expr()), r#"{int, { real, string }}[N][9]"#),
         expect_test::expect![[
-            r#"Array { ty: Array { ty: Tuple([(None, Int), (None, Tuple([(None, Real), (None, String)]))]), range: Immediate(Int(9)) }, range: Ident(Ident { path: ["N"], is_absolute: false, span: 24..25 }) }"#
+            r#"Array { ty: Array { ty: Tuple([(None, Int), (None, Tuple([(None, Real), (None, String)]))]), range: Immediate(Int(9)) }, range: Path(Path { path: [Ident { name: "N", span: 24..25 }], is_absolute: false, span: 24..25 }) }"#
         ]],
     );
 
@@ -1004,7 +1023,7 @@ fn array_expressions() {
             r#"[[foo(), { 2 }], [if true { 1 } else { 2 }, t.0]]"#
         ),
         expect_test::expect![[
-            r#"Array([Array([Call { name: Ident { path: ["foo"], is_absolute: false, span: 2..5 }, args: [] }, Block(Block { statements: [], final_expr: Immediate(Int(2)) })]), Array([If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }, TupleFieldAccess { tuple: Ident(Ident { path: ["t"], is_absolute: false, span: 44..45 }), field: Left(0) }])])"#
+            r#"Array([Array([Call { name: Path { path: [Ident { name: "foo", span: 2..5 }], is_absolute: false, span: 2..5 }, args: [] }, Block(Block { statements: [], final_expr: Immediate(Int(2)) })]), Array([If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }, TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 44..45 }], is_absolute: false, span: 44..45 }), field: Left(0) }])])"#
         ]],
     );
 }
@@ -1014,21 +1033,21 @@ fn array_field_accesss() {
     check(
         &run_parser!(expr(), r#"a[5]"#),
         expect_test::expect![[
-            r#"ArrayElementAccess { array: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), index: Immediate(Int(5)) }"#
+            r#"ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), index: Immediate(Int(5)) }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{ a }[N][foo()][M][4]"#),
         expect_test::expect![[
-            r#"ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: Block(Block { statements: [], final_expr: Ident(Ident { path: ["a"], is_absolute: false, span: 2..3 }) }), index: Immediate(Int(4)) }, index: Ident(Ident { path: ["M"], is_absolute: false, span: 16..17 }) }, index: Call { name: Ident { path: ["foo"], is_absolute: false, span: 9..12 }, args: [] } }, index: Ident(Ident { path: ["N"], is_absolute: false, span: 6..7 }) }"#
+            r#"ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "a", span: 2..3 }], is_absolute: false, span: 2..3 }) }), index: Immediate(Int(4)) }, index: Path(Path { path: [Ident { name: "M", span: 16..17 }], is_absolute: false, span: 16..17 }) }, index: Call { name: Path { path: [Ident { name: "foo", span: 9..12 }], is_absolute: false, span: 9..12 }, args: [] } }, index: Path(Path { path: [Ident { name: "N", span: 6..7 }], is_absolute: false, span: 6..7 }) }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"foo()[{ M }][if true { 1 } else { 3 }]"#),
         expect_test::expect![[
-            r#"ArrayElementAccess { array: ArrayElementAccess { array: Call { name: Ident { path: ["foo"], is_absolute: false, span: 0..3 }, args: [] }, index: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } } }, index: Block(Block { statements: [], final_expr: Ident(Ident { path: ["M"], is_absolute: false, span: 8..9 }) }) }"#
+            r#"ArrayElementAccess { array: ArrayElementAccess { array: Call { name: Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 }, args: [] }, index: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } } }, index: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "M", span: 8..9 }], is_absolute: false, span: 8..9 }) }) }"#
         ]],
     );
 
@@ -1042,7 +1061,7 @@ fn array_field_accesss() {
     check(
         &run_parser!(expr(), r#"a[MyEnum::Variant1];"#),
         expect_test::expect![[
-            r#"ArrayElementAccess { array: Ident(Ident { path: ["a"], is_absolute: false, span: 0..1 }), index: Ident(Ident { path: ["MyEnum", "Variant1"], is_absolute: false, span: 2..18 }) }"#
+            r#"ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), index: Path(Path { path: [Ident { name: "MyEnum", span: 2..8 }, Ident { name: "Variant1", span: 10..18 }], is_absolute: false, span: 2..18 }) }"#
         ]],
     );
 }
@@ -1056,7 +1075,9 @@ fn tuple_expressions() {
 
     check(
         &run_parser!(expr(), r#"{x: 0}"#), // This is a tuple because the field is named so there is no ambiguity
-        expect_test::expect![[r#"Tuple([(Some("x"), Immediate(Int(0)))])"#]],
+        expect_test::expect![[
+            r#"Tuple([(Some(Ident { name: "x", span: 1..2 }), Immediate(Int(0)))])"#
+        ]],
     );
 
     check(
@@ -1066,7 +1087,9 @@ fn tuple_expressions() {
 
     check(
         &run_parser!(expr(), r#"{x: 0,}"#), // This is a tuple
-        expect_test::expect![[r#"Tuple([(Some("x"), Immediate(Int(0)))])"#]],
+        expect_test::expect![[
+            r#"Tuple([(Some(Ident { name: "x", span: 1..2 }), Immediate(Int(0)))])"#
+        ]],
     );
 
     check(
@@ -1079,7 +1102,7 @@ fn tuple_expressions() {
     check(
         &run_parser!(expr(), r#"{x: 0, y: 1.0, z: "foo"}"#),
         expect_test::expect![[
-            r#"Tuple([(Some("x"), Immediate(Int(0))), (Some("y"), Immediate(Real(1.0))), (Some("z"), Immediate(String("foo")))])"#
+            r#"Tuple([(Some(Ident { name: "x", span: 1..2 }), Immediate(Int(0))), (Some(Ident { name: "y", span: 7..8 }), Immediate(Real(1.0))), (Some(Ident { name: "z", span: 15..16 }), Immediate(String("foo")))])"#
         ]],
     );
 
@@ -1093,14 +1116,14 @@ fn tuple_expressions() {
     check(
         &run_parser!(expr(), r#"{x: 0, {y: 1.0, "bar"}, z: "foo"}"#),
         expect_test::expect![[
-            r#"Tuple([(Some("x"), Immediate(Int(0))), (None, Tuple([(Some("y"), Immediate(Real(1.0))), (None, Immediate(String("bar")))])), (Some("z"), Immediate(String("foo")))])"#
+            r#"Tuple([(Some(Ident { name: "x", span: 1..2 }), Immediate(Int(0))), (None, Tuple([(Some(Ident { name: "y", span: 8..9 }), Immediate(Real(1.0))), (None, Immediate(String("bar")))])), (Some(Ident { name: "z", span: 24..25 }), Immediate(String("foo")))])"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{ { 42 }, if c { 2 } else { 3 }, foo() }"#),
         expect_test::expect![[
-            r#"Tuple([(None, Block(Block { statements: [], final_expr: Immediate(Int(42)) })), (None, If { condition: Ident(Ident { path: ["c"], is_absolute: false, span: 13..14 }), then_block: Block { statements: [], final_expr: Immediate(Int(2)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } }), (None, Call { name: Ident { path: ["foo"], is_absolute: false, span: 33..36 }, args: [] })])"#
+            r#"Tuple([(None, Block(Block { statements: [], final_expr: Immediate(Int(42)) })), (None, If { condition: Path(Path { path: [Ident { name: "c", span: 13..14 }], is_absolute: false, span: 13..14 }), then_block: Block { statements: [], final_expr: Immediate(Int(2)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } }), (None, Call { name: Path { path: [Ident { name: "foo", span: 33..36 }], is_absolute: false, span: 33..36 }, args: [] })])"#
         ]],
     );
 
@@ -1110,7 +1133,7 @@ fn tuple_expressions() {
             r#"{ x: { 42 }, y: if c { 2 } else { 3 }, z: foo() }"#
         ),
         expect_test::expect![[
-            r#"Tuple([(Some("x"), Block(Block { statements: [], final_expr: Immediate(Int(42)) })), (Some("y"), If { condition: Ident(Ident { path: ["c"], is_absolute: false, span: 19..20 }), then_block: Block { statements: [], final_expr: Immediate(Int(2)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } }), (Some("z"), Call { name: Ident { path: ["foo"], is_absolute: false, span: 42..45 }, args: [] })])"#
+            r#"Tuple([(Some(Ident { name: "x", span: 2..3 }), Block(Block { statements: [], final_expr: Immediate(Int(42)) })), (Some(Ident { name: "y", span: 13..14 }), If { condition: Path(Path { path: [Ident { name: "c", span: 19..20 }], is_absolute: false, span: 19..20 }), then_block: Block { statements: [], final_expr: Immediate(Int(2)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } }), (Some(Ident { name: "z", span: 39..40 }), Call { name: Path { path: [Ident { name: "foo", span: 42..45 }], is_absolute: false, span: 42..45 }, args: [] })])"#
         ]],
     );
 }
@@ -1120,7 +1143,7 @@ fn tuple_field_accesses() {
     check(
         &run_parser!(expr(), r#"t.0 + t.9999999 + t.x"#),
         expect_test::expect![[
-            r#"BinaryOp { op: Add, lhs: BinaryOp { op: Add, lhs: TupleFieldAccess { tuple: Ident(Ident { path: ["t"], is_absolute: false, span: 0..1 }), field: Left(0) }, rhs: TupleFieldAccess { tuple: Ident(Ident { path: ["t"], is_absolute: false, span: 6..7 }), field: Left(9999999) } }, rhs: TupleFieldAccess { tuple: Ident(Ident { path: ["t"], is_absolute: false, span: 18..19 }), field: Right("x") } }"#
+            r#"BinaryOp { op: Add, lhs: BinaryOp { op: Add, lhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(0) }, rhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 6..7 }], is_absolute: false, span: 6..7 }), field: Left(9999999) } }, rhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 18..19 }], is_absolute: false, span: 18..19 }), field: Right(Ident { name: "x", span: 20..21 }) } }"#
         ]],
     );
 
@@ -1132,49 +1155,49 @@ fn tuple_field_accesses() {
     check(
         &run_parser!(expr(), r#"{0, 1}.x"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(1)))]), field: Right("x") }"#
+            r#"TupleFieldAccess { tuple: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(1)))]), field: Right(Ident { name: "x", span: 7..8 }) }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"t.0 .0"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Ident(Ident { path: ["t"], is_absolute: false, span: 0..1 }), field: Left(0) }, field: Left(0) }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(0) }, field: Left(0) }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"t.x .y"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Ident(Ident { path: ["t"], is_absolute: false, span: 0..1 }), field: Right("x") }, field: Right("y") }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Right(Ident { name: "x", span: 2..3 }) }, field: Right(Ident { name: "y", span: 5..6 }) }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "t \r .1 .2.2. \n 3 . \t 13 . 1.1"),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Ident(Ident { path: ["t"], is_absolute: false, span: 0..1 }), field: Left(1) }, field: Left(2) }, field: Left(2) }, field: Left(3) }, field: Left(13) }, field: Left(1) }, field: Left(1) }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(1) }, field: Left(2) }, field: Left(2) }, field: Left(3) }, field: Left(13) }, field: Left(1) }, field: Left(1) }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "t \r .x .1.2. \n w . \t t. 3.4"),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Ident(Ident { path: ["t"], is_absolute: false, span: 0..1 }), field: Right("x") }, field: Left(1) }, field: Left(2) }, field: Right("w") }, field: Right("t") }, field: Left(3) }, field: Left(4) }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Right(Ident { name: "x", span: 5..6 }) }, field: Left(1) }, field: Left(2) }, field: Right(Ident { name: "w", span: 15..16 }) }, field: Right(Ident { name: "t", span: 21..22 }) }, field: Left(3) }, field: Left(4) }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"foo().0.1"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Call { name: Ident { path: ["foo"], is_absolute: false, span: 0..3 }, args: [] }, field: Left(0) }, field: Left(1) }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Call { name: Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 }, args: [] }, field: Left(0) }, field: Left(1) }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"foo().a.b.0.1"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Call { name: Ident { path: ["foo"], is_absolute: false, span: 0..3 }, args: [] }, field: Right("a") }, field: Right("b") }, field: Left(0) }, field: Left(1) }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Call { name: Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 }, args: [] }, field: Right(Ident { name: "a", span: 6..7 }) }, field: Right(Ident { name: "b", span: 8..9 }) }, field: Left(0) }, field: Left(1) }"#
         ]],
     );
 
@@ -1186,7 +1209,7 @@ fn tuple_field_accesses() {
     check(
         &run_parser!(expr(), r#"{ {0, 0} }.a"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: Block(Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) }), field: Right("a") }"#
+            r#"TupleFieldAccess { tuple: Block(Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) }), field: Right(Ident { name: "a", span: 11..12 }) }"#
         ]],
     );
 
@@ -1198,7 +1221,7 @@ fn tuple_field_accesses() {
     check(
         &run_parser!(expr(), r#"if true { {0, 0} } else { {0, 0} }.x"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) }, else_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) } }, field: Right("x") }"#
+            r#"TupleFieldAccess { tuple: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) }, else_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) } }, field: Right(Ident { name: "x", span: 35..36 }) }"#
         ]],
     );
 
@@ -1212,7 +1235,7 @@ fn tuple_field_accesses() {
     check(
         &run_parser!(expr(), "1 + 2 .a"),
         expect_test::expect![[
-            r#"BinaryOp { op: Add, lhs: Immediate(Int(1)), rhs: TupleFieldAccess { tuple: Immediate(Int(2)), field: Right("a") } }"#
+            r#"BinaryOp { op: Add, lhs: Immediate(Int(1)), rhs: TupleFieldAccess { tuple: Immediate(Int(2)), field: Right(Ident { name: "a", span: 7..8 }) } }"#
         ]],
     );
 
@@ -1275,28 +1298,28 @@ fn cond_exprs() {
     check(
         &run_parser!(cond_expr(expr()), r#"cond { else => a }"#),
         expect_test::expect![[
-            r#"Cond { branches: [], else_result: Ident(Ident { path: ["a"], is_absolute: false, span: 15..16 }) }"#
+            r#"Cond { branches: [], else_result: Path(Path { path: [Ident { name: "a", span: 15..16 }], is_absolute: false, span: 15..16 }) }"#
         ]],
     );
 
     check(
         &run_parser!(cond_expr(expr()), r#"cond { else => { a } }"#),
         expect_test::expect![[
-            r#"Cond { branches: [], else_result: Block(Block { statements: [], final_expr: Ident(Ident { path: ["a"], is_absolute: false, span: 17..18 }) }) }"#
+            r#"Cond { branches: [], else_result: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "a", span: 17..18 }], is_absolute: false, span: 17..18 }) }) }"#
         ]],
     );
 
     check(
         &run_parser!(cond_expr(expr()), r#"cond { a => b, else => c }"#),
         expect_test::expect![[
-            r#"Cond { branches: [CondBranch { condition: Ident(Ident { path: ["a"], is_absolute: false, span: 7..8 }), result: Ident(Ident { path: ["b"], is_absolute: false, span: 12..13 }) }], else_result: Ident(Ident { path: ["c"], is_absolute: false, span: 23..24 }) }"#
+            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: 7..8 }], is_absolute: false, span: 7..8 }), result: Path(Path { path: [Ident { name: "b", span: 12..13 }], is_absolute: false, span: 12..13 }) }], else_result: Path(Path { path: [Ident { name: "c", span: 23..24 }], is_absolute: false, span: 23..24 }) }"#
         ]],
     );
 
     check(
         &run_parser!(cond_expr(expr()), r#"cond { a => { b }, else => c, }"#),
         expect_test::expect![[
-            r#"Cond { branches: [CondBranch { condition: Ident(Ident { path: ["a"], is_absolute: false, span: 7..8 }), result: Block(Block { statements: [], final_expr: Ident(Ident { path: ["b"], is_absolute: false, span: 14..15 }) }) }], else_result: Ident(Ident { path: ["c"], is_absolute: false, span: 27..28 }) }"#
+            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: 7..8 }], is_absolute: false, span: 7..8 }), result: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "b", span: 14..15 }], is_absolute: false, span: 14..15 }) }) }], else_result: Path(Path { path: [Ident { name: "c", span: 27..28 }], is_absolute: false, span: 27..28 }) }"#
         ]],
     );
 
@@ -1306,7 +1329,7 @@ fn cond_exprs() {
             r#"cond { a => b, { true } => d, else => f, }"#
         ),
         expect_test::expect![[
-            r#"Cond { branches: [CondBranch { condition: Ident(Ident { path: ["a"], is_absolute: false, span: 7..8 }), result: Ident(Ident { path: ["b"], is_absolute: false, span: 12..13 }) }, CondBranch { condition: Block(Block { statements: [], final_expr: Immediate(Bool(true)) }), result: Ident(Ident { path: ["d"], is_absolute: false, span: 27..28 }) }], else_result: Ident(Ident { path: ["f"], is_absolute: false, span: 38..39 }) }"#
+            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: 7..8 }], is_absolute: false, span: 7..8 }), result: Path(Path { path: [Ident { name: "b", span: 12..13 }], is_absolute: false, span: 12..13 }) }, CondBranch { condition: Block(Block { statements: [], final_expr: Immediate(Bool(true)) }), result: Path(Path { path: [Ident { name: "d", span: 27..28 }], is_absolute: false, span: 27..28 }) }], else_result: Path(Path { path: [Ident { name: "f", span: 38..39 }], is_absolute: false, span: 38..39 }) }"#
         ]],
     );
 
@@ -1335,7 +1358,7 @@ fn casting() {
     check(
         &run_parser!(expr(), r#"t.0.1 as real * a[5][3] as int"#),
         expect_test::expect![[
-            r#"BinaryOp { op: Mul, lhs: Cast { value: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Ident(Ident { path: ["t"], is_absolute: false, span: 0..1 }), field: Left(0) }, field: Left(1) }, ty: Real }, rhs: Cast { value: ArrayElementAccess { array: ArrayElementAccess { array: Ident(Ident { path: ["a"], is_absolute: false, span: 16..17 }), index: Immediate(Int(3)) }, index: Immediate(Int(5)) }, ty: Int } }"#
+            r#"BinaryOp { op: Mul, lhs: Cast { value: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(0) }, field: Left(1) }, ty: Real }, rhs: Cast { value: ArrayElementAccess { array: ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: 16..17 }], is_absolute: false, span: 16..17 }), index: Immediate(Int(3)) }, index: Immediate(Int(5)) }, ty: Int } }"#
         ]],
     );
 
@@ -1345,7 +1368,7 @@ fn casting() {
             r#"let x = foo() as real as { int, real };"#
         ),
         expect_test::expect![[
-            r#"Let { name: "x", ty: None, init: Some(Cast { value: Cast { value: Call { name: Ident { path: ["foo"], is_absolute: false, span: 8..11 }, args: [] }, ty: Real }, ty: Tuple([(None, Int), (None, Real)]) }), span: 0..39 }"#
+            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Cast { value: Cast { value: Call { name: Path { path: [Ident { name: "foo", span: 8..11 }], is_absolute: false, span: 8..11 }, args: [] }, ty: Real }, ty: Tuple([(None, Int), (None, Real)]) }), span: 0..39 }"#
         ]],
     );
 
@@ -1362,28 +1385,28 @@ fn in_expr() {
     check(
         &run_parser!(expr(), r#"x in { 1, 2 }"#),
         expect_test::expect![[
-            r#"In { value: Ident(Ident { path: ["x"], is_absolute: false, span: 0..1 }), collection: Tuple([(None, Immediate(Int(1))), (None, Immediate(Int(2)))]) }"#
+            r#"In { value: Path(Path { path: [Ident { name: "x", span: 0..1 }], is_absolute: false, span: 0..1 }), collection: Tuple([(None, Immediate(Int(1))), (None, Immediate(Int(2)))]) }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"x in [ 1, 2 ] in { true, false }"#),
         expect_test::expect![[
-            r#"In { value: Ident(Ident { path: ["x"], is_absolute: false, span: 0..1 }), collection: In { value: Array([Immediate(Int(1)), Immediate(Int(2))]), collection: Tuple([(None, Immediate(Bool(true))), (None, Immediate(Bool(false)))]) } }"#
+            r#"In { value: Path(Path { path: [Ident { name: "x", span: 0..1 }], is_absolute: false, span: 0..1 }), collection: In { value: Array([Immediate(Int(1)), Immediate(Int(2))]), collection: Tuple([(None, Immediate(Bool(true))), (None, Immediate(Bool(false)))]) } }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"x as int in { 1, 2 }"#),
         expect_test::expect![[
-            r#"In { value: Cast { value: Ident(Ident { path: ["x"], is_absolute: false, span: 0..1 }), ty: Int }, collection: Tuple([(None, Immediate(Int(1))), (None, Immediate(Int(2)))]) }"#
+            r#"In { value: Cast { value: Path(Path { path: [Ident { name: "x", span: 0..1 }], is_absolute: false, span: 0..1 }), ty: Int }, collection: Tuple([(None, Immediate(Int(1))), (None, Immediate(Int(2)))]) }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"[1] in foo() in [[1]]"#),
         expect_test::expect![[
-            r#"In { value: Array([Immediate(Int(1))]), collection: In { value: Call { name: Ident { path: ["foo"], is_absolute: false, span: 7..10 }, args: [] }, collection: Array([Array([Immediate(Int(1))])]) } }"#
+            r#"In { value: Array([Immediate(Int(1))]), collection: In { value: Call { name: Path { path: [Ident { name: "foo", span: 7..10 }], is_absolute: false, span: 7..10 }, args: [] }, collection: Array([Array([Immediate(Int(1))])]) } }"#
         ]],
     );
 
@@ -1411,7 +1434,7 @@ solve minimize mid;
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Let { name: "low_val", ty: Some(Real), init: Some(Immediate(Real(1.23))), span: 1..26 }, Let { name: "high_val", ty: None, init: Some(Immediate(Real(4.56))), span: 27..47 }, Constraint { expr: BinaryOp { op: GreaterThan, lhs: Ident(Ident { path: ["mid"], is_absolute: false, span: 112..115 }), rhs: BinaryOp { op: Mul, lhs: Ident(Ident { path: ["low_val"], is_absolute: false, span: 118..125 }), rhs: Immediate(Real(2.0)) } }, span: 101..132 }, Constraint { expr: BinaryOp { op: LessThan, lhs: Ident(Ident { path: ["mid"], is_absolute: false, span: 144..147 }), rhs: Ident(Ident { path: ["high_val"], is_absolute: false, span: 150..158 }) }, span: 133..159 }, Solve { directive: Minimize(Ident { path: ["mid"], is_absolute: false, span: 176..179 }), span: 161..180 }]"#
+            r#"[Let { name: Ident { name: "low_val", span: 5..12 }, ty: Some(Real), init: Some(Immediate(Real(1.23))), span: 1..26 }, Let { name: Ident { name: "high_val", span: 31..39 }, ty: None, init: Some(Immediate(Real(4.56))), span: 27..47 }, Constraint { expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "mid", span: 112..115 }], is_absolute: false, span: 112..115 }), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "low_val", span: 118..125 }], is_absolute: false, span: 118..125 }), rhs: Immediate(Real(2.0)) } }, span: 101..132 }, Constraint { expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "mid", span: 144..147 }], is_absolute: false, span: 144..147 }), rhs: Path(Path { path: [Ident { name: "high_val", span: 150..158 }], is_absolute: false, span: 150..158 }) }, span: 133..159 }, Solve { directive: Minimize(Path { path: [Ident { name: "mid", span: 176..179 }], is_absolute: false, span: 176..179 }), span: 161..180 }]"#
         ]],
     );
 }
@@ -1446,7 +1469,7 @@ let low = 1.0;
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Solve { directive: Maximize(Ident { path: ["low"], is_absolute: false, span: 16..19 }), span: 1..20 }, Constraint { expr: BinaryOp { op: LessThan, lhs: Ident(Ident { path: ["low"], is_absolute: false, span: 32..35 }), rhs: Ident(Ident { path: ["high"], is_absolute: false, span: 38..42 }) }, span: 21..43 }, Let { name: "high", ty: None, init: Some(Immediate(Real(2.0))), span: 44..59 }, Solve { directive: Satisfy, span: 60..74 }, Let { name: "low", ty: None, init: Some(Immediate(Real(1.0))), span: 75..89 }]"#
+            r#"[Solve { directive: Maximize(Path { path: [Ident { name: "low", span: 16..19 }], is_absolute: false, span: 16..19 }), span: 1..20 }, Constraint { expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "low", span: 32..35 }], is_absolute: false, span: 32..35 }), rhs: Path(Path { path: [Ident { name: "high", span: 38..42 }], is_absolute: false, span: 38..42 }) }, span: 21..43 }, Let { name: Ident { name: "high", span: 48..52 }, ty: None, init: Some(Immediate(Real(2.0))), span: 44..59 }, Solve { directive: Satisfy, span: 60..74 }, Let { name: Ident { name: "low", span: 79..82 }, ty: None, init: Some(Immediate(Real(1.0))), span: 75..89 }]"#
         ]],
     );
 }
@@ -1472,7 +1495,7 @@ fn test_parse_str_to_ast() {
     check(
         &format!("{:?}", parse_str_to_ast("let x = 5;", "my_file")),
         expect_test::expect![[
-            r#"Ok([Let { name: "x", ty: None, init: Some(Immediate(Int(5))), span: 0..10 }])"#
+            r#"Ok([Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Immediate(Int(5))), span: 0..10 }])"#
         ]],
     );
     check(
@@ -1493,7 +1516,7 @@ fn big_ints() {
             "let blah = 1234567890123456789012345678901234567890;"
         ),
         expect_test::expect![[
-            r#"Let { name: "blah", ty: None, init: Some(Immediate(BigInt(1234567890123456789012345678901234567890))), span: 0..52 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate(BigInt(1234567890123456789012345678901234567890))), span: 0..52 }"#
         ]],
     );
     check(
@@ -1503,7 +1526,7 @@ fn big_ints() {
         ),
         // Confirmed by using the Python REPL to convert from hex to dec...
         expect_test::expect![[
-            r#"Let { name: "blah", ty: None, init: Some(Immediate(BigInt(5421732407698601623698172315373246806734))), span: 0..47 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate(BigInt(5421732407698601623698172315373246806734))), span: 0..47 }"#
         ]],
     );
     check(
@@ -1532,14 +1555,14 @@ interface Foo {
     check(
         &run_parser!(interface_decl(expr()), src),
         expect_test::expect![[
-            r#"Interface(InterfaceDecl { name: "Foo", functions: [FnSig { name: "foo", params: [("x", Real), ("y", Array { ty: Int, range: Immediate(Int(5)) })], return_type: Real, span: 21..55 }, FnSig { name: "bar", params: [("x", Bool)], return_type: Real, span: 61..85 }, FnSig { name: "baz", params: [], return_type: Tuple([(None, Int), (None, Real)]), span: 91..116 }], name_span: 11..14 })"#
+            r#"Interface(InterfaceDecl { name: Ident { name: "Foo", span: 11..14 }, functions: [FnSig { name: Ident { name: "foo", span: 24..27 }, params: [(Ident { name: "x", span: 28..29 }, Real), (Ident { name: "y", span: 37..38 }, Array { ty: Int, range: Immediate(Int(5)) })], return_type: Real, span: 21..55 }, FnSig { name: Ident { name: "bar", span: 64..67 }, params: [(Ident { name: "x", span: 68..69 }, Bool)], return_type: Real, span: 61..85 }, FnSig { name: Ident { name: "baz", span: 94..97 }, params: [], return_type: Tuple([(None, Int), (None, Real)]), span: 91..116 }], span: 1..119 })"#
         ]],
     );
 
     check(
         &run_parser!(interface_decl(expr()), "interface Foo {}"),
         expect_test::expect![[
-            r#"Interface(InterfaceDecl { name: "Foo", functions: [], name_span: 10..13 })"#
+            r#"Interface(InterfaceDecl { name: Ident { name: "Foo", span: 10..13 }, functions: [], span: 0..16 })"#
         ]],
     );
 }
@@ -1549,7 +1572,7 @@ fn contract_test() {
     check(
         &run_parser!(contract_decl(expr()), "contract Foo(0) {}"),
         expect_test::expect![[
-            r#"Contract(ContractDecl { name: "Foo", id: Immediate(Int(0)), interfaces: [], functions: [], name_span: 9..12 })"#
+            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: Immediate(Int(0)), interfaces: [], functions: [], span: 0..18 })"#
         ]],
     );
 
@@ -1559,7 +1582,7 @@ fn contract_test() {
             "contract Foo(if true {0} else {1}) {}"
         ),
         expect_test::expect![[
-            r#"Contract(ContractDecl { name: "Foo", id: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(0)) }, else_block: Block { statements: [], final_expr: Immediate(Int(1)) } }, interfaces: [], functions: [], name_span: 9..12 })"#
+            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(0)) }, else_block: Block { statements: [], final_expr: Immediate(Int(1)) } }, interfaces: [], functions: [], span: 0..37 })"#
         ]],
     );
 
@@ -1569,7 +1592,7 @@ fn contract_test() {
             "contract Foo(0) implements X::Bar, ::Y::Baz {}"
         ),
         expect_test::expect![[
-            r#"Contract(ContractDecl { name: "Foo", id: Immediate(Int(0)), interfaces: [Ident { path: ["X", "Bar"], is_absolute: false, span: 27..33 }, Ident { path: ["Y", "Baz"], is_absolute: true, span: 35..43 }], functions: [], name_span: 9..12 })"#
+            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: Immediate(Int(0)), interfaces: [Path { path: [Ident { name: "X", span: 27..28 }, Ident { name: "Bar", span: 30..33 }], is_absolute: false, span: 27..33 }, Path { path: [Ident { name: "Y", span: 37..38 }, Ident { name: "Baz", span: 40..43 }], is_absolute: true, span: 35..43 }], functions: [], span: 0..46 })"#
         ]],
     );
 
@@ -1579,7 +1602,7 @@ fn contract_test() {
             "contract Foo(0) implements Bar { fn baz(x: real) -> int; }"
         ),
         expect_test::expect![[
-            r#"Contract(ContractDecl { name: "Foo", id: Immediate(Int(0)), interfaces: [Ident { path: ["Bar"], is_absolute: false, span: 27..30 }], functions: [FnSig { name: "baz", params: [("x", Real)], return_type: Int, span: 33..55 }], name_span: 9..12 })"#
+            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: Immediate(Int(0)), interfaces: [Path { path: [Ident { name: "Bar", span: 27..30 }], is_absolute: false, span: 27..30 }], functions: [FnSig { name: Ident { name: "baz", span: 36..39 }, params: [(Ident { name: "x", span: 40..41 }, Real)], return_type: Int, span: 33..55 }], span: 0..58 })"#
         ]],
     );
 
@@ -1602,12 +1625,12 @@ fn contract_test() {
 fn extern_test() {
     check(
         &run_parser!(extern_decl(expr()), "extern {}"),
-        expect_test::expect!["Extern { functions: [], extern_keyword_span: 0..6 }"],
+        expect_test::expect!["Extern { functions: [], span: 0..9 }"],
     );
     check(
         &run_parser!(extern_decl(expr()), "extern { fn foo() -> string; }"),
         expect_test::expect![[
-            r#"Extern { functions: [FnSig { name: "foo", params: [], return_type: String, span: 9..27 }], extern_keyword_span: 0..6 }"#
+            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: 12..15 }, params: [], return_type: String, span: 9..27 }], span: 0..30 }"#
         ]],
     );
     check(
@@ -1616,7 +1639,7 @@ fn extern_test() {
             "extern { fn foo(x: int, y: real) -> int; }"
         ),
         expect_test::expect![[
-            r#"Extern { functions: [FnSig { name: "foo", params: [("x", Int), ("y", Real)], return_type: Int, span: 9..39 }], extern_keyword_span: 0..6 }"#
+            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: 12..15 }, params: [(Ident { name: "x", span: 16..17 }, Int), (Ident { name: "y", span: 24..25 }, Real)], return_type: Int, span: 9..39 }], span: 0..42 }"#
         ]],
     );
     check(
@@ -1625,7 +1648,7 @@ fn extern_test() {
             "extern { fn foo() -> int; fn bar() -> real; }"
         ),
         expect_test::expect![[
-            r#"Extern { functions: [FnSig { name: "foo", params: [], return_type: Int, span: 9..24 }, FnSig { name: "bar", params: [], return_type: Real, span: 26..42 }], extern_keyword_span: 0..6 }"#
+            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: 12..15 }, params: [], return_type: Int, span: 9..24 }, FnSig { name: Ident { name: "bar", span: 29..32 }, params: [], return_type: Real, span: 26..42 }], span: 0..45 }"#
         ]],
     );
     check(

--- a/yurtc/src/types.rs
+++ b/yurtc/src/types.rs
@@ -1,27 +1,28 @@
+use crate::ast::Ident;
 use crate::error::Span;
 
 #[derive(Clone, Debug, PartialEq)]
-pub(super) enum Type<Ident, Expr> {
+pub(super) enum Type<Path, Expr> {
     Bool,
     Int,
     Real,
     String,
     Array { ty: Box<Self>, range: Expr },
-    Tuple(Vec<(Option<String>, Self)>),
-    CustomType(Ident),
+    Tuple(Vec<(Option<Ident>, Self)>),
+    CustomType(Path),
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct EnumDecl {
-    pub(super) name: String,
-    pub(super) variants: Vec<String>,
-    pub(super) name_span: Span,
+    pub(super) name: Ident,
+    pub(super) variants: Vec<Ident>,
+    pub(super) span: Span,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct FnSig<Type> {
-    pub(super) name: String,
-    pub(super) params: Vec<(String, Type)>,
+    pub(super) name: Ident,
+    pub(super) params: Vec<(Ident, Type)>,
     pub(super) return_type: Type,
     pub(super) span: Span,
 }


### PR DESCRIPTION
Closes #174 
- Change Strings as names to `Ident` structs containing the span
- Change old `Ident` to `Path`: a vector of (new) `Idents` + full span
- Add some missing spans to decls