### PR TITLE
Populate all ast nodes with spans

### DIFF
--- a/yurtc/src/ast.rs
+++ b/yurtc/src/ast.rs
@@ -1,7 +1,7 @@
 use crate::{
     contract::{ContractDecl as CD, InterfaceDecl as ID},
-    error::Span,
     expr::Expr as E,
+    span::{Span, Spanned},
     types::{EnumDecl, FnSig as F, Type as T},
 };
 
@@ -52,19 +52,68 @@ pub(super) enum Decl {
     },
 }
 
+impl Spanned for Decl {
+    fn span(&self) -> &Span {
+        use Decl::*;
+        match &self {
+            Use { span, .. }
+            | Let { span, .. }
+            | State { span, .. }
+            | Constraint { span, .. }
+            | Fn { span, .. }
+            | Solve { span, .. }
+            | Extern { span, .. } => span,
+            Enum(enum_decl) => enum_decl.span(),
+            Interface(interface_decl) => interface_decl.span(),
+            Contract(contract_decl) => contract_decl.span(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(super) enum UseTree {
-    Glob,
-    Name { name: Ident },
-    Path { prefix: Ident, suffix: Box<UseTree> },
-    Group { imports: Vec<UseTree> },
-    Alias { name: Ident, alias: Ident },
+    Glob(Span),
+    Name {
+        name: Ident,
+        span: Span,
+    },
+    Path {
+        prefix: Ident,
+        suffix: Box<UseTree>,
+        span: Span,
+    },
+    Group {
+        imports: Vec<UseTree>,
+        span: Span,
+    },
+    Alias {
+        name: Ident,
+        alias: Ident,
+        span: Span,
+    },
+}
+
+impl Spanned for UseTree {
+    fn span(&self) -> &Span {
+        use UseTree::*;
+        match &self {
+            Glob(span) => span,
+            Name { span, .. } | Path { span, .. } | Group { span, .. } | Alias { span, .. } => span,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct Block {
     pub(super) statements: Vec<Decl>,
     pub(super) final_expr: Box<Expr>,
+    pub(super) span: Span,
+}
+
+impl Spanned for Block {
+    fn span(&self) -> &Span {
+        &self.span
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -73,11 +122,23 @@ pub(super) struct Ident {
     pub(super) span: Span,
 }
 
+impl Spanned for Ident {
+    fn span(&self) -> &Span {
+        &self.span
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct Path {
     pub(super) path: Vec<Ident>,
     pub(super) is_absolute: bool,
     pub(super) span: Span,
+}
+
+impl Spanned for Path {
+    fn span(&self) -> &Span {
+        &self.span
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/yurtc/src/contract.rs
+++ b/yurtc/src/contract.rs
@@ -1,10 +1,20 @@
-use crate::{ast::Ident, error::Span, types::FnSig};
+use crate::{
+    ast::Ident,
+    span::{Span, Spanned},
+    types::FnSig,
+};
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct InterfaceDecl<Type> {
     pub(super) name: Ident,
     pub(super) functions: Vec<FnSig<Type>>,
     pub(super) span: Span,
+}
+
+impl<Type> Spanned for InterfaceDecl<Type> {
+    fn span(&self) -> &Span {
+        &self.span
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -14,4 +24,10 @@ pub(super) struct ContractDecl<Path, Expr, Type> {
     pub(super) interfaces: Vec<Path>,
     pub(super) functions: Vec<FnSig<Type>>,
     pub(super) span: Span,
+}
+
+impl<Path, Expr, Type> Spanned for ContractDecl<Path, Expr, Type> {
+    fn span(&self) -> &Span {
+        &self.span
+    }
 }

--- a/yurtc/src/error.rs
+++ b/yurtc/src/error.rs
@@ -1,12 +1,10 @@
-use crate::lexer::Token;
+use crate::{
+    lexer::Token,
+    span::{Span, Spanned},
+};
 use ariadne::{Color, Fmt, Label, Report, ReportKind, Source};
 use chumsky::prelude::*;
 use thiserror::Error;
-
-pub(super) type Span = std::ops::Range<usize>;
-pub(super) fn empty_span() -> Span {
-    0..0
-}
 
 /// An error originating from the lexer
 #[derive(Error, Debug, Clone, PartialEq, Default)]
@@ -136,24 +134,24 @@ pub(super) enum Error<'a> {
     Compile { error: CompileError },
 }
 
-impl<'a> Error<'a> {
-    pub(super) fn span(&self) -> Span {
+impl<'a> Spanned for Error<'a> {
+    fn span(&self) -> &Span {
         use Error::*;
         match self {
-            Lex { span, .. } => span.clone(),
+            Lex { span, .. } => span,
             Parse { error } => match error {
-                ParseError::ExpectedFound { span, .. } => span.clone(),
-                ParseError::KeywordAsIdent { span, .. } => span.clone(),
-                ParseError::UntypedVariable { span, .. } => span.clone(),
-                ParseError::EmptyArrayExpr { span } => span.clone(),
-                ParseError::InvalidIntegerTupleIndex { span, .. } => span.clone(),
-                ParseError::InvalidTupleIndex { span, .. } => span.clone(),
-                ParseError::EmptyTupleExpr { span } => span.clone(),
-                ParseError::EmptyTupleType { span } => span.clone(),
+                ParseError::ExpectedFound { span, .. } => span,
+                ParseError::KeywordAsIdent { span, .. } => span,
+                ParseError::UntypedVariable { span, .. } => span,
+                ParseError::EmptyArrayExpr { span } => span,
+                ParseError::InvalidIntegerTupleIndex { span, .. } => span,
+                ParseError::InvalidTupleIndex { span, .. } => span,
+                ParseError::EmptyTupleExpr { span } => span,
+                ParseError::EmptyTupleType { span } => span,
             },
             Compile { error } => match error {
-                CompileError::Internal { span, .. } => span.clone(),
-                CompileError::NameClash { span, .. } => span.clone(),
+                CompileError::Internal { span, .. } => span,
+                CompileError::NameClash { span, .. } => span,
             },
         }
     }

--- a/yurtc/src/expr.rs
+++ b/yurtc/src/expr.rs
@@ -1,50 +1,97 @@
-use crate::ast::Ident;
+use crate::{
+    ast::Ident,
+    span::{Span, Spanned},
+};
 
 #[derive(Clone, Debug, PartialEq)]
 pub(super) enum Expr<Path, BlockExpr> {
-    Immediate(Immediate),
+    Immediate {
+        value: Immediate,
+        span: Span,
+    },
     Path(Path),
     UnaryOp {
         op: UnaryOp,
         expr: Box<Self>,
+        span: Span,
     },
     BinaryOp {
         op: BinaryOp,
         lhs: Box<Self>,
         rhs: Box<Self>,
+        span: Span,
     },
     Call {
         name: Path,
         args: Vec<Self>,
+        span: Span,
     },
     Block(BlockExpr),
     If {
         condition: Box<Self>,
         then_block: BlockExpr,
         else_block: BlockExpr,
+        span: Span,
     },
     Cond {
         branches: Vec<CondBranch<Self>>,
         else_result: Box<Self>,
+        span: Span,
     },
-    Array(Vec<Self>),
+    Array {
+        elements: Vec<Self>,
+        span: Span,
+    },
     ArrayElementAccess {
         array: Box<Self>,
         index: Box<Self>,
+        span: Span,
     },
-    Tuple(Vec<(Option<Ident>, Self)>),
+    Tuple {
+        fields: Vec<(Option<Ident>, Self)>,
+        span: Span,
+    },
     TupleFieldAccess {
         tuple: Box<Self>,
         field: itertools::Either<usize, Ident>,
+        span: Span,
     },
     Cast {
         value: Box<Self>,
         ty: Box<super::types::Type<Path, Self>>,
+        span: Span,
     },
     In {
         value: Box<Self>,
         collection: Box<Self>,
+        span: Span,
     },
+}
+
+impl<Path, BlockExpr> Spanned for Expr<Path, BlockExpr>
+where
+    Path: Spanned,
+    BlockExpr: Spanned,
+{
+    fn span(&self) -> &Span {
+        use Expr::*;
+        match &self {
+            Immediate { span, .. }
+            | UnaryOp { span, .. }
+            | BinaryOp { span, .. }
+            | Call { span, .. }
+            | If { span, .. }
+            | Cond { span, .. }
+            | Array { span, .. }
+            | ArrayElementAccess { span, .. }
+            | Tuple { span, .. }
+            | TupleFieldAccess { span, .. }
+            | Cast { span, .. }
+            | In { span, .. } => span,
+            Path(path) => path.span(),
+            Block(block) => block.span(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -60,6 +107,13 @@ pub enum Immediate {
 pub(super) struct CondBranch<E> {
     pub(super) condition: Box<E>,
     pub(super) result: Box<E>,
+    pub(super) span: Span,
+}
+
+impl<E> Spanned for CondBranch<E> {
+    fn span(&self) -> &Span {
+        &self.span
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/yurtc/src/intent/intermediate.rs
+++ b/yurtc/src/intent/intermediate.rs
@@ -1,9 +1,10 @@
 use crate::{
     ast,
     contract::{ContractDecl as CD, InterfaceDecl as ID},
-    error::{CompileError, Span},
+    error::CompileError,
     expr::Expr as E,
     intent::{Intent, Path, Solve},
+    span::Span,
     types::{EnumDecl, FnSig as F, Type as T},
 };
 
@@ -81,13 +82,17 @@ use crate::expr;
 
 #[test]
 fn single_let() {
+    use crate::types::{PrimitiveKind::*, Type};
     let ast = vec![ast::Decl::Let {
         // `let foo: real;`
         name: ast::Ident {
             name: "foo".to_owned(),
             span: 4..7,
         },
-        ty: Some(ast::Type::Real),
+        ty: Some(Type::Primitive {
+            kind: Real,
+            span: 9..13,
+        }),
         init: None,
         span: 0..14,
     }];
@@ -97,6 +102,7 @@ fn single_let() {
 
 #[test]
 fn double_let_clash() {
+    use crate::types::{PrimitiveKind::*, Type};
     let ast = vec![
         ast::Decl::Let {
             // `let foo: real;`
@@ -104,7 +110,10 @@ fn double_let_clash() {
                 name: "foo".to_owned(),
                 span: 4..7,
             },
-            ty: Some(ast::Type::Real),
+            ty: Some(Type::Primitive {
+                kind: Real,
+                span: 9..13,
+            }),
             init: None,
             span: 0..14,
         },
@@ -114,7 +123,10 @@ fn double_let_clash() {
                 name: "foo".to_owned(),
                 span: 19..22,
             },
-            ty: Some(ast::Type::Real),
+            ty: Some(Type::Primitive {
+                kind: Real,
+                span: 24..28,
+            }),
             init: None,
             span: 15..29,
         },
@@ -134,6 +146,7 @@ fn double_let_clash() {
 
 #[test]
 fn let_fn_clash() {
+    use crate::types::{PrimitiveKind::*, Type};
     let ast = vec![
         ast::Decl::Let {
             // `let bar: real;`
@@ -141,7 +154,10 @@ fn let_fn_clash() {
                 name: "bar".to_owned(),
                 span: 4..7,
             },
-            ty: Some(ast::Type::Real),
+            ty: Some(Type::Primitive {
+                kind: Real,
+                span: 9..13,
+            }),
             init: None,
             span: 0..14,
         },
@@ -153,12 +169,19 @@ fn let_fn_clash() {
                     span: 18..21,
                 },
                 params: Vec::new(),
-                return_type: ast::Type::Bool,
+                return_type: Type::Primitive {
+                    kind: Bool,
+                    span: 27..31,
+                },
                 span: 15..31,
             },
             body: ast::Block {
                 statements: Vec::new(),
-                final_expr: Box::new(ast::Expr::Immediate(expr::Immediate::Bool(false))),
+                final_expr: Box::new(ast::Expr::Immediate {
+                    value: expr::Immediate::Bool(false),
+                    span: 34..39,
+                }),
+                span: 15..41,
             },
             span: 15..41,
         },

--- a/yurtc/src/intent/intermediate/from_ast.rs
+++ b/yurtc/src/intent/intermediate/from_ast.rs
@@ -1,8 +1,9 @@
 use crate::{
     ast, contract,
-    error::{CompileError, Span},
+    error::CompileError,
     expr,
     intent::{Path, Solve},
+    span::Span,
     types,
 };
 
@@ -32,9 +33,14 @@ pub(super) fn from_ast(ast: &[ast::Decl]) -> super::Result<IntermediateIntent> {
                 });
             }
 
-            ast::Decl::Let { name, ty, init, .. } => {
+            ast::Decl::Let {
+                name,
+                ty,
+                init,
+                span,
+            } => {
                 expr_ctx.check_unique_symbol(name)?;
-                expr_ctx.unpack_let_decl(name, ty, init)?;
+                expr_ctx.unpack_let_decl(name, ty, init, span)?;
             }
 
             ast::Decl::State { name, ty, init, .. } => {
@@ -51,7 +57,7 @@ pub(super) fn from_ast(ast: &[ast::Decl]) -> super::Result<IntermediateIntent> {
                 expr_ctx.constraints.push((expr, span.clone()));
             }
 
-            ast::Decl::Fn { fn_sig, body, .. } => {
+            ast::Decl::Fn { fn_sig, body, span } => {
                 expr_ctx.check_unique_symbol(&fn_sig.name)?;
 
                 let mut local_expr_ctx = ExprContext::default();
@@ -64,15 +70,15 @@ pub(super) fn from_ast(ast: &[ast::Decl]) -> super::Result<IntermediateIntent> {
                         local_constraints: local_expr_ctx.constraints,
                         returned_constraint,
                     },
-                    fn_sig.span.clone(),
+                    span.clone(),
                 ))
             }
 
             ast::Decl::Solve { directive, span } => {
                 let what = match directive {
                     ast::SolveFunc::Satisfy => Solve::Satisfy,
-                    ast::SolveFunc::Minimize(id) => Solve::Minimize(convert_ident(id)?),
-                    ast::SolveFunc::Maximize(id) => Solve::Maximize(convert_ident(id)?),
+                    ast::SolveFunc::Minimize(id) => Solve::Minimize(convert_path(id)?),
+                    ast::SolveFunc::Maximize(id) => Solve::Maximize(convert_path(id)?),
                 };
                 directives.push((what, span.clone()));
             }
@@ -134,82 +140,121 @@ impl ExprContext {
 
     fn convert_expr(&mut self, ast_expr: &ast::Expr) -> super::Result<Expr> {
         Ok(match ast_expr {
-            ast::Expr::Immediate(imm) => Expr::Immediate(imm.clone()),
-            ast::Expr::Path(id) => Expr::Path(convert_ident(id)?),
-            ast::Expr::UnaryOp { op, expr } => Expr::UnaryOp {
+            ast::Expr::Immediate { value, span } => Expr::Immediate {
+                value: value.clone(),
+                span: span.clone(),
+            },
+            ast::Expr::Path(path) => Expr::Path(convert_path(path)?),
+            ast::Expr::UnaryOp { op, expr, span } => Expr::UnaryOp {
                 op: op.clone(),
                 expr: Box::new(self.convert_expr(expr)?),
+                span: span.clone(),
             },
-            ast::Expr::BinaryOp { op, lhs, rhs } => Expr::BinaryOp {
+            ast::Expr::BinaryOp { op, lhs, rhs, span } => Expr::BinaryOp {
                 op: op.clone(),
                 lhs: Box::new(self.convert_expr(lhs)?),
                 rhs: Box::new(self.convert_expr(rhs)?),
+                span: span.clone(),
             },
-            ast::Expr::Call { name, args } => Expr::Call {
-                name: convert_ident(name)?,
+            ast::Expr::Call { name, args, span } => Expr::Call {
+                name: convert_path(name)?,
                 args: convert_vec(args, |arg| self.convert_expr(arg))?,
+                span: span.clone(),
             },
             ast::Expr::Block(block) => self.convert_block(block)?,
             ast::Expr::If {
                 condition,
                 then_block,
                 else_block,
+                span,
             } => Expr::If {
                 condition: Box::new(self.convert_expr(condition)?),
                 then_block: Block(Box::new(self.convert_block(then_block)?)),
                 else_block: Block(Box::new(self.convert_block(else_block)?)),
+                span: span.clone(),
             },
             ast::Expr::Cond {
                 branches,
                 else_result,
+                span,
             } => Expr::Cond {
-                branches: convert_vec(branches, |expr::CondBranch { condition, result }| {
-                    self.convert_expr(condition).and_then(|condition| {
-                        self.convert_expr(result).map(|result| expr::CondBranch {
-                            condition: Box::new(condition),
-                            result: Box::new(result),
+                branches: convert_vec(
+                    branches,
+                    |expr::CondBranch {
+                         condition,
+                         result,
+                         span,
+                     }| {
+                        self.convert_expr(condition).and_then(|condition| {
+                            self.convert_expr(result).map(|result| expr::CondBranch {
+                                condition: Box::new(condition),
+                                result: Box::new(result),
+                                span: span.clone(),
+                            })
                         })
-                    })
-                })?,
+                    },
+                )?,
                 else_result: Box::new(self.convert_expr(else_result)?),
+                span: span.clone(),
             },
-            ast::Expr::Array(els) => Expr::Array(convert_vec(els, |el| self.convert_expr(el))?),
-            ast::Expr::ArrayElementAccess { array, index } => Expr::ArrayElementAccess {
+            ast::Expr::Array { elements, span } => Expr::Array {
+                elements: convert_vec(elements, |element| self.convert_expr(element))?,
+                span: span.clone(),
+            },
+            ast::Expr::ArrayElementAccess { array, index, span } => Expr::ArrayElementAccess {
                 array: Box::new(self.convert_expr(array)?),
                 index: Box::new(self.convert_expr(index)?),
+                span: span.clone(),
             },
-            ast::Expr::Tuple(fields) => Expr::Tuple(convert_vec(fields, |(name, expr)| {
-                self.convert_expr(expr).map(|expr| (name.clone(), expr))
-            })?),
-            ast::Expr::TupleFieldAccess { tuple, field } => Expr::TupleFieldAccess {
+            ast::Expr::Tuple { fields, span } => Expr::Tuple {
+                fields: convert_vec(fields, |(name, expr)| {
+                    self.convert_expr(expr).map(|expr| (name.clone(), expr))
+                })?,
+                span: span.clone(),
+            },
+            ast::Expr::TupleFieldAccess { tuple, field, span } => Expr::TupleFieldAccess {
                 tuple: Box::new(self.convert_expr(tuple)?),
                 field: field.clone(),
+                span: span.clone(),
             },
-            ast::Expr::Cast { value, ty } => Expr::Cast {
+            ast::Expr::Cast { value, ty, span } => Expr::Cast {
                 value: Box::new(self.convert_expr(value)?),
                 ty: Box::new(self.convert_type(ty)?),
+                span: span.clone(),
             },
-            ast::Expr::In { value, collection } => Expr::In {
+            ast::Expr::In {
+                value,
+                collection,
+                span,
+            } => Expr::In {
                 value: Box::new(self.convert_expr(value)?),
                 collection: Box::new(self.convert_expr(collection)?),
+                span: span.clone(),
             },
         })
     }
 
     fn convert_type(&mut self, ast_ty: &ast::Type) -> super::Result<Type> {
         Ok(match ast_ty {
-            ast::Type::Bool => Type::Bool,
-            ast::Type::Int => Type::Int,
-            ast::Type::Real => Type::Real,
-            ast::Type::String => Type::String,
-            ast::Type::Array { ty, range } => Type::Array {
+            ast::Type::Primitive { kind, span } => Type::Primitive {
+                kind: kind.clone(),
+                span: span.clone(),
+            },
+            ast::Type::Array { ty, range, span } => Type::Array {
                 ty: Box::new(self.convert_type(ty)?),
                 range: self.convert_expr(range)?,
+                span: span.clone(),
             },
-            ast::Type::Tuple(fields) => Type::Tuple(convert_vec(fields, |(name, ast_ty)| {
-                self.convert_type(ast_ty).map(|ty| (name.clone(), ty))
-            })?),
-            ast::Type::CustomType(name) => Type::CustomType(convert_ident(name)?),
+            ast::Type::Tuple { fields, span } => Type::Tuple {
+                fields: convert_vec(fields, |(name, ast_ty)| {
+                    self.convert_type(ast_ty).map(|ty| (name.clone(), ty))
+                })?,
+                span: span.clone(),
+            },
+            ast::Type::CustomType { path, span } => Type::CustomType {
+                path: convert_path(path)?,
+                span: span.clone(),
+            },
         })
     }
 
@@ -235,6 +280,7 @@ impl ExprContext {
         let ast::Block {
             statements,
             final_expr,
+            ..
         } = block;
 
         for statement in statements {
@@ -243,9 +289,14 @@ impl ExprContext {
                     self.check_unique_symbol(name)?;
                     self.convert_state(name, ty, init)?;
                 }
-                ast::Decl::Let { name, ty, init, .. } => {
+                ast::Decl::Let {
+                    name,
+                    ty,
+                    init,
+                    span,
+                } => {
                     self.check_unique_symbol(name)?;
-                    self.unpack_let_decl(name, ty, init)?;
+                    self.unpack_let_decl(name, ty, init, span)?;
                 }
                 ast::Decl::Constraint { expr, span } => {
                     let constraint = self.convert_expr(expr)?;
@@ -254,10 +305,7 @@ impl ExprContext {
 
                 // None of the following are allowed in code blocks, only the top-level scope.
                 ast::Decl::Use { span, .. }
-                | ast::Decl::Fn {
-                    fn_sig: ast::FnSig { span, .. },
-                    ..
-                }
+                | ast::Decl::Fn { span, .. }
                 | ast::Decl::Solve { span, .. }
                 | ast::Decl::Enum(types::EnumDecl { span, .. })
                 | ast::Decl::Interface(contract::InterfaceDecl { span, .. })
@@ -306,7 +354,7 @@ impl ExprContext {
         Ok(ContractDecl {
             name: name.clone(),
             id: self.convert_expr(id)?,
-            interfaces: convert_vec(interfaces, convert_ident)?,
+            interfaces: convert_vec(interfaces, convert_path)?,
             functions: convert_vec(functions, |sig| self.convert_fn_sig(sig))?,
             span: span.clone(),
         })
@@ -337,6 +385,7 @@ impl ExprContext {
         name: &ast::Ident,
         ty: &Option<ast::Type>,
         init: &Option<ast::Expr>,
+        span: &Span,
     ) -> super::Result<()> {
         let ty = ty.as_ref().map(|ty| self.convert_type(ty)).transpose()?;
         self.vars.push((
@@ -352,6 +401,7 @@ impl ExprContext {
                 op: expr::BinaryOp::Equal,
                 lhs: Box::new(Expr::Path(name.name.to_owned())),
                 rhs: Box::new(self.convert_expr(init)?),
+                span: span.clone(), // Using the span of the `let` decl here
             };
             self.constraints.push((eq_expr, name.span.clone()));
         };
@@ -360,17 +410,17 @@ impl ExprContext {
     }
 }
 
-fn convert_ident(ast_id: &ast::Path) -> super::Result<Path> {
+fn convert_path(path: &ast::Path) -> super::Result<Path> {
     // NOTE: for now we're only supporting a single main module, so the path MUST be a single
     // element and we're assuming is_absolute.  After we have the module system implemented then
     // all symbols will be canonicalised and an ast::Path will just be a string.
-    if ast_id.path.len() != 1 {
+    if path.path.len() != 1 {
         return Err(CompileError::Internal {
-            span: ast_id.span.clone(),
+            span: path.span.clone(),
             msg: "Multi-path identifiers are not supported yet.",
         });
     }
-    Ok(ast_id.path[0].name.clone())
+    Ok(path.path[0].name.clone())
 }
 
 // We're converting vectors by mapping other conversions over their elements.  This little utility

--- a/yurtc/src/lexer.rs
+++ b/yurtc/src/lexer.rs
@@ -1,4 +1,7 @@
-use crate::error::{Error, LexError, Span};
+use crate::{
+    error::{Error, LexError},
+    span::Span,
+};
 use itertools::{Either, Itertools};
 use logos::Logos;
 use std::fmt;

--- a/yurtc/src/main.rs
+++ b/yurtc/src/main.rs
@@ -7,6 +7,7 @@ mod expr;
 pub mod intent;
 mod lexer;
 mod parser;
+mod span;
 mod types;
 
 fn main() -> anyhow::Result<()> {

--- a/yurtc/src/parser/tests.rs
+++ b/yurtc/src/parser/tests.rs
@@ -20,7 +20,8 @@ macro_rules! run_parser {
                     let span = Error::Parse {
                         error: error.clone(),
                     }
-                    .span();
+                    .span()
+                    .clone();
                     format!("{}@{}..{}: {}\n", acc, span.start, span.end(), error)
                 })
             ),
@@ -37,34 +38,33 @@ fn check(actual: &str, expect: expect_test::Expect) {
 fn types() {
     check(
         &run_parser!(type_(expr()), "int"),
-        expect_test::expect!["Int"],
+        expect_test::expect!["Primitive { kind: Int, span: 0..3 }"],
     );
     check(
         &run_parser!(type_(expr()), "real"),
-        expect_test::expect!["Real"],
+        expect_test::expect!["Primitive { kind: Real, span: 0..4 }"],
     );
     check(
         &run_parser!(type_(expr()), "bool"),
-        expect_test::expect!["Bool"],
+        expect_test::expect!["Primitive { kind: Bool, span: 0..4 }"],
     );
     check(
         &run_parser!(type_(expr()), "string"),
-        expect_test::expect!["String"],
+        expect_test::expect!["Primitive { kind: String, span: 0..6 }"],
     );
     check(
         &run_parser!(type_(expr()), "{int, real, string}"),
-        expect_test::expect!["Tuple([(None, Int), (None, Real), (None, String)])"],
+        expect_test::expect!["Tuple { fields: [(None, Primitive { kind: Int, span: 1..4 }), (None, Primitive { kind: Real, span: 6..10 }), (None, Primitive { kind: String, span: 12..18 })], span: 0..19 }"],
     );
     check(
         &run_parser!(type_(expr()), "{int, {real, int}, string}"),
-        expect_test::expect![
-            "Tuple([(None, Int), (None, Tuple([(None, Real), (None, Int)])), (None, String)])"
+        expect_test::expect!["Tuple { fields: [(None, Primitive { kind: Int, span: 1..4 }), (None, Tuple { fields: [(None, Primitive { kind: Real, span: 7..11 }), (None, Primitive { kind: Int, span: 13..16 })], span: 6..17 }), (None, Primitive { kind: String, span: 19..25 })], span: 0..26 }"
         ],
     );
     check(
         &run_parser!(type_(expr()), "custom_type"),
         expect_test::expect![[
-            r#"CustomType(Path { path: [Ident { name: "custom_type", span: 0..11 }], is_absolute: false, span: 0..11 })"#
+            r#"CustomType { path: Path { path: [Ident { name: "custom_type", span: 0..11 }], is_absolute: false, span: 0..11 }, span: 0..11 }"#
         ]],
     );
 }
@@ -105,53 +105,53 @@ fn immediates() {
 fn use_statements() {
     check(
         &run_parser!(yurt_program(), "use *; use ::*;"),
-        expect_test::expect!["[Use { is_absolute: false, use_tree: Glob, span: 0..6 }, Use { is_absolute: true, use_tree: Glob, span: 7..15 }]"],
+        expect_test::expect!["[Use { is_absolute: false, use_tree: Glob(4..5), span: 0..6 }, Use { is_absolute: true, use_tree: Glob(13..14), span: 7..15 }]"],
     );
 
     check(
         &run_parser!(yurt_program(), "use {}; use ::{};"),
-        expect_test::expect!["[Use { is_absolute: false, use_tree: Group { imports: [] }, span: 0..7 }, Use { is_absolute: true, use_tree: Group { imports: [] }, span: 8..17 }]"],
+        expect_test::expect!["[Use { is_absolute: false, use_tree: Group { imports: [], span: 4..6 }, span: 0..7 }, Use { is_absolute: true, use_tree: Group { imports: [], span: 14..16 }, span: 8..17 }]"],
     );
 
     check(
         &run_parser!(yurt_program(), "use a; use ::a; use ::a as b;"),
         expect_test::expect![[
-            r#"[Use { is_absolute: false, use_tree: Name { name: Ident { name: "a", span: 4..5 } }, span: 0..6 }, Use { is_absolute: true, use_tree: Name { name: Ident { name: "a", span: 13..14 } }, span: 7..15 }, Use { is_absolute: true, use_tree: Alias { name: Ident { name: "a", span: 22..23 }, alias: Ident { name: "b", span: 27..28 } }, span: 16..29 }]"#
+            r#"[Use { is_absolute: false, use_tree: Name { name: Ident { name: "a", span: 4..5 }, span: 4..5 }, span: 0..6 }, Use { is_absolute: true, use_tree: Name { name: Ident { name: "a", span: 13..14 }, span: 13..14 }, span: 7..15 }, Use { is_absolute: true, use_tree: Alias { name: Ident { name: "a", span: 22..23 }, alias: Ident { name: "b", span: 27..28 }, span: 22..28 }, span: 16..29 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use a::b; use ::a::b; use ::a::b as c;"),
         expect_test::expect![[
-            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: 4..5 }, suffix: Name { name: Ident { name: "b", span: 7..8 } } }, span: 0..9 }, Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 16..17 }, suffix: Name { name: Ident { name: "b", span: 19..20 } } }, span: 10..21 }, Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 28..29 }, suffix: Alias { name: Ident { name: "b", span: 31..32 }, alias: Ident { name: "c", span: 36..37 } } }, span: 22..38 }]"#
+            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: 4..5 }, suffix: Name { name: Ident { name: "b", span: 7..8 }, span: 7..8 }, span: 4..8 }, span: 0..9 }, Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 16..17 }, suffix: Name { name: Ident { name: "b", span: 19..20 }, span: 19..20 }, span: 16..20 }, span: 10..21 }, Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 28..29 }, suffix: Alias { name: Ident { name: "b", span: 31..32 }, alias: Ident { name: "c", span: 36..37 }, span: 31..37 }, span: 28..37 }, span: 22..38 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use a::{b, c as d};"),
         expect_test::expect![[
-            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: 4..5 }, suffix: Group { imports: [Name { name: Ident { name: "b", span: 8..9 } }, Alias { name: Ident { name: "c", span: 11..12 }, alias: Ident { name: "d", span: 16..17 } }] } }, span: 0..19 }]"#
+            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: 4..5 }, suffix: Group { imports: [Name { name: Ident { name: "b", span: 8..9 }, span: 8..9 }, Alias { name: Ident { name: "c", span: 11..12 }, alias: Ident { name: "d", span: 16..17 }, span: 11..17 }], span: 7..18 }, span: 4..18 }, span: 0..19 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use ::a::{*, c as d};"),
         expect_test::expect![[
-            r#"[Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 6..7 }, suffix: Group { imports: [Glob, Alias { name: Ident { name: "c", span: 13..14 }, alias: Ident { name: "d", span: 18..19 } }] } }, span: 0..21 }]"#
+            r#"[Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 6..7 }, suffix: Group { imports: [Glob(10..11), Alias { name: Ident { name: "c", span: 13..14 }, alias: Ident { name: "d", span: 18..19 }, span: 13..19 }], span: 9..20 }, span: 6..20 }, span: 0..21 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use ::a::{*, c as d};"),
         expect_test::expect![[
-            r#"[Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 6..7 }, suffix: Group { imports: [Glob, Alias { name: Ident { name: "c", span: 13..14 }, alias: Ident { name: "d", span: 18..19 } }] } }, span: 0..21 }]"#
+            r#"[Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 6..7 }, suffix: Group { imports: [Glob(10..11), Alias { name: Ident { name: "c", span: 13..14 }, alias: Ident { name: "d", span: 18..19 }, span: 13..19 }], span: 9..20 }, span: 6..20 }, span: 0..21 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use a::{{*}, {c as d, { e as f, * }}};"),
         expect_test::expect![[
-            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: 4..5 }, suffix: Group { imports: [Group { imports: [Glob] }, Group { imports: [Alias { name: Ident { name: "c", span: 14..15 }, alias: Ident { name: "d", span: 19..20 } }, Group { imports: [Alias { name: Ident { name: "e", span: 24..25 }, alias: Ident { name: "f", span: 29..30 } }, Glob] }] }] } }, span: 0..38 }]"#
+            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: 4..5 }, suffix: Group { imports: [Group { imports: [Glob(9..10)], span: 8..11 }, Group { imports: [Alias { name: Ident { name: "c", span: 14..15 }, alias: Ident { name: "d", span: 19..20 }, span: 14..20 }, Group { imports: [Alias { name: Ident { name: "e", span: 24..25 }, alias: Ident { name: "f", span: 29..30 }, span: 24..30 }, Glob(32..33)], span: 22..35 }], span: 13..36 }], span: 7..37 }, span: 4..37 }, span: 0..38 }]"#
         ]],
     );
 
@@ -203,73 +203,73 @@ fn let_decls() {
     check(
         &run_parser!(let_decl(expr()), "let blah = 1.0;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate(Real(1.0))), span: 0..15 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate { value: Real(1.0), span: 11..14 }), span: 0..15 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: real = 1.0;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Real), init: Some(Immediate(Real(1.0))), span: 0..21 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: Real, span: 10..14 }), init: Some(Immediate { value: Real(1.0), span: 17..20 }), span: 0..21 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: real;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Real), init: None, span: 0..15 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: Real, span: 10..14 }), init: None, span: 0..15 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah = 1;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate(Int(1))), span: 0..13 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate { value: Int(1), span: 11..12 }), span: 0..13 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: int = 1;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Int), init: Some(Immediate(Int(1))), span: 0..18 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: Int, span: 10..13 }), init: Some(Immediate { value: Int(1), span: 16..17 }), span: 0..18 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: int;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Int), init: None, span: 0..14 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: Int, span: 10..13 }), init: None, span: 0..14 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah = true;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate(Bool(true))), span: 0..16 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate { value: Bool(true), span: 11..15 }), span: 0..16 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: bool = false;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Bool), init: Some(Immediate(Bool(false))), span: 0..23 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: Bool, span: 10..14 }), init: Some(Immediate { value: Bool(false), span: 17..22 }), span: 0..23 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: bool;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Bool), init: None, span: 0..15 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: Bool, span: 10..14 }), init: None, span: 0..15 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), r#"let blah = "hello";"#),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate(String("hello"))), span: 0..19 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate { value: String("hello"), span: 11..18 }), span: 0..19 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), r#"let blah: string = "hello";"#),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(String), init: Some(Immediate(String("hello"))), span: 0..27 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: String, span: 10..16 }), init: Some(Immediate { value: String("hello"), span: 19..26 }), span: 0..27 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), r#"let blah: string;"#),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(String), init: None, span: 0..17 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: String, span: 10..16 }), init: None, span: 0..17 }"#
         ]],
     );
 }
@@ -316,7 +316,7 @@ fn solve_decls() {
 fn basic_exprs() {
     check(
         &run_parser!(expr(), "123"),
-        expect_test::expect!["Immediate(Int(123))"],
+        expect_test::expect!["Immediate { value: Int(123), span: 0..3 }"],
     );
     check(
         &run_parser!(expr(), "foo"),
@@ -331,79 +331,91 @@ fn unary_op_exprs() {
     check(
         &run_parser!(expr(), "!a"),
         expect_test::expect![[
-            r#"UnaryOp { op: Not, expr: Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 }) }"#
+            r#"UnaryOp { op: Not, expr: Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 }), span: 0..2 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "+a"),
         expect_test::expect![[
-            r#"UnaryOp { op: Pos, expr: Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 }) }"#
+            r#"UnaryOp { op: Pos, expr: Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 }), span: 0..2 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "-a"),
         expect_test::expect![[
-            r#"UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 }) }"#
+            r#"UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 }), span: 0..2 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "+7"),
-        expect_test::expect![[r#"UnaryOp { op: Pos, expr: Immediate(Int(7)) }"#]],
+        expect_test::expect![
+            "UnaryOp { op: Pos, expr: Immediate { value: Int(7), span: 1..2 }, span: 0..2 }"
+        ],
     );
     check(
         &run_parser!(expr(), "+3.4"),
-        expect_test::expect![[r#"UnaryOp { op: Pos, expr: Immediate(Real(3.4)) }"#]],
+        expect_test::expect![
+            "UnaryOp { op: Pos, expr: Immediate { value: Real(3.4), span: 1..4 }, span: 0..4 }"
+        ],
     );
     check(
         &run_parser!(expr(), "+0x456"),
-        expect_test::expect![[r#"UnaryOp { op: Pos, expr: Immediate(Int(1110)) }"#]],
+        expect_test::expect![
+            "UnaryOp { op: Pos, expr: Immediate { value: Int(1110), span: 1..6 }, span: 0..6 }"
+        ],
     );
     check(
         &run_parser!(expr(), "+0b01010101"),
-        expect_test::expect![[r#"UnaryOp { op: Pos, expr: Immediate(Int(85)) }"#]],
+        expect_test::expect![
+            "UnaryOp { op: Pos, expr: Immediate { value: Int(85), span: 1..11 }, span: 0..11 }"
+        ],
     );
     check(
         &run_parser!(
             expr(),
             "+0b1101000000001100101010101010101111111111101010101101010101010101"
         ),
-        expect_test::expect![[
-            r#"UnaryOp { op: Pos, expr: Immediate(BigInt(14991544915315053909)) }"#
-        ]],
+        expect_test::expect!["UnaryOp { op: Pos, expr: Immediate { value: BigInt(14991544915315053909), span: 1..67 }, span: 0..67 }"],
     );
     check(
         &run_parser!(expr(), "-1.0"),
-        expect_test::expect![[r#"UnaryOp { op: Neg, expr: Immediate(Real(1.0)) }"#]],
+        expect_test::expect![
+            "UnaryOp { op: Neg, expr: Immediate { value: Real(1.0), span: 1..4 }, span: 0..4 }"
+        ],
     );
     check(
         &run_parser!(expr(), "-1"),
-        expect_test::expect![[r#"UnaryOp { op: Neg, expr: Immediate(Int(1)) }"#]],
+        expect_test::expect![
+            "UnaryOp { op: Neg, expr: Immediate { value: Int(1), span: 1..2 }, span: 0..2 }"
+        ],
     );
     check(
         &run_parser!(expr(), "-0x133"),
-        expect_test::expect![[r#"UnaryOp { op: Neg, expr: Immediate(Int(307)) }"#]],
+        expect_test::expect![
+            "UnaryOp { op: Neg, expr: Immediate { value: Int(307), span: 1..6 }, span: 0..6 }"
+        ],
     );
     check(
         &run_parser!(expr(), "-0b1101"),
-        expect_test::expect![[r#"UnaryOp { op: Neg, expr: Immediate(Int(13)) }"#]],
+        expect_test::expect![
+            "UnaryOp { op: Neg, expr: Immediate { value: Int(13), span: 1..7 }, span: 0..7 }"
+        ],
     );
     check(
         &run_parser!(
             expr(),
             "-0b1101000000001100101010101010101010101010101010101101010101010101"
         ),
-        expect_test::expect![[
-            r#"UnaryOp { op: Neg, expr: Immediate(BigInt(14991544909594023253)) }"#
-        ]],
+        expect_test::expect!["UnaryOp { op: Neg, expr: Immediate { value: BigInt(14991544909594023253), span: 1..67 }, span: 0..67 }"],
     );
     check(
         &run_parser!(expr(), "! - - !  -+  -1"),
-        expect_test::expect!["UnaryOp { op: Not, expr: UnaryOp { op: Neg, expr: UnaryOp { op: Neg, expr: UnaryOp { op: Not, expr: UnaryOp { op: Neg, expr: UnaryOp { op: Pos, expr: UnaryOp { op: Neg, expr: Immediate(Int(1)) } } } } } } }"],
+        expect_test::expect!["UnaryOp { op: Not, expr: UnaryOp { op: Neg, expr: UnaryOp { op: Neg, expr: UnaryOp { op: Not, expr: UnaryOp { op: Neg, expr: UnaryOp { op: Pos, expr: UnaryOp { op: Neg, expr: Immediate { value: Int(1), span: 14..15 }, span: 13..15 }, span: 10..15 }, span: 9..15 }, span: 6..15 }, span: 4..15 }, span: 2..15 }, span: 0..15 }"],
     );
     check(
         &run_parser!(expr(), "+ {- x} '  '  "),
         expect_test::expect![[
-            r#"UnaryOp { op: Pos, expr: UnaryOp { op: NextState, expr: UnaryOp { op: NextState, expr: Block(Block { statements: [], final_expr: UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "x", span: 5..6 }], is_absolute: false, span: 5..6 }) } }) } } }"#
+            r#"UnaryOp { op: Pos, expr: UnaryOp { op: NextState, expr: UnaryOp { op: NextState, expr: Block(Block { statements: [], final_expr: UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "x", span: 5..6 }], is_absolute: false, span: 5..6 }), span: 3..6 }, span: 2..7 }), span: 2..9 }, span: 2..12 }, span: 0..12 }"#
         ]],
     );
 }
@@ -413,99 +425,99 @@ fn binary_op_exprs() {
     check(
         &run_parser!(expr(), "a * 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a / 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Div, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Div, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a % 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Mod, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Mod, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a + 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a - 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Sub, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Sub, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a+2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 2..5 }, span: 0..5 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a-2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Sub, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Sub, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 2..5 }, span: 0..5 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a < 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a > 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a <= 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThanOrEqual, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: LessThanOrEqual, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 5..8 }, span: 0..8 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a >= 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: GreaterThanOrEqual, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: GreaterThanOrEqual, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 5..8 }, span: 0..8 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a == 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Equal, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: Equal, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 5..8 }, span: 0..8 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a != 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: NotEqual, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate(Real(2.0)) }"#
+            r#"BinaryOp { op: NotEqual, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 5..8 }, span: 0..8 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a && b"),
         expect_test::expect![[
-            r#"BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }) }"#
+            r#"BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }), span: 0..6 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "a || b"),
         expect_test::expect![[
-            r#"BinaryOp { op: LogicalOr, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }) }"#
+            r#"BinaryOp { op: LogicalOr, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }), span: 0..6 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "a || b && c || d && !e"),
         expect_test::expect![[
-            r#"BinaryOp { op: LogicalOr, lhs: BinaryOp { op: LogicalOr, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }), rhs: Path(Path { path: [Ident { name: "c", span: 10..11 }], is_absolute: false, span: 10..11 }) } }, rhs: BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "d", span: 15..16 }], is_absolute: false, span: 15..16 }), rhs: UnaryOp { op: Not, expr: Path(Path { path: [Ident { name: "e", span: 21..22 }], is_absolute: false, span: 21..22 }) } } }"#
+            r#"BinaryOp { op: LogicalOr, lhs: BinaryOp { op: LogicalOr, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }), rhs: Path(Path { path: [Ident { name: "c", span: 10..11 }], is_absolute: false, span: 10..11 }), span: 5..11 }, span: 0..11 }, rhs: BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "d", span: 15..16 }], is_absolute: false, span: 15..16 }), rhs: UnaryOp { op: Not, expr: Path(Path { path: [Ident { name: "e", span: 21..22 }], is_absolute: false, span: 21..22 }), span: 20..22 }, span: 15..22 }, span: 0..22 }"#
         ]],
     );
 }
@@ -515,82 +527,82 @@ fn complex_exprs() {
     check(
         &run_parser!(expr(), "2 * b * 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: Immediate(Int(2)), rhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }) }, rhs: Immediate(Int(3)) }"#
+            r#"BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), span: 0..5 }, rhs: Immediate { value: Int(3), span: 8..9 }, span: 0..9 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 < b * 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: Immediate(Int(2)), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), rhs: Immediate(Int(3)) } }"#
+            r#"BinaryOp { op: LessThan, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), rhs: Immediate { value: Int(3), span: 8..9 }, span: 4..9 }, span: 0..9 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2.0 > b * 3.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: GreaterThan, lhs: Immediate(Real(2.0)), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: 6..7 }], is_absolute: false, span: 6..7 }), rhs: Immediate(Real(3.0)) } }"#
+            r#"BinaryOp { op: GreaterThan, lhs: Immediate { value: Real(2.0), span: 0..3 }, rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: 6..7 }], is_absolute: false, span: 6..7 }), rhs: Immediate { value: Real(3.0), span: 10..13 }, span: 6..13 }, span: 0..13 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2.0 * b < 3.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: Mul, lhs: Immediate(Real(2.0)), rhs: Path(Path { path: [Ident { name: "b", span: 6..7 }], is_absolute: false, span: 6..7 }) }, rhs: Immediate(Real(3.0)) }"#
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: Mul, lhs: Immediate { value: Real(2.0), span: 0..3 }, rhs: Path(Path { path: [Ident { name: "b", span: 6..7 }], is_absolute: false, span: 6..7 }), span: 0..7 }, rhs: Immediate { value: Real(3.0), span: 10..13 }, span: 0..13 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 > b < 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: GreaterThan, lhs: Immediate(Int(2)), rhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }) }, rhs: Immediate(Int(3)) }"#
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: GreaterThan, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), span: 0..5 }, rhs: Immediate { value: Int(3), span: 8..9 }, span: 0..9 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 != b < 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: NotEqual, lhs: Immediate(Int(2)), rhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }) }, rhs: Immediate(Int(3)) }"#
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: NotEqual, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }), span: 0..6 }, rhs: Immediate { value: Int(3), span: 9..10 }, span: 0..10 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 < b != 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: NotEqual, lhs: BinaryOp { op: LessThan, lhs: Immediate(Int(2)), rhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }) }, rhs: Immediate(Int(3)) }"#
+            r#"BinaryOp { op: NotEqual, lhs: BinaryOp { op: LessThan, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), span: 0..5 }, rhs: Immediate { value: Int(3), span: 9..10 }, span: 0..10 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a > b * c < d"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), rhs: Path(Path { path: [Ident { name: "c", span: 8..9 }], is_absolute: false, span: 8..9 }) } }, rhs: Path(Path { path: [Ident { name: "d", span: 12..13 }], is_absolute: false, span: 12..13 }) }"#
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), rhs: Path(Path { path: [Ident { name: "c", span: 8..9 }], is_absolute: false, span: 8..9 }), span: 4..9 }, span: 0..9 }, rhs: Path(Path { path: [Ident { name: "d", span: 12..13 }], is_absolute: false, span: 12..13 }), span: 0..13 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 + 3 * 4"),
-        expect_test::expect!["BinaryOp { op: Add, lhs: Immediate(Int(2)), rhs: BinaryOp { op: Mul, lhs: Immediate(Int(3)), rhs: Immediate(Int(4)) } }"],
+        expect_test::expect!["BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(3), span: 4..5 }, rhs: Immediate { value: Int(4), span: 8..9 }, span: 4..9 }, span: 0..9 }"],
     );
     check(
         &run_parser!(expr(), "10 - 8 / 4"),
-        expect_test::expect!["BinaryOp { op: Sub, lhs: Immediate(Int(10)), rhs: BinaryOp { op: Div, lhs: Immediate(Int(8)), rhs: Immediate(Int(4)) } }"],
+        expect_test::expect!["BinaryOp { op: Sub, lhs: Immediate { value: Int(10), span: 0..2 }, rhs: BinaryOp { op: Div, lhs: Immediate { value: Int(8), span: 5..6 }, rhs: Immediate { value: Int(4), span: 9..10 }, span: 5..10 }, span: 0..10 }"],
     );
     check(
         &run_parser!(expr(), "10 + 8 % 4"),
-        expect_test::expect!["BinaryOp { op: Add, lhs: Immediate(Int(10)), rhs: BinaryOp { op: Mod, lhs: Immediate(Int(8)), rhs: Immediate(Int(4)) } }"],
+        expect_test::expect!["BinaryOp { op: Add, lhs: Immediate { value: Int(10), span: 0..2 }, rhs: BinaryOp { op: Mod, lhs: Immediate { value: Int(8), span: 5..6 }, rhs: Immediate { value: Int(4), span: 9..10 }, span: 5..10 }, span: 0..10 }"],
     );
     check(
         &run_parser!(expr(), "2 + 3 * 4 < 5"),
-        expect_test::expect!["BinaryOp { op: LessThan, lhs: BinaryOp { op: Add, lhs: Immediate(Int(2)), rhs: BinaryOp { op: Mul, lhs: Immediate(Int(3)), rhs: Immediate(Int(4)) } }, rhs: Immediate(Int(5)) }"],
+        expect_test::expect!["BinaryOp { op: LessThan, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(3), span: 4..5 }, rhs: Immediate { value: Int(4), span: 8..9 }, span: 4..9 }, span: 0..9 }, rhs: Immediate { value: Int(5), span: 12..13 }, span: 0..13 }"],
     );
     check(
         &run_parser!(expr(), "2 * 3 / 4 < 5"),
-        expect_test::expect!["BinaryOp { op: LessThan, lhs: BinaryOp { op: Div, lhs: BinaryOp { op: Mul, lhs: Immediate(Int(2)), rhs: Immediate(Int(3)) }, rhs: Immediate(Int(4)) }, rhs: Immediate(Int(5)) }"],
+        expect_test::expect!["BinaryOp { op: LessThan, lhs: BinaryOp { op: Div, lhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: Immediate { value: Int(3), span: 4..5 }, span: 0..5 }, rhs: Immediate { value: Int(4), span: 8..9 }, span: 0..9 }, rhs: Immediate { value: Int(5), span: 12..13 }, span: 0..13 }"],
     );
     check(
         &run_parser!(expr(), "10 - 5 + 3 > 7"),
-        expect_test::expect!["BinaryOp { op: GreaterThan, lhs: BinaryOp { op: Add, lhs: BinaryOp { op: Sub, lhs: Immediate(Int(10)), rhs: Immediate(Int(5)) }, rhs: Immediate(Int(3)) }, rhs: Immediate(Int(7)) }"],
+        expect_test::expect!["BinaryOp { op: GreaterThan, lhs: BinaryOp { op: Add, lhs: BinaryOp { op: Sub, lhs: Immediate { value: Int(10), span: 0..2 }, rhs: Immediate { value: Int(5), span: 5..6 }, span: 0..6 }, rhs: Immediate { value: Int(3), span: 9..10 }, span: 0..10 }, rhs: Immediate { value: Int(7), span: 13..14 }, span: 0..14 }"],
     );
     check(
         &run_parser!(expr(), "10 % 2 * 4 < 3"),
-        expect_test::expect!["BinaryOp { op: LessThan, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Mod, lhs: Immediate(Int(10)), rhs: Immediate(Int(2)) }, rhs: Immediate(Int(4)) }, rhs: Immediate(Int(3)) }"],
+        expect_test::expect!["BinaryOp { op: LessThan, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Mod, lhs: Immediate { value: Int(10), span: 0..2 }, rhs: Immediate { value: Int(2), span: 5..6 }, span: 0..6 }, rhs: Immediate { value: Int(4), span: 9..10 }, span: 0..10 }, rhs: Immediate { value: Int(3), span: 13..14 }, span: 0..14 }"],
     );
     check(
         &run_parser!(expr(), "2 + 3 * 4 - 5 / 2 > 1"),
-        expect_test::expect!["BinaryOp { op: GreaterThan, lhs: BinaryOp { op: Sub, lhs: BinaryOp { op: Add, lhs: Immediate(Int(2)), rhs: BinaryOp { op: Mul, lhs: Immediate(Int(3)), rhs: Immediate(Int(4)) } }, rhs: BinaryOp { op: Div, lhs: Immediate(Int(5)), rhs: Immediate(Int(2)) } }, rhs: Immediate(Int(1)) }"],
+        expect_test::expect!["BinaryOp { op: GreaterThan, lhs: BinaryOp { op: Sub, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(3), span: 4..5 }, rhs: Immediate { value: Int(4), span: 8..9 }, span: 4..9 }, span: 0..9 }, rhs: BinaryOp { op: Div, lhs: Immediate { value: Int(5), span: 12..13 }, rhs: Immediate { value: Int(2), span: 16..17 }, span: 12..17 }, span: 0..17 }, rhs: Immediate { value: Int(1), span: 20..21 }, span: 0..21 }"],
     );
 }
 
@@ -598,73 +610,73 @@ fn complex_exprs() {
 fn parens_exprs() {
     check(
         &run_parser!(expr(), "(1 + 2) * 3"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate(Int(1)), rhs: Immediate(Int(2)) }, rhs: Immediate(Int(3)) }"],
+        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: Immediate { value: Int(2), span: 5..6 }, span: 1..6 }, rhs: Immediate { value: Int(3), span: 10..11 }, span: 1..11 }"],
     );
     check(
         &run_parser!(expr(), "1 * (2 + 3)"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: Immediate(Int(1)), rhs: BinaryOp { op: Add, lhs: Immediate(Int(2)), rhs: Immediate(Int(3)) } }"],
+        expect_test::expect!["BinaryOp { op: Mul, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: 5..6 }, rhs: Immediate { value: Int(3), span: 9..10 }, span: 5..10 }, span: 0..11 }"],
     );
     check(
         &run_parser!(expr(), "(1 + 2) * (3 + 4)"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate(Int(1)), rhs: Immediate(Int(2)) }, rhs: BinaryOp { op: Add, lhs: Immediate(Int(3)), rhs: Immediate(Int(4)) } }"],
+        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: Immediate { value: Int(2), span: 5..6 }, span: 1..6 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(3), span: 11..12 }, rhs: Immediate { value: Int(4), span: 15..16 }, span: 11..16 }, span: 1..17 }"],
     );
     check(
         &run_parser!(expr(), "(1 + (2 * 3)) * 4"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate(Int(1)), rhs: BinaryOp { op: Mul, lhs: Immediate(Int(2)), rhs: Immediate(Int(3)) } }, rhs: Immediate(Int(4)) }"],
+        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(2), span: 6..7 }, rhs: Immediate { value: Int(3), span: 10..11 }, span: 6..11 }, span: 1..12 }, rhs: Immediate { value: Int(4), span: 16..17 }, span: 1..17 }"],
     );
     check(
         &run_parser!(expr(), "(1 * (2 + 3)) * 4"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: Immediate(Int(1)), rhs: BinaryOp { op: Add, lhs: Immediate(Int(2)), rhs: Immediate(Int(3)) } }, rhs: Immediate(Int(4)) }"],
+        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: 6..7 }, rhs: Immediate { value: Int(3), span: 10..11 }, span: 6..11 }, span: 1..12 }, rhs: Immediate { value: Int(4), span: 16..17 }, span: 1..17 }"],
     );
     check(
         &run_parser!(expr(), "((1 + 2) * 3) * 4"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate(Int(1)), rhs: Immediate(Int(2)) }, rhs: Immediate(Int(3)) }, rhs: Immediate(Int(4)) }"],
+        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 2..3 }, rhs: Immediate { value: Int(2), span: 6..7 }, span: 2..7 }, rhs: Immediate { value: Int(3), span: 11..12 }, span: 2..12 }, rhs: Immediate { value: Int(4), span: 16..17 }, span: 2..17 }"],
     );
     check(
         &run_parser!(expr(), "((1 + 2) * (3 + 4)) * 5"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate(Int(1)), rhs: Immediate(Int(2)) }, rhs: BinaryOp { op: Add, lhs: Immediate(Int(3)), rhs: Immediate(Int(4)) } }, rhs: Immediate(Int(5)) }"],
+        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 2..3 }, rhs: Immediate { value: Int(2), span: 6..7 }, span: 2..7 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(3), span: 12..13 }, rhs: Immediate { value: Int(4), span: 16..17 }, span: 12..17 }, span: 2..18 }, rhs: Immediate { value: Int(5), span: 22..23 }, span: 2..23 }"],
     );
     check(
         &run_parser!(expr(), "(1 + 2) * 3 / 4"),
-        expect_test::expect!["BinaryOp { op: Div, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate(Int(1)), rhs: Immediate(Int(2)) }, rhs: Immediate(Int(3)) }, rhs: Immediate(Int(4)) }"],
+        expect_test::expect!["BinaryOp { op: Div, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: Immediate { value: Int(2), span: 5..6 }, span: 1..6 }, rhs: Immediate { value: Int(3), span: 10..11 }, span: 1..11 }, rhs: Immediate { value: Int(4), span: 14..15 }, span: 1..15 }"],
     );
     check(
         &run_parser!(expr(), "1 / (2 + 3) * 4"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Div, lhs: Immediate(Int(1)), rhs: BinaryOp { op: Add, lhs: Immediate(Int(2)), rhs: Immediate(Int(3)) } }, rhs: Immediate(Int(4)) }"],
+        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Div, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: 5..6 }, rhs: Immediate { value: Int(3), span: 9..10 }, span: 5..10 }, span: 0..11 }, rhs: Immediate { value: Int(4), span: 14..15 }, span: 0..15 }"],
     );
     check(
         &run_parser!(expr(), "(1 < 2) && (3 > 4)"),
-        expect_test::expect!["BinaryOp { op: LogicalAnd, lhs: BinaryOp { op: LessThan, lhs: Immediate(Int(1)), rhs: Immediate(Int(2)) }, rhs: BinaryOp { op: GreaterThan, lhs: Immediate(Int(3)), rhs: Immediate(Int(4)) } }"],
+        expect_test::expect!["BinaryOp { op: LogicalAnd, lhs: BinaryOp { op: LessThan, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: Immediate { value: Int(2), span: 5..6 }, span: 1..6 }, rhs: BinaryOp { op: GreaterThan, lhs: Immediate { value: Int(3), span: 12..13 }, rhs: Immediate { value: Int(4), span: 16..17 }, span: 12..17 }, span: 1..18 }"],
     );
     check(
         &run_parser!(expr(), "(1 == 2) || (3 != 4)"),
-        expect_test::expect!["BinaryOp { op: LogicalOr, lhs: BinaryOp { op: Equal, lhs: Immediate(Int(1)), rhs: Immediate(Int(2)) }, rhs: BinaryOp { op: NotEqual, lhs: Immediate(Int(3)), rhs: Immediate(Int(4)) } }"],
+        expect_test::expect!["BinaryOp { op: LogicalOr, lhs: BinaryOp { op: Equal, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: Immediate { value: Int(2), span: 6..7 }, span: 1..7 }, rhs: BinaryOp { op: NotEqual, lhs: Immediate { value: Int(3), span: 13..14 }, rhs: Immediate { value: Int(4), span: 18..19 }, span: 13..19 }, span: 1..20 }"],
     );
     check(
         &run_parser!(expr(), "1 < (2 && 3) > 4"),
-        expect_test::expect!["BinaryOp { op: GreaterThan, lhs: BinaryOp { op: LessThan, lhs: Immediate(Int(1)), rhs: BinaryOp { op: LogicalAnd, lhs: Immediate(Int(2)), rhs: Immediate(Int(3)) } }, rhs: Immediate(Int(4)) }"],
+        expect_test::expect!["BinaryOp { op: GreaterThan, lhs: BinaryOp { op: LessThan, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: BinaryOp { op: LogicalAnd, lhs: Immediate { value: Int(2), span: 5..6 }, rhs: Immediate { value: Int(3), span: 10..11 }, span: 5..11 }, span: 0..12 }, rhs: Immediate { value: Int(4), span: 15..16 }, span: 0..16 }"],
     );
     check(
         &run_parser!(expr(), "1 && (2 || 3)"),
-        expect_test::expect!["BinaryOp { op: LogicalAnd, lhs: Immediate(Int(1)), rhs: BinaryOp { op: LogicalOr, lhs: Immediate(Int(2)), rhs: Immediate(Int(3)) } }"],
+        expect_test::expect!["BinaryOp { op: LogicalAnd, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: BinaryOp { op: LogicalOr, lhs: Immediate { value: Int(2), span: 6..7 }, rhs: Immediate { value: Int(3), span: 11..12 }, span: 6..12 }, span: 0..13 }"],
     );
     check(
         &run_parser!(expr(), "1 == (2 || 3) != 4"),
-        expect_test::expect!["BinaryOp { op: NotEqual, lhs: BinaryOp { op: Equal, lhs: Immediate(Int(1)), rhs: BinaryOp { op: LogicalOr, lhs: Immediate(Int(2)), rhs: Immediate(Int(3)) } }, rhs: Immediate(Int(4)) }"],
+        expect_test::expect!["BinaryOp { op: NotEqual, lhs: BinaryOp { op: Equal, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: BinaryOp { op: LogicalOr, lhs: Immediate { value: Int(2), span: 6..7 }, rhs: Immediate { value: Int(3), span: 11..12 }, span: 6..12 }, span: 0..13 }, rhs: Immediate { value: Int(4), span: 17..18 }, span: 0..18 }"],
     );
     check(
         &run_parser!(expr(), "-(1 + 2)"),
-        expect_test::expect!["UnaryOp { op: Neg, expr: BinaryOp { op: Add, lhs: Immediate(Int(1)), rhs: Immediate(Int(2)) } }"],
+        expect_test::expect!["UnaryOp { op: Neg, expr: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 2..3 }, rhs: Immediate { value: Int(2), span: 6..7 }, span: 2..7 }, span: 0..8 }"],
     );
     check(
         &run_parser!(expr(), "!(a < b)"),
         expect_test::expect![[
-            r#"UnaryOp { op: Not, expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: 2..3 }], is_absolute: false, span: 2..3 }), rhs: Path(Path { path: [Ident { name: "b", span: 6..7 }], is_absolute: false, span: 6..7 }) } }"#
+            r#"UnaryOp { op: Not, expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: 2..3 }], is_absolute: false, span: 2..3 }), rhs: Path(Path { path: [Ident { name: "b", span: 6..7 }], is_absolute: false, span: 6..7 }), span: 2..7 }, span: 0..8 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "(1)"),
-        expect_test::expect!["Immediate(Int(1))"],
+        expect_test::expect!["Immediate { value: Int(1), span: 1..2 }"],
     );
     check(
         &run_parser!(expr(), "(a)"),
@@ -681,13 +693,13 @@ fn parens_exprs() {
     check(
         &run_parser!(expr(), "(if a < b { 1 } else { 2 })"),
         expect_test::expect![[
-            r#"If { condition: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: 4..5 }], is_absolute: false, span: 4..5 }), rhs: Path(Path { path: [Ident { name: "b", span: 8..9 }], is_absolute: false, span: 8..9 }) }, then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }"#
+            r#"If { condition: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: 4..5 }], is_absolute: false, span: 4..5 }), rhs: Path(Path { path: [Ident { name: "b", span: 8..9 }], is_absolute: false, span: 8..9 }), span: 4..9 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 12..13 }, span: 10..15 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: 23..24 }, span: 21..26 }, span: 1..26 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "(foo(a, b, c))"),
         expect_test::expect![[
-            r#"Call { name: Path { path: [Ident { name: "foo", span: 1..4 }], is_absolute: false, span: 1..4 }, args: [Path(Path { path: [Ident { name: "a", span: 5..6 }], is_absolute: false, span: 5..6 }), Path(Path { path: [Ident { name: "b", span: 8..9 }], is_absolute: false, span: 8..9 }), Path(Path { path: [Ident { name: "c", span: 11..12 }], is_absolute: false, span: 11..12 })] }"#
+            r#"Call { name: Path { path: [Ident { name: "foo", span: 1..4 }], is_absolute: false, span: 1..4 }, args: [Path(Path { path: [Ident { name: "a", span: 5..6 }], is_absolute: false, span: 5..6 }), Path(Path { path: [Ident { name: "b", span: 8..9 }], is_absolute: false, span: 8..9 }), Path(Path { path: [Ident { name: "c", span: 11..12 }], is_absolute: false, span: 11..12 })], span: 1..13 }"#
         ]],
     );
 }
@@ -731,7 +743,7 @@ fn enums() {
             "#
         ),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "e", span: 17..18 }, ty: Some(CustomType(Path { path: [Ident { name: "path", span: 22..26 }, Ident { name: "to", span: 28..30 }, Ident { name: "MyEnum", span: 32..38 }], is_absolute: true, span: 20..38 })), init: None, span: 13..39 }"#
+            r#"Let { name: Ident { name: "e", span: 17..18 }, ty: Some(CustomType { path: Path { path: [Ident { name: "path", span: 22..26 }, Ident { name: "to", span: 28..30 }, Ident { name: "MyEnum", span: 32..38 }], is_absolute: true, span: 20..38 }, span: 20..38 }), init: None, span: 13..39 }"#
         ]],
     );
 }
@@ -835,7 +847,7 @@ fn foo(x: real, y: real) -> real {
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Fn { fn_sig: FnSig { name: Ident { name: "foo", span: 4..7 }, params: [(Ident { name: "x", span: 8..9 }, Real), (Ident { name: "y", span: 17..18 }, Real)], return_type: Real, span: 1..33 }, body: Block { statements: [Let { name: Ident { name: "z", span: 44..45 }, ty: None, init: Some(Immediate(Real(5.0))), span: 40..52 }], final_expr: Path(Path { path: [Ident { name: "z", span: 57..58 }], is_absolute: false, span: 57..58 }) }, span: 1..60 }]"#
+            r#"[Fn { fn_sig: FnSig { name: Ident { name: "foo", span: 4..7 }, params: [(Ident { name: "x", span: 8..9 }, Primitive { kind: Real, span: 11..15 }), (Ident { name: "y", span: 17..18 }, Primitive { kind: Real, span: 20..24 })], return_type: Primitive { kind: Real, span: 29..33 }, span: 1..33 }, body: Block { statements: [Let { name: Ident { name: "z", span: 44..45 }, ty: None, init: Some(Immediate { value: Real(5.0), span: 48..51 }), span: 40..52 }], final_expr: Path(Path { path: [Ident { name: "z", span: 57..58 }], is_absolute: false, span: 57..58 }), span: 34..60 }, span: 1..60 }]"#
         ]],
     );
 }
