### PR TITLE
Multi-span error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -76,7 +76,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -91,6 +91,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72fe02fc62033df9ba41cba57ee19acf5e742511a140c7dbc3a873e19a19a1bd"
 dependencies = [
+ "concolor",
  "unicode-width",
  "yansi",
 ]
@@ -106,6 +107,18 @@ name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "cc"
@@ -167,6 +180,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "concolor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b946244a988c390a94667ae0e3958411fa40cc46ea496a929b263d883f5f9c3"
+dependencies = [
+ "bitflags 1.3.2",
+ "concolor-query",
+ "is-terminal",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "dissimilar"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +210,27 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "errno"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "expect-test"
@@ -215,6 +269,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +299,12 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "logos"
@@ -366,6 +443,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
+name = "rustix"
+version = "0.38.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "stacker"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,11 +565,35 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -488,14 +602,20 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -505,9 +625,21 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -517,9 +649,21 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -529,9 +673,21 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -562,6 +718,7 @@ dependencies = [
  "regex",
  "test_bin",
  "thiserror",
+ "yansi",
 ]
 
 [[package]]

--- a/yurtc/Cargo.toml
+++ b/yurtc/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 ansi_term = "0.12"
 anyhow = "1.0"
-ariadne = "0.3"
+ariadne = { version = "0.3", features = ["auto-color"] }
 chumsky = { workspace = true }
 clap = { version = "4.3", features = ["cargo"] }
 expect-test = "1.4"
@@ -19,3 +19,4 @@ num-traits = "0.2"
 regex = "1.9"
 test_bin = "0.4"
 thiserror = "1.0"
+yansi = "0.5"

--- a/yurtc/src/error.rs
+++ b/yurtc/src/error.rs
@@ -1,125 +1,33 @@
-use crate::{
-    lexer::Token,
-    span::{Span, Spanned},
-};
-use ariadne::{Color, Fmt, Label, Report, ReportKind, Source};
+mod compile_error;
+mod lex_error;
+mod parse_error;
+
+use crate::span::Span;
+use ariadne::{Label, Report, ReportKind, Source};
 use chumsky::prelude::*;
+pub(super) use compile_error::CompileError;
+pub(super) use lex_error::LexError;
+pub(super) use parse_error::ParseError;
 use thiserror::Error;
+use yansi::{Color, Style};
 
