### PR TITLE
Update versions of Rust tools used by Trunk to the latest versions.

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -9,12 +9,12 @@ plugins:
 lint:
   enabled:
     - actionlint@1.6.25
-    - clippy@1.65.0
+    - clippy@1.72.0
     - git-diff-check
     - gitleaks@8.17.0
     - markdownlint@0.35.0
     - prettier@3.0.2
-    - rustfmt@1.65.0
+    - rustfmt@1.72.0
     - taplo@0.8.1
     - yamllint@1.32.0
 runtimes:


### PR DESCRIPTION
1.65 -> 1.72.