@@ -849,14 +861,14 @@ let x = foo(a*3, c);
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Let { name: Ident { name: "x", span: 5..6 }, ty: None, init: Some(Call { name: Path { path: [Ident { name: "foo", span: 9..12 }], is_absolute: false, span: 9..12 }, args: [BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "a", span: 13..14 }], is_absolute: false, span: 13..14 }), rhs: Immediate(Int(3)) }, Path(Path { path: [Ident { name: "c", span: 18..19 }], is_absolute: false, span: 18..19 })] }), span: 1..21 }]"#
+            r#"[Let { name: Ident { name: "x", span: 5..6 }, ty: None, init: Some(Call { name: Path { path: [Ident { name: "foo", span: 9..12 }], is_absolute: false, span: 9..12 }, args: [BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "a", span: 13..14 }], is_absolute: false, span: 13..14 }), rhs: Immediate { value: Int(3), span: 15..16 }, span: 13..16 }, Path(Path { path: [Ident { name: "c", span: 18..19 }], is_absolute: false, span: 18..19 })], span: 9..20 }), span: 1..21 }]"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "A::B::foo(-a, b+c)"),
         expect_test::expect![[
-            r#"Call { name: Path { path: [Ident { name: "A", span: 0..1 }, Ident { name: "B", span: 3..4 }, Ident { name: "foo", span: 6..9 }], is_absolute: false, span: 0..9 }, args: [UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "a", span: 11..12 }], is_absolute: false, span: 11..12 }) }, BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "b", span: 14..15 }], is_absolute: false, span: 14..15 }), rhs: Path(Path { path: [Ident { name: "c", span: 16..17 }], is_absolute: false, span: 16..17 }) }] }"#
+            r#"Call { name: Path { path: [Ident { name: "A", span: 0..1 }, Ident { name: "B", span: 3..4 }, Ident { name: "foo", span: 6..9 }], is_absolute: false, span: 0..9 }, args: [UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "a", span: 11..12 }], is_absolute: false, span: 11..12 }), span: 10..12 }, BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "b", span: 14..15 }], is_absolute: false, span: 14..15 }), rhs: Path(Path { path: [Ident { name: "c", span: 16..17 }], is_absolute: false, span: 16..17 }), span: 14..17 }], span: 0..18 }"#
         ]],
     );
 }
