### PR TITLE
Update Spec: Add state-items as part of block-statements

### DIFF
--- a/specs/src/lang/language_primitives.md
+++ b/specs/src/lang/language_primitives.md
@@ -283,7 +283,7 @@ Block expressions are expressions that contains a list of _statements_ followed 
 <block-expr> ::= "{" ( <block-statement> ";" )* <expr> "}"
 
 <block-statement> ::= <let-item>
-                    | <state-time>
+                    | <state-item>
                     | <constraint-item>
 ```
 


### PR DESCRIPTION
Making sure the spec is clear that state-items can be used inside of code blocks as discussed in [slack](https://e20s.slack.com/archives/C055SELU0E9/p1693410459303319) and PR #215 