### PR TITLE
Some enhancements to spans and errors

### DIFF
--- a/yurtc/src/error/compile_error.rs
+++ b/yurtc/src/error/compile_error.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{ErrorLabel, ReportableError},
-    span::Span,
+    span::{Span, Spanned},
 };
 use thiserror::Error;
 use yansi::Color;
@@ -12,8 +12,8 @@ pub(crate) enum CompileError {
     #[error("symbol `{sym}` has already been declared")]
     NameClash {
         sym: String,
-        span: Span,
-        prev_span: Span,
+        span: Span,      // Actual error location
+        prev_span: Span, // Span of the previous occurance
     },
 }
 
@@ -65,5 +65,14 @@ impl ReportableError for CompileError {
 
     fn help(&self) -> Option<String> {
         None
+    }
+}
+
+impl Spanned for CompileError {
+    fn span(&self) -> &Span {
+        use CompileError::*;
+        match &self {
+            Internal { span, .. } | NameClash { span, .. } => span,
+        }
     }
 }

--- a/yurtc/src/error/lex_error.rs
+++ b/yurtc/src/error/lex_error.rs
@@ -1,5 +1,10 @@
-use crate::error::{ErrorLabel, ReportableError};
 use thiserror::Error;
+
+// We would like to implement the trait `ReportableError` for `LexError` but that trait requires
+// that the types that implement it are `Spanned`. Since, we don't have access to spans in
+// `LexError`, and because it only has a single lex error variant for now, we don't need to
+// over-engineer this. We'll leave to `impl ReportableError for Error<'_>` to directly handle lex
+// error labels, error code, note, and help message.
 
 /// An error originating from the lexer
 #[derive(Error, Debug, Clone, PartialEq, Default)]
@@ -7,22 +12,4 @@ pub(crate) enum LexError {
     #[default]
     #[error("invalid token")]
     InvalidToken,
-}
-
-impl ReportableError for LexError {
-    fn labels(&self) -> Vec<ErrorLabel> {
-        Vec::new()
-    }
-
-    fn note(&self) -> Option<String> {
-        None
-    }
-
-    fn code(&self) -> Option<String> {
-        None
-    }
-
-    fn help(&self) -> Option<String> {
-        None
-    }
 }

--- a/yurtc/src/error/parse_error.rs
+++ b/yurtc/src/error/parse_error.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{ErrorLabel, ReportableError},
     lexer::Token,
-    span::Span,
+    span::{Span, Spanned},
 };
 use thiserror::Error;
 use yansi::Color;
@@ -192,4 +192,20 @@ fn format_expected_found_error<'a>(
         format_expected_tokens_message(expected),
         format_optional_token(found),
     )
+}
+
+impl Spanned for ParseError<'_> {
+    fn span(&self) -> &Span {
+        use ParseError::*;
+        match &self {
+            ExpectedFound { span, .. }
+            | KeywordAsIdent { span, .. }
+            | UntypedVariable { span, .. }
+            | EmptyArrayExpr { span }
+            | InvalidIntegerTupleIndex { span, .. }
+            | InvalidTupleIndex { span, .. }
+            | EmptyTupleExpr { span, .. }
+            | EmptyTupleType { span, .. } => span,
+        }
+    }
 }

--- a/yurtc/src/parser/tests.rs
+++ b/yurtc/src/parser/tests.rs
@@ -24,10 +24,7 @@ macro_rules! run_parser {
                         error.labels().iter().fold(String::new(), |acc, label| {
                             format!(
                                 "\n{}@{}..{}: {}\n",
-                                acc,
-                                label.span().start,
-                                label.span().end,
-                                label.message()
+                                acc, label.span.start, label.span.end, label.message
                             )
                         })
                     );


### PR DESCRIPTION
Closes #217 

Also does some other small things. For example, it turns out we do need a "main" span for each error. This is the span where the error actually is and shows up right after the name of the file in the printed error. Example:
![image](https://github.com/essential-contributions/yurt/assets/59666792/9ee829f0-a3e3-4b69-99d7-eb5180e23c5f)