@@ -866,14 +878,14 @@ fn code_blocks() {
     check(
         &run_parser!(let_decl(expr()), "let x = { 0 };"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Block(Block { statements: [], final_expr: Immediate(Int(0)) })), span: 0..14 }"#
+            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Block(Block { statements: [], final_expr: Immediate { value: Int(0), span: 10..11 }, span: 8..13 })), span: 0..14 }"#
         ]],
     );
 
     check(
         &run_parser!(let_decl(expr()), "let x = { constraint x > 0.0; 0.0 };"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Block(Block { statements: [Constraint { expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "x", span: 21..22 }], is_absolute: false, span: 21..22 }), rhs: Immediate(Real(0.0)) }, span: 10..29 }], final_expr: Immediate(Real(0.0)) })), span: 0..36 }"#
+            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Block(Block { statements: [Constraint { expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "x", span: 21..22 }], is_absolute: false, span: 21..22 }), rhs: Immediate { value: Real(0.0), span: 25..28 }, span: 21..28 }, span: 10..29 }], final_expr: Immediate { value: Real(0.0), span: 30..33 }, span: 8..35 })), span: 0..36 }"#
         ]],
     );
 
@@ -883,14 +895,14 @@ fn code_blocks() {
             "constraint { constraint { true }; x > 0 };"
         ),
         expect_test::expect![[
-            r#"Constraint { expr: Block(Block { statements: [Constraint { expr: Block(Block { statements: [], final_expr: Immediate(Bool(true)) }), span: 13..33 }], final_expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "x", span: 34..35 }], is_absolute: false, span: 34..35 }), rhs: Immediate(Int(0)) } }), span: 0..42 }"#
+            r#"Constraint { expr: Block(Block { statements: [Constraint { expr: Block(Block { statements: [], final_expr: Immediate { value: Bool(true), span: 26..30 }, span: 24..32 }), span: 13..33 }], final_expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "x", span: 34..35 }], is_absolute: false, span: 34..35 }), rhs: Immediate { value: Int(0), span: 38..39 }, span: 34..39 }, span: 11..41 }), span: 0..42 }"#
         ]],
     );
 
     check(
         &run_parser!(let_decl(expr()), "let x = { 1.0 } * { 2.0 };"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(BinaryOp { op: Mul, lhs: Block(Block { statements: [], final_expr: Immediate(Real(1.0)) }), rhs: Block(Block { statements: [], final_expr: Immediate(Real(2.0)) }) }), span: 0..26 }"#
+            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(BinaryOp { op: Mul, lhs: Block(Block { statements: [], final_expr: Immediate { value: Real(1.0), span: 10..13 }, span: 8..15 }), rhs: Block(Block { statements: [], final_expr: Immediate { value: Real(2.0), span: 20..23 }, span: 18..25 }), span: 8..25 }), span: 0..26 }"#
         ]],
     );
 