-/// An error originating from the lexer
-#[derive(Error, Debug, Clone, PartialEq, Default)]
-pub(super) enum LexError {
-    #[default]
-    #[error("invalid token")]
-    InvalidToken,
+pub(super) struct ErrorLabel {
+    message: String,
+    span: Span,
+    color: Color,
 }
 
-/// An error originating from the parser
-#[derive(Error, Debug, PartialEq, Clone)]
-pub(super) enum ParseError<'a> {
-    #[error("{}", format_expected_found_error(&mut expected.clone(), found))]
-    ExpectedFound {
-        span: Span,
-        expected: Vec<Option<Token<'a>>>,
-        found: Option<Token<'a>>,
-    },
-    #[error("expected identifier, found keyword \"{keyword}\"")]
-    KeywordAsIdent { span: Span, keyword: Token<'a> },
-    #[error("type annotation or initializer needed for variable \"{name}\"")]
-    UntypedVariable { span: Span, name: String },
-    #[error("empty array expressions are not allowed")]
-    EmptyArrayExpr { span: Span },
-    #[error("invalid integer value \"{}\" for tuple index", index)]
-    InvalidIntegerTupleIndex { span: Span, index: &'a str },
-    #[error("invalid value \"{}\" for tuple index", index)]
-    InvalidTupleIndex { span: Span, index: Token<'a> },
-    #[error("empty tuple expressions are not allowed")]
-    EmptyTupleExpr { span: Span },
-    #[error("empty tuple types are not allowed")]
-    EmptyTupleType { span: Span },
-}
-
-#[derive(Error, Debug, PartialEq, Clone)]
-pub(super) enum CompileError {
-    #[error("internal error: {msg}")]
-    Internal { span: Span, msg: &'static str },
-    #[error("symbol \"{sym}\" has already been declared")]
-    NameClash {
-        sym: String,
-        span: Span,
-        prev_span: Span,
-    },
-}
-
-fn format_expected_found_error<'a>(
-    expected: &mut Vec<Option<Token<'a>>>,
-    found: &Option<Token<'a>>,
-) -> String {
-    let format_optional_token = |token: &Option<Token>| match &token {
-        Some(token) => format!("\"{token}\""),
-        None => "end of input".to_string(),
-    };
-
-    format!(
-        "found {} but expected {}",
-        format_optional_token(found),
-        match &expected[..] {
-            [] => "something else".to_string(),
-            [expected] => format_optional_token(expected),
-            _ => {
-                // Make sure that the list of expected tokens is printed in a deterministic order
-                expected.sort();
-
-                let mut token_list = "".to_string();
-                for expected in &expected[..expected.len() - 1] {
-                    token_list = format!("{token_list}{}, ", format_optional_token(expected));
-                }
-                format!(
-                    "{token_list} or {}",
-                    format_optional_token(expected.last().unwrap())
-                )
-            }
-        }
-    )
-}
-
-/// Implement the `ParseError` trait from Chumsky for `ParseError`
-impl<'a> chumsky::Error<Token<'a>> for ParseError<'a> {
-    type Span = Span;
-    type Label = ();
-
-    fn expected_input_found<Iter: IntoIterator<Item = Option<Token<'a>>>>(
-        span: Span,
-        expected: Iter,
-        found: Option<Token<'a>>,
-    ) -> Self {
-        Self::ExpectedFound {
-            span,
-            expected: expected.into_iter().collect(),
-            found,
-        }
+impl ErrorLabel {
+    pub(super) fn message(&self) -> &String {
+        &self.message
     }
 
-    // Not currently doing anything with the label
-    fn with_label(self, _: Self::Label) -> Self {
-        self
+    pub(super) fn span(&self) -> &Span {
+        &self.span
     }
 
-    // Merge two errors that point to the same input together, combining their information. Only
-    // relevant for the `ExpectedFound` error for now.
-    fn merge(mut self, mut other: Self) -> Self {
-        #[allow(clippy::single_match)]
-        match (&mut self, &mut other) {
-            (
-                Self::ExpectedFound { expected, .. },
-                Self::ExpectedFound {
-                    expected: expected_other,
-                    ..
-                },
-            ) => expected.append(expected_other),
-            _ => {}
-        }
-        self
+    pub(super) fn color(&self) -> &Color {
+        &self.color
     }
 }
 
@@ -134,45 +42,112 @@ pub(super) enum Error<'a> {
     Compile { error: CompileError },
 }
 
-impl<'a> Spanned for Error<'a> {
-    fn span(&self) -> &Span {
+/// Types that implement this trait can be pretty printed to the terminal using `ariadne` by
+/// calling the `print()` method.
+pub(super) trait ReportableError
+where
+    Self: std::fmt::Display,
+{
+    /// A list of error labels for emitting diagnostics at multiple span locations
+    fn labels(&self) -> Vec<ErrorLabel>;
+
+    /// A helpful "note" about the error
+    fn note(&self) -> Option<String>;
+
+    /// A unique error code
+    fn code(&self) -> Option<String>;
+
+    /// Additional information to help the user address the diagnostic
+    fn help(&self) -> Option<String>;
+
+    /// Pretty print an error to the terminal
+    fn print(&self, filename: &str, source: &str) {
+        let mut report_builder = Report::build(ReportKind::Error, filename, 0)
+            .with_message(format!("{}", Style::default().bold().paint(self)))
+            .with_labels({
+                let mut labels = vec![];
+                for label in self.labels() {
+                    let style = Style::new(label.color).bold();
+                    labels.push(
+                        Label::new((filename, label.span().start()..label.span().end()))
+                            .with_message(style.paint(label.message()))
+                            .with_color(*label.color()),
+                    );
+                }
+                labels
+            });
+
+        if let Some(code) = self.code() {
+            report_builder = report_builder.with_code(code)
+        };
+
+        if let Some(note) = self.note() {
+            report_builder = report_builder.with_note(note)
+        };
+
+        if let Some(help) = self.help() {
+            report_builder = report_builder.with_help(help)
+        };
+
+        report_builder
+            .finish()
+            .print((filename, Source::from(source)))
+            .unwrap();
+    }
+}
+
+/// Types that implement this trait can be printed
+impl<'a> ReportableError for Error<'a> {
+    fn labels(&self) -> Vec<ErrorLabel> {
         use Error::*;
         match self {
-            Lex { span, .. } => span,
-            Parse { error } => match error {
-                ParseError::ExpectedFound { span, .. } => span,
-                ParseError::KeywordAsIdent { span, .. } => span,
-                ParseError::UntypedVariable { span, .. } => span,
-                ParseError::EmptyArrayExpr { span } => span,
-                ParseError::InvalidIntegerTupleIndex { span, .. } => span,
-                ParseError::InvalidTupleIndex { span, .. } => span,
-                ParseError::EmptyTupleExpr { span } => span,
-                ParseError::EmptyTupleType { span } => span,
+            Lex { error, span } => match error {
+                // For lex errors, insert the labels here for now because we don't have access to
+                // `span` in `LexError` just yet.
+                LexError::InvalidToken => vec![ErrorLabel {
+                    message: "invalid token".into(),
+                    span: span.clone(),
+                    color: Color::Red,
+                }],
             },
-            Compile { error } => match error {
-                CompileError::Internal { span, .. } => span,
-                CompileError::NameClash { span, .. } => span,
-            },
+            Parse { error } => error.labels(),
+            Compile { error } => error.labels(),
+        }
+    }
+
+    fn note(&self) -> Option<String> {
+        use Error::*;
+        match self {
+            Lex { error, .. } => error.note(),
+            Parse { error } => error.note(),
+            Compile { error } => error.note(),
+        }
+    }
+
+    fn code(&self) -> Option<String> {
+        use Error::*;
+        match self {
+            Lex { error, .. } => error.code().map(|code| format!("L{}", code)),
+            Parse { error } => error.code().map(|code| format!("P{}", code)),
+            Compile { error } => error.code().map(|code| format!("C{}", code)),
+        }
+    }
+
+    fn help(&self) -> Option<String> {
+        use Error::*;
+        match self {
+            Lex { error, .. } => error.help(),
+            Parse { error } => error.help(),
+            Compile { error } => error.help(),
         }
     }
 }
 
 /// Print a list of [`Error`] using the `ariadne` library
-pub(super) fn print_on_failure(filename: &str, source: &str, errs: &Vec<Error>) -> usize {
+pub(super) fn print_errors(errs: &Vec<Error>, filename: &str, source: &str) {
     for err in errs {
-        let span = err.span();
-        Report::build(ReportKind::Error, filename, span.start())
-            .with_label(
-                Label::new((filename, span.start()..span.end()))
-                    .with_message(format!("{}", err.fg(Color::Red)))
-                    .with_color(Color::Red),
-            )
-            .finish()
-            .print((filename, Source::from(source)))
-            .unwrap();
+        err.print(filename, source);
     }
-
-    errs.len()
 }
 
 /// A simple warpper around `anyhow::bail!` that prints a different message based on a the number
@@ -180,10 +155,10 @@ pub(super) fn print_on_failure(filename: &str, source: &str, errs: &Vec<Error>) 
 macro_rules! yurtc_bail {
     ($number_of_errors: expr, $filename: expr) => {
         if $number_of_errors == 1 {
-            anyhow::bail!("could not compile \"{}\" due to previous error", $filename)
+            anyhow::bail!("could not compile `{}` due to previous error", $filename)
         } else {
             anyhow::bail!(
-                "could not compile \"{}\" due to {} previous errors",
+                "could not compile `{}` due to {} previous errors",
                 $filename,
                 $number_of_errors
             )

--- a/yurtc/src/error/compile_error.rs
+++ b/yurtc/src/error/compile_error.rs
@@ -1,0 +1,69 @@
+use crate::{
+    error::{ErrorLabel, ReportableError},
+    span::Span,
+};
+use thiserror::Error;
+use yansi::Color;
+
+#[derive(Error, Debug, PartialEq, Clone)]
+pub(crate) enum CompileError {
+    #[error("internal error: {msg}")]
+    Internal { span: Span, msg: &'static str },
+    #[error("symbol `{sym}` has already been declared")]
+    NameClash {
+        sym: String,
+        span: Span,
+        prev_span: Span,
+    },
+}
+
+impl ReportableError for CompileError {
+    fn labels(&self) -> Vec<ErrorLabel> {
+        use CompileError::*;
+        match self {
+            NameClash {
+                sym,
+                span,
+                prev_span,
+            } => {
+                vec![
+                    ErrorLabel {
+                        message: format!("previous definition of the value `{sym}` here"),
+                        span: prev_span.clone(),
+                        color: Color::Blue,
+                    },
+                    ErrorLabel {
+                        message: format!("`{sym}` redefined here"),
+                        span: span.clone(),
+                        color: Color::Red,
+                    },
+                ]
+            }
+            Internal { span, msg } => {
+                vec![ErrorLabel {
+                    message: msg.to_string(),
+                    span: span.clone(),
+                    color: Color::Red,
+                }]
+            }
+        }
+    }
+
+    fn note(&self) -> Option<String> {
+        use CompileError::*;
+        match self {
+            NameClash { sym, .. } => {
+                Some(format!("`{sym}` must be defined only once in this scope"))
+            }
+            _ => None,
+        }
+    }
+
+    fn code(&self) -> Option<String> {
+        None
+    }
+
+    fn help(&self) -> Option<String> {
+        None
+    }
+}

--- a/yurtc/src/error/lex_error.rs
+++ b/yurtc/src/error/lex_error.rs
@@ -1,0 +1,28 @@
+use crate::error::{ErrorLabel, ReportableError};
+use thiserror::Error;
+
+/// An error originating from the lexer
+#[derive(Error, Debug, Clone, PartialEq, Default)]
+pub(crate) enum LexError {
+    #[default]
+    #[error("invalid token")]
+    InvalidToken,
+}
+
+impl ReportableError for LexError {
+    fn labels(&self) -> Vec<ErrorLabel> {
+        Vec::new()
+    }
+
+    fn note(&self) -> Option<String> {
+        None
+    }
+
+    fn code(&self) -> Option<String> {
+        None
+    }
+
+    fn help(&self) -> Option<String> {
+        None
+    }
+}

--- a/yurtc/src/error/parse_error.rs
+++ b/yurtc/src/error/parse_error.rs
@@ -1,0 +1,195 @@
+use crate::{
+    error::{ErrorLabel, ReportableError},
+    lexer::Token,
+    span::Span,
+};
+use thiserror::Error;
+use yansi::Color;
+
+/// An error originating from the parser
+#[derive(Error, Debug, PartialEq, Clone)]
+pub(crate) enum ParseError<'a> {
+    #[error("{}", format_expected_found_error(&mut expected.clone(), found))]
+    ExpectedFound {
+        span: Span,
+        expected: Vec<Option<Token<'a>>>,
+        found: Option<Token<'a>>,
+    },
+    #[error("expected identifier, found keyword `{keyword}`")]
+    KeywordAsIdent { span: Span, keyword: Token<'a> },
+    #[error("type annotation or initializer needed for variable `{name}`")]
+    UntypedVariable { span: Span, name: String },
+    #[error("empty array expressions are not allowed")]
+    EmptyArrayExpr { span: Span },
+    #[error("invalid integer `{}` as tuple index", index)]
+    InvalidIntegerTupleIndex { span: Span, index: &'a str },
+    #[error("invalid value `{}` as tuple index", index)]
+    InvalidTupleIndex { span: Span, index: Token<'a> },
+    #[error("empty tuple expressions are not allowed")]
+    EmptyTupleExpr { span: Span },
+    #[error("empty tuple types are not allowed")]
+    EmptyTupleType { span: Span },
+}
+
+/// Implement the `ParseError` trait from Chumsky for `ParseError`
+impl<'a> chumsky::Error<Token<'a>> for ParseError<'a> {
+    type Span = Span;
+    type Label = ();
+
+    fn expected_input_found<Iter: IntoIterator<Item = Option<Token<'a>>>>(
+        span: Span,
+        expected: Iter,
+        found: Option<Token<'a>>,
+    ) -> Self {
+        Self::ExpectedFound {
+            span,
+            expected: expected.into_iter().collect(),
+            found,
+        }
+    }
+
+    // Not currently doing anything with the label
+    fn with_label(self, _: Self::Label) -> Self {
+        self
+    }
+
+    // Merge two errors that point to the same input together, combining their information. Only
+    // relevant for the `ExpectedFound` error for now.
+    fn merge(mut self, mut other: Self) -> Self {
+        #[allow(clippy::single_match)]
+        match (&mut self, &mut other) {
+            (
+                Self::ExpectedFound { expected, .. },
+                Self::ExpectedFound {
+                    expected: expected_other,
+                    ..
+                },
+            ) => expected.append(expected_other),
+            _ => {}
+        }
+        self
+    }
+}
+
+impl ReportableError for ParseError<'_> {
+    fn labels(&self) -> Vec<ErrorLabel> {
+        use ParseError::*;
+        match self {
+            ExpectedFound { span, expected, .. } => {
+                vec![ErrorLabel {
+                    message: format_expected_tokens_message(&mut expected.clone()),
+                    span: span.clone(),
+                    color: Color::Red,
+                }]
+            }
+            KeywordAsIdent { span, .. } => {
+                vec![ErrorLabel {
+                    message: "expected identifier, found keyword".to_string(),
+                    span: span.clone(),
+                    color: Color::Red,
+                }]
+            }
+            UntypedVariable { span, .. } => {
+                vec![ErrorLabel {
+                    message: "type annotation or initializer needed".to_string(),
+                    span: span.clone(),
+                    color: Color::Red,
+                }]
+            }
+            EmptyArrayExpr { span } => {
+                vec![ErrorLabel {
+                    message: "empty array expression found".to_string(),
+                    span: span.clone(),
+                    color: Color::Red,
+                }]
+            }
+            InvalidIntegerTupleIndex { span, .. } => {
+                vec![ErrorLabel {
+                    message: "invalid integer as tuple index".to_string(),
+                    span: span.clone(),
+                    color: Color::Red,
+                }]
+            }
+            InvalidTupleIndex { span, .. } => {
+                vec![ErrorLabel {
+                    message: "invalid value as tuple index".to_string(),
+                    span: span.clone(),
+                    color: Color::Red,
+                }]
+            }
+            EmptyTupleExpr { span } => {
+                vec![ErrorLabel {
+                    message: "empty tuple expression found".to_string(),
+                    span: span.clone(),
+                    color: Color::Red,
+                }]
+            }
+            EmptyTupleType { span } => {
+                vec![ErrorLabel {
+                    message: "empty tuple type found".to_string(),
+                    span: span.clone(),
+                    color: Color::Red,
+                }]
+            }
+        }
+    }
+
+    fn note(&self) -> Option<String> {
+        None
+    }
+
+    fn code(&self) -> Option<String> {
+        None
+    }
+
+    fn help(&self) -> Option<String> {
+        use ParseError::*;
+        match self {
+            UntypedVariable { name, .. } => Some(format!(
+                "consider giving `{name}` an explicit type or an initializer"
+            )),
+            _ => None,
+        }
+    }
+}
+
+fn format_optional_token(token: &Option<Token>) -> String {
+    match &token {
+        Some(token) => format!("`{token}`"),
+        None => "\"end of input\"".into(),
+    }
+}
+
+fn format_expected_tokens_message(expected: &mut Vec<Option<Token<'_>>>) -> String {
+    format!(
+        "expected {}",
+        match &expected[..] {
+            [] => "something else".to_string(),
+            [expected] => format_optional_token(expected),
+            _ => {
+                // Make sure that the list of expected tokens is printed in a deterministic order
+                expected.sort();
+
+                let mut token_list = "".to_string();
+                for expected in &expected[..expected.len() - 1] {
+                    token_list = format!("{token_list}{}, ", format_optional_token(expected));
+                }
+                format!(
+                    "{token_list}or {}",
+                    format_optional_token(expected.last().unwrap())
+                )
+            }
+        }
+    )
+}
+
+fn format_expected_found_error<'a>(
+    expected: &mut Vec<Option<Token<'a>>>,
+    found: &Option<Token<'a>>,
+) -> String {
+    format!(
+        "{}, found {}",
+        format_expected_tokens_message(expected),
+        format_optional_token(found),
+    )
+}

--- a/yurtc/src/intent.rs
+++ b/yurtc/src/intent.rs
@@ -14,12 +14,8 @@ pub struct Intent {
 }
 
 impl Intent {
-    pub(crate) fn from_ast(ast: &[ast::Decl]) -> anyhow::Result<Self> {
-        let cnv_err = |e| anyhow::anyhow!(error::Error::Compile { error: e });
-        intermediate::IntermediateIntent::from_ast(ast)
-            .map_err(cnv_err)?
-            .compile()
-            .map_err(cnv_err)
+    pub(crate) fn from_ast(ast: &[ast::Decl]) -> Result<Self, error::CompileError> {
+        intermediate::IntermediateIntent::from_ast(ast)?.compile()
     }
 }
 

--- a/yurtc/src/main.rs
+++ b/yurtc/src/main.rs
@@ -11,29 +11,51 @@ mod span;
 mod types;
 
 fn main() -> anyhow::Result<()> {
-    let (srcs, compile_flag) = parse_cli();
-    let asts = srcs
-        .iter()
-        .map(|src| parser::parse_path_to_ast(std::path::Path::new(src), src))
-        .collect::<anyhow::Result<Vec<_>>>()?;
+    let (filename, compile_flag) = parse_cli();
+    let filepath = std::path::Path::new(&filename);
+    let source_code = std::fs::read_to_string(filepath)?;
 
-    dbg!(&asts);
+    // Lex + Parse
+    let ast = match parser::parse_str_to_ast(&source_code) {
+        Ok(ast) => ast,
+        Err(errors) => {
+            if !cfg!(test) {
+                error::print_errors(&errors, &filename, &source_code);
+            }
+            yurtc_bail!(errors.len(), filename)
+        }
+    };
 
+    // Compile ast down to a final intent
     if compile_flag {
-        let intents = asts
-            .iter()
-            .map(|ast| intent::Intent::from_ast(ast))
-            .collect::<anyhow::Result<Vec<_>>>()?;
+        let intent = match intent::Intent::from_ast(&ast) {
+            Ok(intent) => intent,
+            Err(error) => {
+                if !cfg!(test) {
+                    error::print_errors(
+                        &vec![error::Error::Compile { error }],
+                        &filename,
+                        &source_code,
+                    );
+                }
+                yurtc_bail!(1, filename)
+            }
+        };
 
-        dbg!(&intents);
+        dbg!(&intent);
+    }
+
+    // If `compile_flag` is set, there is no need to print the initial AST.
+    if !compile_flag {
+        dbg!(&ast);
     }
 
     Ok(())
 }
 
-fn parse_cli() -> (Vec<String>, bool) {
-    // This is very basic for now.  Doesn't take any options or anything, just a list of source
-    // file path strings.  It'll also just exit if `-h` or `-V` are passed, or if there's an error.
+fn parse_cli() -> (String, bool) {
+    // This is very basic for now.  It only take a single source file and a single optional flag.
+    // It'll also just exit if `-h` or `-V` are passed, or if there's an error.
     let cli = clap::command!()
         .arg(
             clap::Arg::new("compile")
@@ -44,15 +66,13 @@ fn parse_cli() -> (Vec<String>, bool) {
         .arg(
             clap::Arg::new("filename")
                 .required(true)
-                .action(clap::ArgAction::Append),
+                .action(clap::ArgAction::Set),
         )
         .get_matches();
 
-    let srcs = cli
-        .get_many::<String>("filename")
-        .map(|fs| fs.cloned().collect())
-        .unwrap();
+    let filename = cli.get_one::<String>("filename").unwrap();
+
     let compile_flag = cli.get_flag("compile");
 
-    (srcs, compile_flag)
+    (filename.clone(), compile_flag)
 }

--- a/yurtc/src/parser.rs
+++ b/yurtc/src/parser.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast, contract,
-    error::{print_on_failure, Error, ParseError},
+    error::{Error, ParseError},
     expr,
     lexer::{self, Token, KEYWORDS},
     span::{Span, Spanned},
@@ -9,33 +9,15 @@ use crate::{
 use chumsky::{prelude::*, Stream};
 use itertools::Either;
 use regex::Regex;
-use std::{fs::read_to_string, path::Path};
 
 #[cfg(test)]
 mod tests;
 
 type Ast = Vec<ast::Decl>;
 
-pub(super) fn parse_path_to_ast(path: &Path, filename: &str) -> anyhow::Result<Ast> {
-    parse_str_to_ast(&read_to_string(path)?, filename)
-}
-
-/// Parse `source` and returns an AST. Upon failure, print all compile errors and exit.
-fn parse_str_to_ast(source: &str, filename: &str) -> anyhow::Result<Ast> {
-    match parse_str_to_ast_inner(source) {
-        Ok(ast) => Ok(ast),
-        Err(errors) => {
-            if !cfg!(test) {
-                print_on_failure(filename, source, &errors);
-            }
-            yurtc_bail!(errors.len(), filename)
-        }
-    }
-}
-
 /// Parse `source` and returns an AST. Upon failure, return a vector of all compile errors
 /// encountered.
-fn parse_str_to_ast_inner(source: &str) -> Result<Ast, Vec<Error>> {
+pub(super) fn parse_str_to_ast(source: &str) -> Result<Ast, Vec<Error>> {
     let mut errors = vec![];
 
     // Lex the input into tokens and spans. Also collect any lex errors encountered.

--- a/yurtc/src/parser/tests.rs
+++ b/yurtc/src/parser/tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::Error,
+    error::ReportableError,
     lexer::{self, KEYWORDS},
     parser::*,
 };
@@ -17,12 +17,27 @@ macro_rules! run_parser {
                 "{}",
                 // Print each error on one line. For each error, start with the span.
                 errors.iter().fold(String::new(), |acc, error| {
-                    let span = Error::Parse {
-                        error: error.clone(),
+                    let mut all_diagnostics = format!("{}{}", acc, error);
+                    all_diagnostics = format!(
+                        "{}{}",
+                        all_diagnostics,
+                        error.labels().iter().fold(String::new(), |acc, label| {
+                            format!(
+                                "\n{}@{}..{}: {}\n",
+                                acc,
+                                label.span().start,
+                                label.span().end,
+                                label.message()
+                            )
+                        })
+                    );
+                    if let Some(note) = error.note() {
+                        all_diagnostics = format!("{}{}", all_diagnostics, note);
                     }
-                    .span()
-                    .clone();
-                    format!("{}@{}..{}: {}\n", acc, span.start, span.end(), error)
+                    if let Some(help) = error.help() {
+                        all_diagnostics = format!("{}{}", all_diagnostics, help);
+                    }
+                    all_diagnostics
                 })
             ),
         }
@@ -159,35 +174,40 @@ fn use_statements() {
     check(
         &run_parser!(use_statement(), "use ;"),
         expect_test::expect![[r#"
-            @4..5: found ";" but expected "::", "*",  or "{"
+            expected `::`, `*`, or `{`, found `;`
+            @4..5: expected `::`, `*`, or `{`
         "#]],
     );
 
     check(
         &run_parser!(use_statement(), "use ::;"),
         expect_test::expect![[r#"
-            @6..7: found ";" but expected "*",  or "{"
+            expected `*`, or `{`, found `;`
+            @6..7: expected `*`, or `{`
         "#]],
     );
 
     check(
         &run_parser!(use_statement(), "use a::;"),
         expect_test::expect![[r#"
-            @5..7: found "::" but expected ";"
+            expected `;`, found `::`
+            @5..7: expected `;`
         "#]],
     );
 
     check(
         &run_parser!(use_statement(), "use * as b;"),
         expect_test::expect![[r#"
-            @6..8: found "as" but expected ";"
+            expected `;`, found `as`
+            @6..8: expected `;`
         "#]],
     );
 
     check(
         &run_parser!(use_statement(), "use a::{* as d};"),
         expect_test::expect![[r#"
-            @5..7: found "::" but expected ";"
+            expected `;`, found `::`
+            @5..7: expected `;`
         "#]],
     );
 }
@@ -197,8 +217,9 @@ fn let_decls() {
     check(
         &run_parser!(let_decl(expr()), "let blah;"),
         expect_test::expect![[r#"
-            @0..9: type annotation or initializer needed for variable "blah"
-        "#]],
+            type annotation or initializer needed for variable `blah`
+            @0..9: type annotation or initializer needed
+            consider giving `blah` an explicit type or an initializer"#]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah = 1.0;"),
@@ -307,7 +328,8 @@ fn solve_decls() {
     check(
         &run_parser!(solve_decl(), "solve world hunger;"),
         expect_test::expect![[r#"
-            @6..11: found "world" but expected "maximize", "minimize",  or "satisfy"
+            expected `maximize`, `minimize`, or `satisfy`, found `world`
+            @6..11: expected `maximize`, `minimize`, or `satisfy`
         "#]],
     );
 }
@@ -687,7 +709,8 @@ fn parens_exprs() {
     check(
         &run_parser!(expr(), "()"),
         expect_test::expect![[r#"
-            @1..2: found ")" but expected "::", "::", "!", "+", "-", "{", "{", "(", "[", "if",  or "cond"
+            expected `::`, `::`, `!`, `+`, `-`, `{`, `{`, `(`, `[`, `if`, or `cond`, found `)`
+            @1..2: expected `::`, `::`, `!`, `+`, `-`, `{`, `{`, `(`, `[`, `if`, or `cond`
         "#]],
     );
     check(
@@ -777,7 +800,8 @@ fn idents() {
     check(
         &run_parser!(ident(), "12_ab"),
         expect_test::expect![[r#"
-            @0..2: found "12" but expected something else
+            expected something else, found `12`
+            @0..2: expected something else
         "#]],
     );
     check(
@@ -785,7 +809,8 @@ fn idents() {
         // This shows that we're not able to parser `ab*cd` as a single identifier
         &run_parser!(ident(), "ab*cd"),
         expect_test::expect![[r#"
-            @2..3: found "*" but expected end of input
+            expected "end of input", found `*`
+            @2..3: expected "end of input"
         "#]],
     );
 }
@@ -827,13 +852,15 @@ fn paths() {
     check(
         &run_parser!(path().then_ignore(end()), "foo::"),
         expect_test::expect![[r#"
-            @5..5: found end of input but expected something else
+            expected something else, found "end of input"
+            @5..5: expected something else
         "#]],
     );
     check(
         &run_parser!(path().then_ignore(end()), "::foo::"),
         expect_test::expect![[r#"
-            @7..7: found end of input but expected something else
+            expected something else, found "end of input"
+            @7..7: expected something else
         "#]],
     );
 }
@@ -910,8 +937,11 @@ fn code_blocks() {
     );
 
     check(
-        &format!("{:?}", run_parser!(let_decl(expr()), "let x = {};")),
-        expect_test::expect![[r#""@8..10: empty tuple expressions are not allowed\n""#]],
+        &run_parser!(let_decl(expr()), "let x = {};"),
+        expect_test::expect![[r#"
+            empty tuple expressions are not allowed
+            @8..10: empty tuple expression found
+        "#]],
     );
 }
 
@@ -920,7 +950,8 @@ fn if_exprs() {
     check(
         &run_parser!(if_expr(expr()), "if c { 1 }"),
         expect_test::expect![[r#"
-            @10..10: found end of input but expected "else"
+            expected `else`, found "end of input"
+            @10..10: expected `else`
         "#]],
     );
 
@@ -950,7 +981,7 @@ fn if_exprs() {
 fn array_type() {
     check(
         &run_parser!(type_(expr()), r#"int[5]"#),
-        expect_test::expect!["Array { ty: Primitive { kind: Int, span: 0..3 }, range: Immediate { value: Int(5), span: 4..5 }, span: 0..6 }"],
+        expect_test::expect![["Array { ty: Primitive { kind: Int, span: 0..3 }, range: Immediate { value: Int(5), span: 4..5 }, span: 0..6 }"]],
     );
 
     check(
@@ -994,7 +1025,8 @@ fn array_type() {
     check(
         &run_parser!(let_decl(expr()), r#"let a: int[];"#),
         expect_test::expect![[r#"
-            @11..12: found "]" but expected "::", "::", "!", "+", "-", "{", "{", "(", "[", "if",  or "cond"
+            expected `::`, `::`, `!`, `+`, `-`, `{`, `{`, `(`, `[`, `if`, or `cond`, found `]`
+            @11..12: expected `::`, `::`, `!`, `+`, `-`, `{`, `{`, `(`, `[`, `if`, or `cond`
         "#]],
     );
 }
@@ -1071,7 +1103,8 @@ fn array_field_accesss() {
     check(
         &run_parser!(let_decl(expr()), r#"let x = a[];"#),
         expect_test::expect![[r#"
-            @10..11: found "]" but expected "::", "::", "!", "+", "-", "{", "{", "(", "[", "if",  or "cond"
+            expected `::`, `::`, `!`, `+`, `-`, `{`, `{`, `(`, `[`, `if`, or `cond`, found `]`
+            @10..11: expected `::`, `::`, `!`, `+`, `-`, `{`, `{`, `(`, `[`, `if`, or `cond`
         "#]],
     );
 
@@ -1261,28 +1294,32 @@ fn tuple_field_accesses() {
     check(
         &run_parser!(let_decl(expr()), "let x = t.0xa;"),
         expect_test::expect![[r#"
-            @10..13: invalid integer value "0xa" for tuple index
+            invalid integer `0xa` as tuple index
+            @10..13: invalid integer as tuple index
         "#]],
     );
 
     check(
         &run_parser!(let_decl(expr()), "let x = t.111111111111111111111111111;"),
         expect_test::expect![[r#"
-            @10..37: invalid integer value "111111111111111111111111111" for tuple index
+            invalid integer `111111111111111111111111111` as tuple index
+            @10..37: invalid integer as tuple index
         "#]],
     );
 
     check(
         &run_parser!(let_decl(expr()), "let x = t.111111111111111111111111111.2;"),
         expect_test::expect![[r#"
-            @10..37: invalid integer value "111111111111111111111111111" for tuple index
+            invalid integer `111111111111111111111111111` as tuple index
+            @10..37: invalid integer as tuple index
         "#]],
     );
 
     check(
         &run_parser!(let_decl(expr()), "let x = t.2.111111111111111111111111111;"),
         expect_test::expect![[r#"
-            @12..39: invalid integer value "111111111111111111111111111" for tuple index
+            invalid integer `111111111111111111111111111` as tuple index
+            @12..39: invalid integer as tuple index
         "#]],
     );
 
@@ -1292,22 +1329,26 @@ fn tuple_field_accesses() {
             "let x = t.222222222222222222222.111111111111111111111111111;"
         ),
         expect_test::expect![[r#"
-            @10..31: invalid integer value "222222222222222222222" for tuple index
+            invalid integer `222222222222222222222` as tuple index
+            @10..31: invalid integer as tuple index
         "#]],
     );
 
     check(
         &run_parser!(let_decl(expr()), "let x = t.1e5;"),
         expect_test::expect![[r#"
-            @10..13: invalid value "1e5" for tuple index
+            invalid value `1e5` as tuple index
+            @10..13: invalid value as tuple index
         "#]],
     );
 
     check(
         &run_parser!(let_decl(expr()), "let bad_tuple:{} = {};"),
         expect_test::expect![[r#"
-            @14..16: empty tuple types are not allowed
-            @19..21: empty tuple expressions are not allowed
+            empty tuple types are not allowed
+            @14..16: empty tuple type found
+            empty tuple expressions are not allowed
+            @19..21: empty tuple expression found
         "#]],
     );
 }
@@ -1355,14 +1396,16 @@ fn cond_exprs() {
     check(
         &run_parser!(cond_expr(expr()), r#"cond { a => b, }"#),
         expect_test::expect![[r#"
-            @15..16: found "}" but expected "::", "::", "!", "+", "-", "{", "{", "(", "[", "if", "else",  or "cond"
+            expected `::`, `::`, `!`, `+`, `-`, `{`, `{`, `(`, `[`, `if`, `else`, or `cond`, found `}`
+            @15..16: expected `::`, `::`, `!`, `+`, `-`, `{`, `{`, `(`, `[`, `if`, `else`, or `cond`
         "#]],
     );
 
     check(
         &run_parser!(cond_expr(expr()), r#"cond { else => a, b => c }"#),
         expect_test::expect![[r#"
-            @18..19: found "b" but expected "}"
+            expected `}`, found `b`
+            @18..19: expected `}`
         "#]],
     );
 }
@@ -1394,7 +1437,8 @@ fn casting() {
     check(
         &run_parser!(let_decl(expr()), r#"let x = 5 as;"#),
         expect_test::expect![[r#"
-            @12..13: found ";" but expected "::", "{", "real", "int", "bool",  or "string"
+            expected `::`, `{`, `real`, `int`, `bool`, or `string`, found `;`
+            @12..13: expected `::`, `{`, `real`, `int`, `bool`, or `string`
         "#]],
     );
 }
@@ -1432,7 +1476,8 @@ fn in_expr() {
     check(
         &run_parser!(let_decl(expr()), r#"let x = 5 in;"#),
         expect_test::expect![[r#"
-            @12..13: found ";" but expected "::", "::", "!", "+", "-", "{", "{", "(", "[", "if",  or "cond"
+            expected `::`, `::`, `!`, `+`, `-`, `{`, `{`, `(`, `[`, `if`, or `cond`, found `;`
+            @12..13: expected `::`, `::`, `!`, `+`, `-`, `{`, `{`, `(`, `[`, `if`, or `cond`
         "#]],
     );
 }
@@ -1463,14 +1508,16 @@ fn fn_errors() {
     check(
         &run_parser!(yurt_program(), "fn foo() {5}"),
         expect_test::expect![[r#"
-            @9..10: found "{" but expected "->"
+            expected `->`, found `{`
+            @9..10: expected `->`
         "#]],
     );
 
     check(
         &run_parser!(yurt_program(), "fn foo() -> real {}"),
         expect_test::expect![[r#"
-            @18..19: found "}" but expected "::", "::", "!", "+", "-", "{", "{", "(", "[", "if", "cond", "let", "state",  or "constraint"
+            expected `::`, `::`, `!`, `+`, `-`, `{`, `{`, `(`, `[`, `if`, `cond`, `let`, `state`, or `constraint`, found `}`
+            @18..19: expected `::`, `::`, `!`, `+`, `-`, `{`, `{`, `(`, `[`, `if`, `cond`, `let`, `state`, or `constraint`
         "#]],
     );
 }
@@ -1499,10 +1546,7 @@ fn keywords_as_identifiers_errors() {
         let src = format!("let {keyword} = 5;");
         assert_eq!(
             &run_parser!(yurt_program(), &src),
-            &format!(
-                "@4..{}: expected identifier, found keyword \"{keyword}\"\n",
-                4 + format!("{keyword}").len() // End of the error span
-            ),
+            &format!("expected identifier, found keyword `{keyword}`\n@4..{}: expected identifier, found keyword\n", 4 + format!("{keyword}").len()), // End of the error span),
             "Check \"identifier as keyword\" error for  keyword \"{}\"",
             keyword
         );
@@ -1512,18 +1556,18 @@ fn keywords_as_identifiers_errors() {
 #[test]
 fn test_parse_str_to_ast() {
     check(
-        &format!("{:?}", parse_str_to_ast("let x = 5;", "my_file")),
+        &format!("{:?}", parse_str_to_ast("let x = 5;")),
         expect_test::expect![[
             r#"Ok([Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Immediate { value: Int(5), span: 8..9 }), span: 0..10 }])"#
         ]],
     );
     check(
-        &format!("{:?}", parse_str_to_ast("let x = 5", "my_file")),
-        expect_test::expect![[r#"Err(could not compile "my_file" due to previous error)"#]],
+        &format!("{:?}", parse_str_to_ast("let x = 5")),
+        expect_test::expect!["Err([Parse { error: ExpectedFound { span: 9..9, expected: [Some(Semi), Some(DoublePipe), Some(DoubleAmpersand), Some(NotEq), Some(EqEq), Some(GtEq), Some(LtEq), Some(Gt), Some(Lt), Some(Plus), Some(Minus), Some(Star), Some(Div), Some(Mod), Some(In), Some(As), Some(Dot), Some(BracketOpen), Some(SingleQuote)], found: None } }])"],
     );
     check(
-        &format!("{:?}", parse_str_to_ast("@ @", "my_file")),
-        expect_test::expect![[r#"Err(could not compile "my_file" due to 2 previous errors)"#]],
+        &format!("{:?}", parse_str_to_ast("@ @")),
+        expect_test::expect!["Err([Lex { span: 0..1, error: InvalidToken }, Lex { span: 2..3, error: InvalidToken }])"],
     );
 }
 
@@ -1626,14 +1670,16 @@ fn contract_test() {
     check(
         &run_parser!(contract_decl(expr()), "contract Foo { }"),
         expect_test::expect![[r#"
-            @13..14: found "{" but expected "("
+            expected `(`, found `{`
+            @13..14: expected `(`
         "#]],
     );
 
     check(
         &run_parser!(contract_decl(expr()), "contract Foo(0) implements { }"),
         expect_test::expect![[r#"
-            @27..28: found "{" but expected "::"
+            expected `::`, found `{`
+            @27..28: expected `::`
         "#]],
     );
 }
@@ -1671,7 +1717,8 @@ fn extern_test() {
     check(
         &run_parser!(extern_decl(expr()), "extern { fn foo(); }"),
         expect_test::expect![[r#"
-            @17..18: found ";" but expected "->"
+            expected `->`, found `;`
+            @17..18: expected `->`
         "#]],
     );
 }


### PR DESCRIPTION
Closes #172 

Main changes:
- Only accept a single source file for now. I think we want that anyways because we will assume an entry file and the rest will be available by default based on `use` statements.
- New error modules: `parse_error`, `lex_error`, and `compile_error`.
- New trait `ReportableError` which exposes a few utilities such as `labels()`, `notes()`, `print()`, etc.
- Errors now have:
  1. Messages: this is the main description of the error and shows up in the `#[error(..)]` annotation.
  2. Labels: this is a list of labels with spans that point to specific places in the source code. Can have multiple labels for a single error.
  3. Notes, help messages, and error codes.

Examples:
![image](https://github.com/essential-contributions/yurt/assets/59666792/87de9388-3f03-4384-a633-9d98c86852d9)
![image](https://github.com/essential-contributions/yurt/assets/59666792/11b2a00d-7496-4c31-b1bb-c051762f9f80)

I set up the tools to support error codes but have not added them yet. We need to figure out a way to organize the error codes such that new codes are always generated for new errors. See https://github.com/essential-contributions/yurt/issues/216