@@ -912,21 +924,21 @@ fn if_exprs() {
     check(
         &run_parser!(if_expr(expr()), "if c { 1 } else { 0 }"),
         expect_test::expect![[
-            r#"If { condition: Path(Path { path: [Ident { name: "c", span: 3..4 }], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } }"#
+            r#"If { condition: Path(Path { path: [Ident { name: "c", span: 3..4 }], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 7..8 }, span: 5..10 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(0), span: 18..19 }, span: 16..21 }, span: 0..21 }"#
         ]],
     );
 
     check(
         &run_parser!(if_expr(expr()), "if c { if c { 1 } else { 0 } } else { 2 }"),
         expect_test::expect![[
-            r#"If { condition: Path(Path { path: [Ident { name: "c", span: 3..4 }], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: If { condition: Path(Path { path: [Ident { name: "c", span: 10..11 }], is_absolute: false, span: 10..11 }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } } }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }"#
+            r#"If { condition: Path(Path { path: [Ident { name: "c", span: 3..4 }], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: If { condition: Path(Path { path: [Ident { name: "c", span: 10..11 }], is_absolute: false, span: 10..11 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 14..15 }, span: 12..17 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(0), span: 25..26 }, span: 23..28 }, span: 7..28 }, span: 5..30 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: 38..39 }, span: 36..41 }, span: 0..41 }"#
         ]],
     );
 
     check(
         &run_parser!(if_expr(expr()), "if c { if c { 1 } else { 0 } } else { 2 }"),
         expect_test::expect![[
-            r#"If { condition: Path(Path { path: [Ident { name: "c", span: 3..4 }], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: If { condition: Path(Path { path: [Ident { name: "c", span: 10..11 }], is_absolute: false, span: 10..11 }), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(0)) } } }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }"#
+            r#"If { condition: Path(Path { path: [Ident { name: "c", span: 3..4 }], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: If { condition: Path(Path { path: [Ident { name: "c", span: 10..11 }], is_absolute: false, span: 10..11 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 14..15 }, span: 12..17 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(0), span: 25..26 }, span: 23..28 }, span: 7..28 }, span: 5..30 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: 38..39 }, span: 36..41 }, span: 0..41 }"#
         ]],
     );
 }
@@ -935,20 +947,20 @@ fn if_exprs() {
 fn array_type() {
     check(
         &run_parser!(type_(expr()), r#"int[5]"#),
-        expect_test::expect!["Array { ty: Int, range: Immediate(Int(5)) }"],
+        expect_test::expect!["Array { ty: Primitive { kind: Int, span: 0..3 }, range: Immediate { value: Int(5), span: 4..5 }, span: 0..6 }"],
     );
 
     check(
         &run_parser!(type_(expr()), r#"int[MyEnum]"#),
         expect_test::expect![[
-            r#"Array { ty: Int, range: Path(Path { path: [Ident { name: "MyEnum", span: 4..10 }], is_absolute: false, span: 4..10 }) }"#
+            r#"Array { ty: Primitive { kind: Int, span: 0..3 }, range: Path(Path { path: [Ident { name: "MyEnum", span: 4..10 }], is_absolute: false, span: 4..10 }), span: 0..11 }"#
         ]],
     );
 
     check(
         &run_parser!(type_(expr()), r#"int[N]"#),
         expect_test::expect![[
-            r#"Array { ty: Int, range: Path(Path { path: [Ident { name: "N", span: 4..5 }], is_absolute: false, span: 4..5 }) }"#
+            r#"Array { ty: Primitive { kind: Int, span: 0..3 }, range: Path(Path { path: [Ident { name: "N", span: 4..5 }], is_absolute: false, span: 4..5 }), span: 0..6 }"#
         ]],
     );
 
@@ -958,21 +970,21 @@ fn array_type() {
             r#"string[foo()][{ 7 }][if true { 1 } else { 2 }"#
         ),
         expect_test::expect![[
-            r#"Array { ty: Array { ty: String, range: Block(Block { statements: [], final_expr: Immediate(Int(7)) }) }, range: Call { name: Path { path: [Ident { name: "foo", span: 7..10 }], is_absolute: false, span: 7..10 }, args: [] } }"#
+            r#"Array { ty: Array { ty: Primitive { kind: String, span: 0..6 }, range: Block(Block { statements: [], final_expr: Immediate { value: Int(7), span: 16..17 }, span: 14..19 }), span: 0..20 }, range: Call { name: Path { path: [Ident { name: "foo", span: 7..10 }], is_absolute: false, span: 7..10 }, args: [], span: 7..12 }, span: 0..13 }"#
         ]],
     );
 
     check(
         &run_parser!(type_(expr()), r#"real[N][9][M][3]"#),
         expect_test::expect![[
-            r#"Array { ty: Array { ty: Array { ty: Array { ty: Real, range: Immediate(Int(3)) }, range: Path(Path { path: [Ident { name: "M", span: 11..12 }], is_absolute: false, span: 11..12 }) }, range: Immediate(Int(9)) }, range: Path(Path { path: [Ident { name: "N", span: 5..6 }], is_absolute: false, span: 5..6 }) }"#
+            r#"Array { ty: Array { ty: Array { ty: Array { ty: Primitive { kind: Real, span: 0..4 }, range: Immediate { value: Int(3), span: 14..15 }, span: 0..16 }, range: Path(Path { path: [Ident { name: "M", span: 11..12 }], is_absolute: false, span: 11..12 }), span: 0..13 }, range: Immediate { value: Int(9), span: 8..9 }, span: 0..10 }, range: Path(Path { path: [Ident { name: "N", span: 5..6 }], is_absolute: false, span: 5..6 }), span: 0..7 }"#
         ]],
     );
 
     check(
         &run_parser!(type_(expr()), r#"{int, { real, string }}[N][9]"#),
         expect_test::expect![[
-            r#"Array { ty: Array { ty: Tuple([(None, Int), (None, Tuple([(None, Real), (None, String)]))]), range: Immediate(Int(9)) }, range: Path(Path { path: [Ident { name: "N", span: 24..25 }], is_absolute: false, span: 24..25 }) }"#
+            r#"Array { ty: Array { ty: Tuple { fields: [(None, Primitive { kind: Int, span: 1..4 }), (None, Tuple { fields: [(None, Primitive { kind: Real, span: 8..12 }), (None, Primitive { kind: String, span: 14..20 })], span: 6..22 })], span: 0..23 }, range: Immediate { value: Int(9), span: 27..28 }, span: 0..29 }, range: Path(Path { path: [Ident { name: "N", span: 24..25 }], is_absolute: false, span: 24..25 }), span: 0..26 }"#
         ]],
     );
 
@@ -987,34 +999,36 @@ fn array_type() {
 fn array_expressions() {
     check(
         &run_parser!(expr(), r#"[5]"#),
-        expect_test::expect!["Array([Immediate(Int(5))])"],
-    );
-
-    check(
-        &run_parser!(expr(), r#"[5,]"#),
-        expect_test::expect!["Array([Immediate(Int(5))])"],
-    );
-
-    check(
-        &run_parser!(expr(), r#"[5, 4]"#),
-        expect_test::expect!["Array([Immediate(Int(5)), Immediate(Int(4))])"],
-    );
-
-    check(
-        &run_parser!(expr(), r#"[[ 1 ],]"#),
-        expect_test::expect!["Array([Array([Immediate(Int(1))])])"],
-    );
-
-    check(
-        &run_parser!(expr(), r#"[[1, 2], 3]"#), // This should fail in semantic analysis
         expect_test::expect![
-            "Array([Array([Immediate(Int(1)), Immediate(Int(2))]), Immediate(Int(3))])"
+            "Array { elements: [Immediate { value: Int(5), span: 1..2 }], span: 0..3 }"
         ],
     );
 
     check(
+        &run_parser!(expr(), r#"[5,]"#),
+        expect_test::expect![
+            "Array { elements: [Immediate { value: Int(5), span: 1..2 }], span: 0..4 }"
+        ],
+    );
+
+    check(
+        &run_parser!(expr(), r#"[5, 4]"#),
+        expect_test::expect!["Array { elements: [Immediate { value: Int(5), span: 1..2 }, Immediate { value: Int(4), span: 4..5 }], span: 0..6 }"],
+    );
+
+    check(
+        &run_parser!(expr(), r#"[[ 1 ],]"#),
+        expect_test::expect!["Array { elements: [Array { elements: [Immediate { value: Int(1), span: 3..4 }], span: 1..6 }], span: 0..8 }"],
+    );
+
+    check(
+        &run_parser!(expr(), r#"[[1, 2], 3]"#), // This should fail in semantic analysis
+        expect_test::expect!["Array { elements: [Array { elements: [Immediate { value: Int(1), span: 2..3 }, Immediate { value: Int(2), span: 5..6 }], span: 1..7 }, Immediate { value: Int(3), span: 9..10 }], span: 0..11 }"]
+    );
+
+    check(
         &run_parser!(expr(), r#"[[1, 2], [3, 4]]"#),
-        expect_test::expect!["Array([Array([Immediate(Int(1)), Immediate(Int(2))]), Array([Immediate(Int(3)), Immediate(Int(4))])])"],
+        expect_test::expect!["Array { elements: [Array { elements: [Immediate { value: Int(1), span: 2..3 }, Immediate { value: Int(2), span: 5..6 }], span: 1..7 }, Array { elements: [Immediate { value: Int(3), span: 10..11 }, Immediate { value: Int(4), span: 13..14 }], span: 9..15 }], span: 0..16 }"],
     );
 
     check(
@@ -1023,7 +1037,7 @@ fn array_expressions() {
             r#"[[foo(), { 2 }], [if true { 1 } else { 2 }, t.0]]"#
         ),
         expect_test::expect![[
-            r#"Array([Array([Call { name: Path { path: [Ident { name: "foo", span: 2..5 }], is_absolute: false, span: 2..5 }, args: [] }, Block(Block { statements: [], final_expr: Immediate(Int(2)) })]), Array([If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(2)) } }, TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 44..45 }], is_absolute: false, span: 44..45 }), field: Left(0) }])])"#
+            r#"Array { elements: [Array { elements: [Call { name: Path { path: [Ident { name: "foo", span: 2..5 }], is_absolute: false, span: 2..5 }, args: [], span: 2..7 }, Block(Block { statements: [], final_expr: Immediate { value: Int(2), span: 11..12 }, span: 9..14 })], span: 1..15 }, Array { elements: [If { condition: Immediate { value: Bool(true), span: 21..25 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 28..29 }, span: 26..31 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: 39..40 }, span: 37..42 }, span: 18..42 }, TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 44..45 }], is_absolute: false, span: 44..45 }), field: Left(0), span: 44..47 }], span: 17..48 }], span: 0..49 }"#
         ]],
     );
 }
@@ -1033,21 +1047,21 @@ fn array_field_accesss() {
     check(
         &run_parser!(expr(), r#"a[5]"#),
         expect_test::expect![[
-            r#"ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), index: Immediate(Int(5)) }"#
+            r#"ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), index: Immediate { value: Int(5), span: 2..3 }, span: 0..4 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{ a }[N][foo()][M][4]"#),
         expect_test::expect![[
-            r#"ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "a", span: 2..3 }], is_absolute: false, span: 2..3 }) }), index: Immediate(Int(4)) }, index: Path(Path { path: [Ident { name: "M", span: 16..17 }], is_absolute: false, span: 16..17 }) }, index: Call { name: Path { path: [Ident { name: "foo", span: 9..12 }], is_absolute: false, span: 9..12 }, args: [] } }, index: Path(Path { path: [Ident { name: "N", span: 6..7 }], is_absolute: false, span: 6..7 }) }"#
+            r#"ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "a", span: 2..3 }], is_absolute: false, span: 2..3 }), span: 0..5 }), index: Immediate { value: Int(4), span: 19..20 }, span: 0..21 }, index: Path(Path { path: [Ident { name: "M", span: 16..17 }], is_absolute: false, span: 16..17 }), span: 0..18 }, index: Call { name: Path { path: [Ident { name: "foo", span: 9..12 }], is_absolute: false, span: 9..12 }, args: [], span: 9..14 }, span: 0..15 }, index: Path(Path { path: [Ident { name: "N", span: 6..7 }], is_absolute: false, span: 6..7 }), span: 0..8 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"foo()[{ M }][if true { 1 } else { 3 }]"#),
         expect_test::expect![[
-            r#"ArrayElementAccess { array: ArrayElementAccess { array: Call { name: Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 }, args: [] }, index: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(1)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } } }, index: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "M", span: 8..9 }], is_absolute: false, span: 8..9 }) }) }"#
+            r#"ArrayElementAccess { array: ArrayElementAccess { array: Call { name: Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 }, args: [], span: 0..5 }, index: If { condition: Immediate { value: Bool(true), span: 16..20 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 23..24 }, span: 21..26 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(3), span: 34..35 }, span: 32..37 }, span: 13..37 }, span: 0..38 }, index: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "M", span: 8..9 }], is_absolute: false, span: 8..9 }), span: 6..11 }), span: 0..12 }"#
         ]],
     );
 
@@ -1061,7 +1075,7 @@ fn array_field_accesss() {
     check(
         &run_parser!(expr(), r#"a[MyEnum::Variant1];"#),
         expect_test::expect![[
-            r#"ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), index: Path(Path { path: [Ident { name: "MyEnum", span: 2..8 }, Ident { name: "Variant1", span: 10..18 }], is_absolute: false, span: 2..18 }) }"#
+            r#"ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), index: Path(Path { path: [Ident { name: "MyEnum", span: 2..8 }, Ident { name: "Variant1", span: 10..18 }], is_absolute: false, span: 2..18 }), span: 0..19 }"#
         ]],
     );
 }
@@ -1070,60 +1084,62 @@ fn array_field_accesss() {
 fn tuple_expressions() {
     check(
         &run_parser!(expr(), r#"{0}"#), // This is not a tuple. It is a code block expr.
-        expect_test::expect!["Block(Block { statements: [], final_expr: Immediate(Int(0)) })"],
+        expect_test::expect!["Block(Block { statements: [], final_expr: Immediate { value: Int(0), span: 1..2 }, span: 0..3 })"],
     );
 
     check(
         &run_parser!(expr(), r#"{x: 0}"#), // This is a tuple because the field is named so there is no ambiguity
         expect_test::expect![[
-            r#"Tuple([(Some(Ident { name: "x", span: 1..2 }), Immediate(Int(0)))])"#
+            r#"Tuple { fields: [(Some(Ident { name: "x", span: 1..2 }), Immediate { value: Int(0), span: 4..5 })], span: 0..6 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{0,}"#), // This is a tuple
-        expect_test::expect!["Tuple([(None, Immediate(Int(0)))])"],
+        expect_test::expect![
+            "Tuple { fields: [(None, Immediate { value: Int(0), span: 1..2 })], span: 0..4 }"
+        ],
     );
 
     check(
         &run_parser!(expr(), r#"{x: 0,}"#), // This is a tuple
         expect_test::expect![[
-            r#"Tuple([(Some(Ident { name: "x", span: 1..2 }), Immediate(Int(0)))])"#
+            r#"Tuple { fields: [(Some(Ident { name: "x", span: 1..2 }), Immediate { value: Int(0), span: 4..5 })], span: 0..7 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{0, 1.0, "foo"}"#),
         expect_test::expect![[
-            r#"Tuple([(None, Immediate(Int(0))), (None, Immediate(Real(1.0))), (None, Immediate(String("foo")))])"#
+            r#"Tuple { fields: [(None, Immediate { value: Int(0), span: 1..2 }), (None, Immediate { value: Real(1.0), span: 4..7 }), (None, Immediate { value: String("foo"), span: 9..14 })], span: 0..15 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{x: 0, y: 1.0, z: "foo"}"#),
         expect_test::expect![[
-            r#"Tuple([(Some(Ident { name: "x", span: 1..2 }), Immediate(Int(0))), (Some(Ident { name: "y", span: 7..8 }), Immediate(Real(1.0))), (Some(Ident { name: "z", span: 15..16 }), Immediate(String("foo")))])"#
+            r#"Tuple { fields: [(Some(Ident { name: "x", span: 1..2 }), Immediate { value: Int(0), span: 4..5 }), (Some(Ident { name: "y", span: 7..8 }), Immediate { value: Real(1.0), span: 10..13 }), (Some(Ident { name: "z", span: 15..16 }), Immediate { value: String("foo"), span: 18..23 })], span: 0..24 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{0, {1.0, "bar"}, "foo"}"#),
         expect_test::expect![[
-            r#"Tuple([(None, Immediate(Int(0))), (None, Tuple([(None, Immediate(Real(1.0))), (None, Immediate(String("bar")))])), (None, Immediate(String("foo")))])"#
+            r#"Tuple { fields: [(None, Immediate { value: Int(0), span: 1..2 }), (None, Tuple { fields: [(None, Immediate { value: Real(1.0), span: 5..8 }), (None, Immediate { value: String("bar"), span: 10..15 })], span: 4..16 }), (None, Immediate { value: String("foo"), span: 18..23 })], span: 0..24 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{x: 0, {y: 1.0, "bar"}, z: "foo"}"#),
         expect_test::expect![[
-            r#"Tuple([(Some(Ident { name: "x", span: 1..2 }), Immediate(Int(0))), (None, Tuple([(Some(Ident { name: "y", span: 8..9 }), Immediate(Real(1.0))), (None, Immediate(String("bar")))])), (Some(Ident { name: "z", span: 24..25 }), Immediate(String("foo")))])"#
+            r#"Tuple { fields: [(Some(Ident { name: "x", span: 1..2 }), Immediate { value: Int(0), span: 4..5 }), (None, Tuple { fields: [(Some(Ident { name: "y", span: 8..9 }), Immediate { value: Real(1.0), span: 11..14 }), (None, Immediate { value: String("bar"), span: 16..21 })], span: 7..22 }), (Some(Ident { name: "z", span: 24..25 }), Immediate { value: String("foo"), span: 27..32 })], span: 0..33 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{ { 42 }, if c { 2 } else { 3 }, foo() }"#),
         expect_test::expect![[
-            r#"Tuple([(None, Block(Block { statements: [], final_expr: Immediate(Int(42)) })), (None, If { condition: Path(Path { path: [Ident { name: "c", span: 13..14 }], is_absolute: false, span: 13..14 }), then_block: Block { statements: [], final_expr: Immediate(Int(2)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } }), (None, Call { name: Path { path: [Ident { name: "foo", span: 33..36 }], is_absolute: false, span: 33..36 }, args: [] })])"#
+            r#"Tuple { fields: [(None, Block(Block { statements: [], final_expr: Immediate { value: Int(42), span: 4..6 }, span: 2..8 })), (None, If { condition: Path(Path { path: [Ident { name: "c", span: 13..14 }], is_absolute: false, span: 13..14 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: 17..18 }, span: 15..20 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(3), span: 28..29 }, span: 26..31 }, span: 10..31 }), (None, Call { name: Path { path: [Ident { name: "foo", span: 33..36 }], is_absolute: false, span: 33..36 }, args: [], span: 33..38 })], span: 0..40 }"#
         ]],
     );
 
@@ -1133,7 +1149,7 @@ fn tuple_expressions() {
             r#"{ x: { 42 }, y: if c { 2 } else { 3 }, z: foo() }"#
         ),
         expect_test::expect![[
-            r#"Tuple([(Some(Ident { name: "x", span: 2..3 }), Block(Block { statements: [], final_expr: Immediate(Int(42)) })), (Some(Ident { name: "y", span: 13..14 }), If { condition: Path(Path { path: [Ident { name: "c", span: 19..20 }], is_absolute: false, span: 19..20 }), then_block: Block { statements: [], final_expr: Immediate(Int(2)) }, else_block: Block { statements: [], final_expr: Immediate(Int(3)) } }), (Some(Ident { name: "z", span: 39..40 }), Call { name: Path { path: [Ident { name: "foo", span: 42..45 }], is_absolute: false, span: 42..45 }, args: [] })])"#
+            r#"Tuple { fields: [(Some(Ident { name: "x", span: 2..3 }), Block(Block { statements: [], final_expr: Immediate { value: Int(42), span: 7..9 }, span: 5..11 })), (Some(Ident { name: "y", span: 13..14 }), If { condition: Path(Path { path: [Ident { name: "c", span: 19..20 }], is_absolute: false, span: 19..20 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: 23..24 }, span: 21..26 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(3), span: 34..35 }, span: 32..37 }, span: 16..37 }), (Some(Ident { name: "z", span: 39..40 }), Call { name: Path { path: [Ident { name: "foo", span: 42..45 }], is_absolute: false, span: 42..45 }, args: [], span: 42..47 })], span: 0..49 }"#
         ]],
     );
 }
@@ -1143,99 +1159,99 @@ fn tuple_field_accesses() {
     check(
         &run_parser!(expr(), r#"t.0 + t.9999999 + t.x"#),
         expect_test::expect![[
-            r#"BinaryOp { op: Add, lhs: BinaryOp { op: Add, lhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(0) }, rhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 6..7 }], is_absolute: false, span: 6..7 }), field: Left(9999999) } }, rhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 18..19 }], is_absolute: false, span: 18..19 }), field: Right(Ident { name: "x", span: 20..21 }) } }"#
+            r#"BinaryOp { op: Add, lhs: BinaryOp { op: Add, lhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(0), span: 0..3 }, rhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 6..7 }], is_absolute: false, span: 6..7 }), field: Left(9999999), span: 6..15 }, span: 0..15 }, rhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 18..19 }], is_absolute: false, span: 18..19 }), field: Right(Ident { name: "x", span: 20..21 }), span: 18..21 }, span: 0..21 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{0, 1}.0"#),
-        expect_test::expect!["TupleFieldAccess { tuple: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(1)))]), field: Left(0) }"],
+        expect_test::expect!["TupleFieldAccess { tuple: Tuple { fields: [(None, Immediate { value: Int(0), span: 1..2 }), (None, Immediate { value: Int(1), span: 4..5 })], span: 0..6 }, field: Left(0), span: 0..8 }"],
     );
 
     check(
         &run_parser!(expr(), r#"{0, 1}.x"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(1)))]), field: Right(Ident { name: "x", span: 7..8 }) }"#
+            r#"TupleFieldAccess { tuple: Tuple { fields: [(None, Immediate { value: Int(0), span: 1..2 }), (None, Immediate { value: Int(1), span: 4..5 })], span: 0..6 }, field: Right(Ident { name: "x", span: 7..8 }), span: 0..8 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"t.0 .0"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(0) }, field: Left(0) }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(0), span: 0..3 }, field: Left(0), span: 0..6 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"t.x .y"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Right(Ident { name: "x", span: 2..3 }) }, field: Right(Ident { name: "y", span: 5..6 }) }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Right(Ident { name: "x", span: 2..3 }), span: 0..3 }, field: Right(Ident { name: "y", span: 5..6 }), span: 0..6 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "t \r .1 .2.2. \n 3 . \t 13 . 1.1"),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(1) }, field: Left(2) }, field: Left(2) }, field: Left(3) }, field: Left(13) }, field: Left(1) }, field: Left(1) }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(1), span: 0..6 }, field: Left(2), span: 0..9 }, field: Left(2), span: 0..11 }, field: Left(3), span: 0..16 }, field: Left(13), span: 0..23 }, field: Left(1), span: 0..27 }, field: Left(1), span: 0..29 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "t \r .x .1.2. \n w . \t t. 3.4"),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Right(Ident { name: "x", span: 5..6 }) }, field: Left(1) }, field: Left(2) }, field: Right(Ident { name: "w", span: 15..16 }) }, field: Right(Ident { name: "t", span: 21..22 }) }, field: Left(3) }, field: Left(4) }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Right(Ident { name: "x", span: 5..6 }), span: 0..6 }, field: Left(1), span: 0..9 }, field: Left(2), span: 0..11 }, field: Right(Ident { name: "w", span: 15..16 }), span: 0..16 }, field: Right(Ident { name: "t", span: 21..22 }), span: 0..22 }, field: Left(3), span: 0..25 }, field: Left(4), span: 0..27 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"foo().0.1"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Call { name: Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 }, args: [] }, field: Left(0) }, field: Left(1) }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Call { name: Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 }, args: [], span: 0..5 }, field: Left(0), span: 0..7 }, field: Left(1), span: 0..9 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"foo().a.b.0.1"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Call { name: Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 }, args: [] }, field: Right(Ident { name: "a", span: 6..7 }) }, field: Right(Ident { name: "b", span: 8..9 }) }, field: Left(0) }, field: Left(1) }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Call { name: Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 }, args: [], span: 0..5 }, field: Right(Ident { name: "a", span: 6..7 }), span: 0..7 }, field: Right(Ident { name: "b", span: 8..9 }), span: 0..9 }, field: Left(0), span: 0..11 }, field: Left(1), span: 0..13 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{ {0, 0} }.0"#),
-        expect_test::expect!["TupleFieldAccess { tuple: Block(Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) }), field: Left(0) }"],
+        expect_test::expect!["TupleFieldAccess { tuple: Block(Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: 3..4 }), (None, Immediate { value: Int(0), span: 6..7 })], span: 2..8 }, span: 0..10 }), field: Left(0), span: 0..12 }"],
     );
 
     check(
         &run_parser!(expr(), r#"{ {0, 0} }.a"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: Block(Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) }), field: Right(Ident { name: "a", span: 11..12 }) }"#
+            r#"TupleFieldAccess { tuple: Block(Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: 3..4 }), (None, Immediate { value: Int(0), span: 6..7 })], span: 2..8 }, span: 0..10 }), field: Right(Ident { name: "a", span: 11..12 }), span: 0..12 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"if true { {0, 0} } else { {0, 0} }.0"#),
-        expect_test::expect!["TupleFieldAccess { tuple: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) }, else_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) } }, field: Left(0) }"],
+        expect_test::expect!["TupleFieldAccess { tuple: If { condition: Immediate { value: Bool(true), span: 3..7 }, then_block: Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: 11..12 }), (None, Immediate { value: Int(0), span: 14..15 })], span: 10..16 }, span: 8..18 }, else_block: Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: 27..28 }), (None, Immediate { value: Int(0), span: 30..31 })], span: 26..32 }, span: 24..34 }, span: 0..34 }, field: Left(0), span: 0..36 }"],
     );
 
     check(
         &run_parser!(expr(), r#"if true { {0, 0} } else { {0, 0} }.x"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) }, else_block: Block { statements: [], final_expr: Tuple([(None, Immediate(Int(0))), (None, Immediate(Int(0)))]) } }, field: Right(Ident { name: "x", span: 35..36 }) }"#
+            r#"TupleFieldAccess { tuple: If { condition: Immediate { value: Bool(true), span: 3..7 }, then_block: Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: 11..12 }), (None, Immediate { value: Int(0), span: 14..15 })], span: 10..16 }, span: 8..18 }, else_block: Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: 27..28 }), (None, Immediate { value: Int(0), span: 30..31 })], span: 26..32 }, span: 24..34 }, span: 0..34 }, field: Right(Ident { name: "x", span: 35..36 }), span: 0..36 }"#
         ]],
     );
 
     // This parses because `1 + 2` is an expression, but it should fail in semantic analysis.
     check(
         &run_parser!(expr(), "1 + 2 .3"),
-        expect_test::expect!["BinaryOp { op: Add, lhs: Immediate(Int(1)), rhs: TupleFieldAccess { tuple: Immediate(Int(2)), field: Left(3) } }"],
+        expect_test::expect!["BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: TupleFieldAccess { tuple: Immediate { value: Int(2), span: 4..5 }, field: Left(3), span: 4..8 }, span: 0..8 }"],
     );
 
     // This parses because `1 + 2` is an expression, but it should fail in semantic analysis.
     check(
         &run_parser!(expr(), "1 + 2 .a"),
         expect_test::expect![[
-            r#"BinaryOp { op: Add, lhs: Immediate(Int(1)), rhs: TupleFieldAccess { tuple: Immediate(Int(2)), field: Right(Ident { name: "a", span: 7..8 }) } }"#
+            r#"BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: TupleFieldAccess { tuple: Immediate { value: Int(2), span: 4..5 }, field: Right(Ident { name: "a", span: 7..8 }), span: 4..8 }, span: 0..8 }"#
         ]],
     );
 
@@ -1298,28 +1314,28 @@ fn cond_exprs() {
     check(
         &run_parser!(cond_expr(expr()), r#"cond { else => a }"#),
         expect_test::expect![[
-            r#"Cond { branches: [], else_result: Path(Path { path: [Ident { name: "a", span: 15..16 }], is_absolute: false, span: 15..16 }) }"#
+            r#"Cond { branches: [], else_result: Path(Path { path: [Ident { name: "a", span: 15..16 }], is_absolute: false, span: 15..16 }), span: 0..18 }"#
         ]],
     );
 
     check(
         &run_parser!(cond_expr(expr()), r#"cond { else => { a } }"#),
         expect_test::expect![[
-            r#"Cond { branches: [], else_result: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "a", span: 17..18 }], is_absolute: false, span: 17..18 }) }) }"#
+            r#"Cond { branches: [], else_result: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "a", span: 17..18 }], is_absolute: false, span: 17..18 }), span: 15..20 }), span: 0..22 }"#
         ]],
     );
 
     check(
         &run_parser!(cond_expr(expr()), r#"cond { a => b, else => c }"#),
         expect_test::expect![[
-            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: 7..8 }], is_absolute: false, span: 7..8 }), result: Path(Path { path: [Ident { name: "b", span: 12..13 }], is_absolute: false, span: 12..13 }) }], else_result: Path(Path { path: [Ident { name: "c", span: 23..24 }], is_absolute: false, span: 23..24 }) }"#
+            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: 7..8 }], is_absolute: false, span: 7..8 }), result: Path(Path { path: [Ident { name: "b", span: 12..13 }], is_absolute: false, span: 12..13 }), span: 7..14 }], else_result: Path(Path { path: [Ident { name: "c", span: 23..24 }], is_absolute: false, span: 23..24 }), span: 0..26 }"#
         ]],
     );
 
     check(
         &run_parser!(cond_expr(expr()), r#"cond { a => { b }, else => c, }"#),
         expect_test::expect![[
-            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: 7..8 }], is_absolute: false, span: 7..8 }), result: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "b", span: 14..15 }], is_absolute: false, span: 14..15 }) }) }], else_result: Path(Path { path: [Ident { name: "c", span: 27..28 }], is_absolute: false, span: 27..28 }) }"#
+            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: 7..8 }], is_absolute: false, span: 7..8 }), result: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "b", span: 14..15 }], is_absolute: false, span: 14..15 }), span: 12..17 }), span: 7..18 }], else_result: Path(Path { path: [Ident { name: "c", span: 27..28 }], is_absolute: false, span: 27..28 }), span: 0..31 }"#
         ]],
     );
 
@@ -1329,7 +1345,7 @@ fn cond_exprs() {
             r#"cond { a => b, { true } => d, else => f, }"#
         ),
         expect_test::expect![[
-            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: 7..8 }], is_absolute: false, span: 7..8 }), result: Path(Path { path: [Ident { name: "b", span: 12..13 }], is_absolute: false, span: 12..13 }) }, CondBranch { condition: Block(Block { statements: [], final_expr: Immediate(Bool(true)) }), result: Path(Path { path: [Ident { name: "d", span: 27..28 }], is_absolute: false, span: 27..28 }) }], else_result: Path(Path { path: [Ident { name: "f", span: 38..39 }], is_absolute: false, span: 38..39 }) }"#
+            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: 7..8 }], is_absolute: false, span: 7..8 }), result: Path(Path { path: [Ident { name: "b", span: 12..13 }], is_absolute: false, span: 12..13 }), span: 7..14 }, CondBranch { condition: Block(Block { statements: [], final_expr: Immediate { value: Bool(true), span: 17..21 }, span: 15..23 }), result: Path(Path { path: [Ident { name: "d", span: 27..28 }], is_absolute: false, span: 27..28 }), span: 15..29 }], else_result: Path(Path { path: [Ident { name: "f", span: 38..39 }], is_absolute: false, span: 38..39 }), span: 0..42 }"#
         ]],
     );
 
@@ -1352,13 +1368,13 @@ fn cond_exprs() {
 fn casting() {
     check(
         &run_parser!(expr(), r#"(5 as int) as real as int"#),
-        expect_test::expect!["Cast { value: Cast { value: Cast { value: Immediate(Int(5)), ty: Int }, ty: Real }, ty: Int }"],
+        expect_test::expect!["Cast { value: Cast { value: Cast { value: Immediate { value: Int(5), span: 1..2 }, ty: Primitive { kind: Int, span: 6..9 }, span: 1..9 }, ty: Primitive { kind: Real, span: 14..18 }, span: 1..18 }, ty: Primitive { kind: Int, span: 22..25 }, span: 1..25 }"],
     );
 
     check(
         &run_parser!(expr(), r#"t.0.1 as real * a[5][3] as int"#),
         expect_test::expect![[
-            r#"BinaryOp { op: Mul, lhs: Cast { value: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(0) }, field: Left(1) }, ty: Real }, rhs: Cast { value: ArrayElementAccess { array: ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: 16..17 }], is_absolute: false, span: 16..17 }), index: Immediate(Int(3)) }, index: Immediate(Int(5)) }, ty: Int } }"#
+            r#"BinaryOp { op: Mul, lhs: Cast { value: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(0), span: 0..3 }, field: Left(1), span: 0..5 }, ty: Primitive { kind: Real, span: 9..13 }, span: 0..13 }, rhs: Cast { value: ArrayElementAccess { array: ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: 16..17 }], is_absolute: false, span: 16..17 }), index: Immediate { value: Int(3), span: 21..22 }, span: 16..23 }, index: Immediate { value: Int(5), span: 18..19 }, span: 16..20 }, ty: Primitive { kind: Int, span: 27..30 }, span: 16..30 }, span: 0..30 }"#
         ]],
     );
 
@@ -1368,7 +1384,7 @@ fn casting() {
             r#"let x = foo() as real as { int, real };"#
         ),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Cast { value: Cast { value: Call { name: Path { path: [Ident { name: "foo", span: 8..11 }], is_absolute: false, span: 8..11 }, args: [] }, ty: Real }, ty: Tuple([(None, Int), (None, Real)]) }), span: 0..39 }"#
+            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Cast { value: Cast { value: Call { name: Path { path: [Ident { name: "foo", span: 8..11 }], is_absolute: false, span: 8..11 }, args: [], span: 8..13 }, ty: Primitive { kind: Real, span: 17..21 }, span: 8..21 }, ty: Tuple { fields: [(None, Primitive { kind: Int, span: 27..30 }), (None, Primitive { kind: Real, span: 32..36 })], span: 25..38 }, span: 8..38 }), span: 0..39 }"#
         ]],
     );
 
@@ -1385,28 +1401,28 @@ fn in_expr() {
     check(
         &run_parser!(expr(), r#"x in { 1, 2 }"#),
         expect_test::expect![[
-            r#"In { value: Path(Path { path: [Ident { name: "x", span: 0..1 }], is_absolute: false, span: 0..1 }), collection: Tuple([(None, Immediate(Int(1))), (None, Immediate(Int(2)))]) }"#
+            r#"In { value: Path(Path { path: [Ident { name: "x", span: 0..1 }], is_absolute: false, span: 0..1 }), collection: Tuple { fields: [(None, Immediate { value: Int(1), span: 7..8 }), (None, Immediate { value: Int(2), span: 10..11 })], span: 5..13 }, span: 0..13 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"x in [ 1, 2 ] in { true, false }"#),
         expect_test::expect![[
-            r#"In { value: Path(Path { path: [Ident { name: "x", span: 0..1 }], is_absolute: false, span: 0..1 }), collection: In { value: Array([Immediate(Int(1)), Immediate(Int(2))]), collection: Tuple([(None, Immediate(Bool(true))), (None, Immediate(Bool(false)))]) } }"#
+            r#"In { value: Path(Path { path: [Ident { name: "x", span: 0..1 }], is_absolute: false, span: 0..1 }), collection: In { value: Array { elements: [Immediate { value: Int(1), span: 7..8 }, Immediate { value: Int(2), span: 10..11 }], span: 5..13 }, collection: Tuple { fields: [(None, Immediate { value: Bool(true), span: 19..23 }), (None, Immediate { value: Bool(false), span: 25..30 })], span: 17..32 }, span: 5..32 }, span: 0..32 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"x as int in { 1, 2 }"#),
         expect_test::expect![[
-            r#"In { value: Cast { value: Path(Path { path: [Ident { name: "x", span: 0..1 }], is_absolute: false, span: 0..1 }), ty: Int }, collection: Tuple([(None, Immediate(Int(1))), (None, Immediate(Int(2)))]) }"#
+            r#"In { value: Cast { value: Path(Path { path: [Ident { name: "x", span: 0..1 }], is_absolute: false, span: 0..1 }), ty: Primitive { kind: Int, span: 5..8 }, span: 0..8 }, collection: Tuple { fields: [(None, Immediate { value: Int(1), span: 14..15 }), (None, Immediate { value: Int(2), span: 17..18 })], span: 12..20 }, span: 0..20 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"[1] in foo() in [[1]]"#),
         expect_test::expect![[
-            r#"In { value: Array([Immediate(Int(1))]), collection: In { value: Call { name: Path { path: [Ident { name: "foo", span: 7..10 }], is_absolute: false, span: 7..10 }, args: [] }, collection: Array([Array([Immediate(Int(1))])]) } }"#
+            r#"In { value: Array { elements: [Immediate { value: Int(1), span: 1..2 }], span: 0..3 }, collection: In { value: Call { name: Path { path: [Ident { name: "foo", span: 7..10 }], is_absolute: false, span: 7..10 }, args: [], span: 7..12 }, collection: Array { elements: [Array { elements: [Immediate { value: Int(1), span: 18..19 }], span: 17..20 }], span: 16..21 }, span: 7..21 }, span: 0..21 }"#
         ]],
     );
 
@@ -1434,7 +1450,7 @@ solve minimize mid;
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Let { name: Ident { name: "low_val", span: 5..12 }, ty: Some(Real), init: Some(Immediate(Real(1.23))), span: 1..26 }, Let { name: Ident { name: "high_val", span: 31..39 }, ty: None, init: Some(Immediate(Real(4.56))), span: 27..47 }, Constraint { expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "mid", span: 112..115 }], is_absolute: false, span: 112..115 }), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "low_val", span: 118..125 }], is_absolute: false, span: 118..125 }), rhs: Immediate(Real(2.0)) } }, span: 101..132 }, Constraint { expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "mid", span: 144..147 }], is_absolute: false, span: 144..147 }), rhs: Path(Path { path: [Ident { name: "high_val", span: 150..158 }], is_absolute: false, span: 150..158 }) }, span: 133..159 }, Solve { directive: Minimize(Path { path: [Ident { name: "mid", span: 176..179 }], is_absolute: false, span: 176..179 }), span: 161..180 }]"#
+            r#"[Let { name: Ident { name: "low_val", span: 5..12 }, ty: Some(Primitive { kind: Real, span: 14..18 }), init: Some(Immediate { value: Real(1.23), span: 21..25 }), span: 1..26 }, Let { name: Ident { name: "high_val", span: 31..39 }, ty: None, init: Some(Immediate { value: Real(4.56), span: 42..46 }), span: 27..47 }, Constraint { expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "mid", span: 112..115 }], is_absolute: false, span: 112..115 }), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "low_val", span: 118..125 }], is_absolute: false, span: 118..125 }), rhs: Immediate { value: Real(2.0), span: 128..131 }, span: 118..131 }, span: 112..131 }, span: 101..132 }, Constraint { expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "mid", span: 144..147 }], is_absolute: false, span: 144..147 }), rhs: Path(Path { path: [Ident { name: "high_val", span: 150..158 }], is_absolute: false, span: 150..158 }), span: 144..158 }, span: 133..159 }, Solve { directive: Minimize(Path { path: [Ident { name: "mid", span: 176..179 }], is_absolute: false, span: 176..179 }), span: 161..180 }]"#
         ]],
     );
 }
@@ -1469,7 +1485,7 @@ let low = 1.0;
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Solve { directive: Maximize(Path { path: [Ident { name: "low", span: 16..19 }], is_absolute: false, span: 16..19 }), span: 1..20 }, Constraint { expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "low", span: 32..35 }], is_absolute: false, span: 32..35 }), rhs: Path(Path { path: [Ident { name: "high", span: 38..42 }], is_absolute: false, span: 38..42 }) }, span: 21..43 }, Let { name: Ident { name: "high", span: 48..52 }, ty: None, init: Some(Immediate(Real(2.0))), span: 44..59 }, Solve { directive: Satisfy, span: 60..74 }, Let { name: Ident { name: "low", span: 79..82 }, ty: None, init: Some(Immediate(Real(1.0))), span: 75..89 }]"#
+            r#"[Solve { directive: Maximize(Path { path: [Ident { name: "low", span: 16..19 }], is_absolute: false, span: 16..19 }), span: 1..20 }, Constraint { expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "low", span: 32..35 }], is_absolute: false, span: 32..35 }), rhs: Path(Path { path: [Ident { name: "high", span: 38..42 }], is_absolute: false, span: 38..42 }), span: 32..42 }, span: 21..43 }, Let { name: Ident { name: "high", span: 48..52 }, ty: None, init: Some(Immediate { value: Real(2.0), span: 55..58 }), span: 44..59 }, Solve { directive: Satisfy, span: 60..74 }, Let { name: Ident { name: "low", span: 79..82 }, ty: None, init: Some(Immediate { value: Real(1.0), span: 85..88 }), span: 75..89 }]"#
         ]],
     );
 }
@@ -1495,7 +1511,7 @@ fn test_parse_str_to_ast() {
     check(
         &format!("{:?}", parse_str_to_ast("let x = 5;", "my_file")),
         expect_test::expect![[
-            r#"Ok([Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Immediate(Int(5))), span: 0..10 }])"#
+            r#"Ok([Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Immediate { value: Int(5), span: 8..9 }), span: 0..10 }])"#
         ]],
     );
     check(
@@ -1516,7 +1532,7 @@ fn big_ints() {
             "let blah = 1234567890123456789012345678901234567890;"
         ),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate(BigInt(1234567890123456789012345678901234567890))), span: 0..52 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate { value: BigInt(1234567890123456789012345678901234567890), span: 11..51 }), span: 0..52 }"#
         ]],
     );
     check(
@@ -1526,7 +1542,7 @@ fn big_ints() {
         ),
         // Confirmed by using the Python REPL to convert from hex to dec...
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate(BigInt(5421732407698601623698172315373246806734))), span: 0..47 }"#
+            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate { value: BigInt(5421732407698601623698172315373246806734), span: 11..46 }), span: 0..47 }"#
         ]],
     );
     check(
@@ -1536,9 +1552,7 @@ fn big_ints() {
             0b01001001010110101010101001010101010010100100101001010010100100100001010"
         ),
         // Again confirmed using the Python REPL.  Handy.
-        expect_test::expect![
-            "BinaryOp { op: Add, lhs: Immediate(BigInt(31076614848392666458794)), rhs: Immediate(BigInt(676572722683907229962)) }"
-        ],
+        expect_test::expect!["BinaryOp { op: Add, lhs: Immediate { value: BigInt(31076614848392666458794), span: 0..77 }, rhs: Immediate { value: BigInt(676572722683907229962), span: 80..153 }, span: 0..153 }"]
     );
 }
 
@@ -1555,7 +1569,7 @@ interface Foo {
     check(
         &run_parser!(interface_decl(expr()), src),
         expect_test::expect![[
-            r#"Interface(InterfaceDecl { name: Ident { name: "Foo", span: 11..14 }, functions: [FnSig { name: Ident { name: "foo", span: 24..27 }, params: [(Ident { name: "x", span: 28..29 }, Real), (Ident { name: "y", span: 37..38 }, Array { ty: Int, range: Immediate(Int(5)) })], return_type: Real, span: 21..55 }, FnSig { name: Ident { name: "bar", span: 64..67 }, params: [(Ident { name: "x", span: 68..69 }, Bool)], return_type: Real, span: 61..85 }, FnSig { name: Ident { name: "baz", span: 94..97 }, params: [], return_type: Tuple([(None, Int), (None, Real)]), span: 91..116 }], span: 1..119 })"#
+            r#"Interface(InterfaceDecl { name: Ident { name: "Foo", span: 11..14 }, functions: [FnSig { name: Ident { name: "foo", span: 24..27 }, params: [(Ident { name: "x", span: 28..29 }, Primitive { kind: Real, span: 31..35 }), (Ident { name: "y", span: 37..38 }, Array { ty: Primitive { kind: Int, span: 40..43 }, range: Immediate { value: Int(5), span: 44..45 }, span: 40..46 })], return_type: Primitive { kind: Real, span: 51..55 }, span: 21..55 }, FnSig { name: Ident { name: "bar", span: 64..67 }, params: [(Ident { name: "x", span: 68..69 }, Primitive { kind: Bool, span: 71..75 })], return_type: Primitive { kind: Real, span: 81..85 }, span: 61..85 }, FnSig { name: Ident { name: "baz", span: 94..97 }, params: [], return_type: Tuple { fields: [(None, Primitive { kind: Int, span: 105..108 }), (None, Primitive { kind: Real, span: 110..114 })], span: 103..116 }, span: 91..116 }], span: 1..119 })"#
         ]],
     );
 
@@ -1572,7 +1586,7 @@ fn contract_test() {
     check(
         &run_parser!(contract_decl(expr()), "contract Foo(0) {}"),
         expect_test::expect![[
-            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: Immediate(Int(0)), interfaces: [], functions: [], span: 0..18 })"#
+            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: Immediate { value: Int(0), span: 13..14 }, interfaces: [], functions: [], span: 0..18 })"#
         ]],
     );
 
@@ -1582,7 +1596,7 @@ fn contract_test() {
             "contract Foo(if true {0} else {1}) {}"
         ),
         expect_test::expect![[
-            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: If { condition: Immediate(Bool(true)), then_block: Block { statements: [], final_expr: Immediate(Int(0)) }, else_block: Block { statements: [], final_expr: Immediate(Int(1)) } }, interfaces: [], functions: [], span: 0..37 })"#
+            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: If { condition: Immediate { value: Bool(true), span: 16..20 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(0), span: 22..23 }, span: 21..24 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 31..32 }, span: 30..33 }, span: 13..33 }, interfaces: [], functions: [], span: 0..37 })"#
         ]],
     );
 
@@ -1592,7 +1606,7 @@ fn contract_test() {
             "contract Foo(0) implements X::Bar, ::Y::Baz {}"
         ),
         expect_test::expect![[
-            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: Immediate(Int(0)), interfaces: [Path { path: [Ident { name: "X", span: 27..28 }, Ident { name: "Bar", span: 30..33 }], is_absolute: false, span: 27..33 }, Path { path: [Ident { name: "Y", span: 37..38 }, Ident { name: "Baz", span: 40..43 }], is_absolute: true, span: 35..43 }], functions: [], span: 0..46 })"#
+            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: Immediate { value: Int(0), span: 13..14 }, interfaces: [Path { path: [Ident { name: "X", span: 27..28 }, Ident { name: "Bar", span: 30..33 }], is_absolute: false, span: 27..33 }, Path { path: [Ident { name: "Y", span: 37..38 }, Ident { name: "Baz", span: 40..43 }], is_absolute: true, span: 35..43 }], functions: [], span: 0..46 })"#
         ]],
     );
 
@@ -1602,7 +1616,7 @@ fn contract_test() {
             "contract Foo(0) implements Bar { fn baz(x: real) -> int; }"
         ),
         expect_test::expect![[
-            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: Immediate(Int(0)), interfaces: [Path { path: [Ident { name: "Bar", span: 27..30 }], is_absolute: false, span: 27..30 }], functions: [FnSig { name: Ident { name: "baz", span: 36..39 }, params: [(Ident { name: "x", span: 40..41 }, Real)], return_type: Int, span: 33..55 }], span: 0..58 })"#
+            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: Immediate { value: Int(0), span: 13..14 }, interfaces: [Path { path: [Ident { name: "Bar", span: 27..30 }], is_absolute: false, span: 27..30 }], functions: [FnSig { name: Ident { name: "baz", span: 36..39 }, params: [(Ident { name: "x", span: 40..41 }, Primitive { kind: Real, span: 43..47 })], return_type: Primitive { kind: Int, span: 52..55 }, span: 33..55 }], span: 0..58 })"#
         ]],
     );
 
@@ -1630,7 +1644,7 @@ fn extern_test() {
     check(
         &run_parser!(extern_decl(expr()), "extern { fn foo() -> string; }"),
         expect_test::expect![[
-            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: 12..15 }, params: [], return_type: String, span: 9..27 }], span: 0..30 }"#
+            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: 12..15 }, params: [], return_type: Primitive { kind: String, span: 21..27 }, span: 9..27 }], span: 0..30 }"#
         ]],
     );
     check(
@@ -1639,7 +1653,7 @@ fn extern_test() {
             "extern { fn foo(x: int, y: real) -> int; }"
         ),
         expect_test::expect![[
-            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: 12..15 }, params: [(Ident { name: "x", span: 16..17 }, Int), (Ident { name: "y", span: 24..25 }, Real)], return_type: Int, span: 9..39 }], span: 0..42 }"#
+            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: 12..15 }, params: [(Ident { name: "x", span: 16..17 }, Primitive { kind: Int, span: 19..22 }), (Ident { name: "y", span: 24..25 }, Primitive { kind: Real, span: 27..31 })], return_type: Primitive { kind: Int, span: 36..39 }, span: 9..39 }], span: 0..42 }"#
         ]],
     );
     check(
@@ -1648,7 +1662,7 @@ fn extern_test() {
             "extern { fn foo() -> int; fn bar() -> real; }"
         ),
         expect_test::expect![[
-            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: 12..15 }, params: [], return_type: Int, span: 9..24 }, FnSig { name: Ident { name: "bar", span: 29..32 }, params: [], return_type: Real, span: 26..42 }], span: 0..45 }"#
+            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: 12..15 }, params: [], return_type: Primitive { kind: Int, span: 21..24 }, span: 9..24 }, FnSig { name: Ident { name: "bar", span: 29..32 }, params: [], return_type: Primitive { kind: Real, span: 38..42 }, span: 26..42 }], span: 0..45 }"#
         ]],
     );
     check(

--- a/yurtc/src/span.rs
+++ b/yurtc/src/span.rs
@@ -1,0 +1,9 @@
+pub(super) type Span = std::ops::Range<usize>;
+
+pub(super) fn empty_span() -> Span {
+    0..0
+}
+
+pub(super) trait Spanned {
+    fn span(&self) -> &Span;
+}

--- a/yurtc/src/types.rs
+++ b/yurtc/src/types.rs
@@ -1,15 +1,47 @@
-use crate::ast::Ident;
-use crate::error::Span;
+use crate::{
+    ast::Ident,
+    span::{Span, Spanned},
+};
 
 #[derive(Clone, Debug, PartialEq)]
-pub(super) enum Type<Path, Expr> {
+pub(super) enum PrimitiveKind {
     Bool,
     Int,
     Real,
     String,
-    Array { ty: Box<Self>, range: Expr },
-    Tuple(Vec<(Option<Ident>, Self)>),
-    CustomType(Path),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) enum Type<Path, Expr> {
+    Primitive {
+        kind: PrimitiveKind,
+        span: Span,
+    },
+    Array {
+        ty: Box<Self>,
+        range: Expr,
+        span: Span,
+    },
+    Tuple {
+        fields: Vec<(Option<Ident>, Self)>,
+        span: Span,
+    },
+    CustomType {
+        path: Path,
+        span: Span,
+    },
+}
+
+impl<Path, Expr> Spanned for Type<Path, Expr> {
+    fn span(&self) -> &Span {
+        use Type::*;
+        match &self {
+            Primitive { span, .. }
+            | Array { span, .. }
+            | Tuple { span, .. }
+            | CustomType { span, .. } => span,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -19,10 +51,22 @@ pub(super) struct EnumDecl {
     pub(super) span: Span,
 }
 
+impl Spanned for EnumDecl {
+    fn span(&self) -> &Span {
+        &self.span
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(super) struct FnSig<Type> {
     pub(super) name: Ident,
     pub(super) params: Vec<(Ident, Type)>,
     pub(super) return_type: Type,
     pub(super) span: Span,
+}
+
+impl<Type> Spanned for FnSig<Type> {
+    fn span(&self) -> &Span {
+        &self.span
+    }
 }


### PR DESCRIPTION
Closes #196 

This populates all AST nodes, including expressions and types, with spans. These will be useful for error reporting in later stages of the compiler. Also added a `Spanned` trait to be implemented for as many data structures as possible.

I spot checked these to the extent possible. They are automatically tested as part of the unit tests.