### PR TITLE
Include filepaths in spans

### DIFF
--- a/yurtc/src/error.rs
+++ b/yurtc/src/error.rs
@@ -3,7 +3,7 @@ mod lex_error;
 mod parse_error;
 
 use crate::span::{Span, Spanned};
-use ariadne::{Label, Report, ReportKind, Source};
+use ariadne::{FnCache, Label, Report, ReportKind, Source};
 use chumsky::prelude::*;
 pub(super) use compile_error::CompileError;
 pub(super) use lex_error::LexError;
@@ -48,20 +48,32 @@ where
     fn help(&self) -> Option<String>;
 
     /// Pretty print an error to the terminal
-    fn print(&self, filename: &str, source: &str) {
-        let mut report_builder = Report::build(ReportKind::Error, filename, self.span().start)
+    fn print(&self) {
+        let filepaths_and_sources = self
+            .labels()
+            .iter()
+            .map(|label| {
+                let filepath = format!("{}", label.span.context().display());
+                let source = std::fs::read_to_string(filepath.clone()).unwrap();
+                (filepath, source)
+            })
+            .collect::<Vec<(String, String)>>();
+
+        let error_file: &str = &format!("{}", self.span().context().display());
+        let mut report_builder = Report::build(ReportKind::Error, error_file, self.span().start())
             .with_message(format!("{}", Style::default().bold().paint(self)))
             .with_labels({
-                let mut labels = vec![];
-                for label in self.labels() {
-                    let style = Style::new(label.color).bold();
-                    labels.push(
-                        Label::new((filename, label.span.start()..label.span.end()))
-                            .with_message(style.paint(label.message))
-                            .with_color(label.color),
-                    );
-                }
-                labels
+                self.labels()
+                    .iter()
+                    .enumerate()
+                    .map(|(index, label)| {
+                        let filepath: &str = &filepaths_and_sources[index].0;
+                        let style = Style::new(label.color).bold();
+                        Label::new((filepath, label.span.start()..label.span.end()))
+                            .with_message(style.paint(label.message.clone()))
+                            .with_color(label.color)
+                    })
+                    .collect::<Vec<_>>()
             });
 
         if let Some(code) = self.code() {
@@ -78,7 +90,17 @@ where
 
         report_builder
             .finish()
-            .print((filename, Source::from(source)))
+            .print(
+                FnCache::new(|id: &&str| {
+                    Err(Box::new(format!("Failed to fetch source '{}'", id)) as _)
+                })
+                .with_sources(
+                    filepaths_and_sources
+                        .iter()
+                        .map(|(id, s)| (&id[..], Source::from(s)))
+                        .collect(),
+                ),
+            )
             .unwrap();
     }
 }
@@ -141,22 +163,25 @@ impl Spanned for Error<'_> {
 }
 
 /// Print a list of [`Error`] using the `ariadne` crate
-pub(super) fn print_errors(errs: &Vec<Error>, filename: &str, source: &str) {
+pub(super) fn print_errors(errs: &Vec<Error>) {
     for err in errs {
-        err.print(filename, source);
+        err.print();
     }
 }
 
-/// A simple warpper around `anyhow::bail!` that prints a different message based on a the number
+/// A simple wrapper around `anyhow::bail!` that prints a different message based on a the number
 /// of compile errors.
 macro_rules! yurtc_bail {
-    ($number_of_errors: expr, $filename: expr) => {
+    ($number_of_errors: expr, $filepath: expr) => {
         if $number_of_errors == 1 {
-            anyhow::bail!("could not compile `{}` due to previous error", $filename)
+            anyhow::bail!(
+                "could not compile `{}` due to previous error",
+                format!("{}", $filepath.display())
+            )
         } else {
             anyhow::bail!(
                 "could not compile `{}` due to {} previous errors",
-                $filename,
+                format!("{}", $filepath.display()),
                 $number_of_errors
             )
         }

--- a/yurtc/src/error/compile_error.rs
+++ b/yurtc/src/error/compile_error.rs
@@ -13,7 +13,7 @@ pub(crate) enum CompileError {
     NameClash {
         sym: String,
         span: Span,      // Actual error location
-        prev_span: Span, // Span of the previous occurance
+        prev_span: Span, // Span of the previous occurrence
     },
 }
 

--- a/yurtc/src/intent/intermediate.rs
+++ b/yurtc/src/intent/intermediate.rs
@@ -8,6 +8,10 @@ use crate::{
     span::Span,
     types::{EnumDecl, FnSig as F, Type as T},
 };
+#[cfg(test)]
+use chumsky::prelude::*;
+#[cfg(test)]
+use std::rc::Rc;
 
 mod compile;
 mod from_ast;
@@ -85,18 +89,19 @@ use crate::expr;
 #[test]
 fn single_let() {
     use crate::types::{PrimitiveKind::*, Type};
+    let filepath: Rc<std::path::Path> = Rc::from(std::path::Path::new("test"));
     let ast = vec![ast::Decl::Let {
         // `let foo: real;`
         name: ast::Ident {
             name: "foo".to_owned(),
-            span: 4..7,
+            span: Span::new(Rc::clone(&filepath), 4..7),
         },
         ty: Some(Type::Primitive {
             kind: Real,
-            span: 9..13,
+            span: Span::new(Rc::clone(&filepath), 9..13),
         }),
         init: None,
-        span: 0..14,
+        span: Span::new(filepath, 0..14),
     }];
 
     assert!(IntermediateIntent::from_ast(&ast).is_ok());
@@ -105,32 +110,33 @@ fn single_let() {
 #[test]
 fn double_let_clash() {
     use crate::types::{PrimitiveKind::*, Type};
+    let filepath: Rc<std::path::Path> = Rc::from(std::path::Path::new("test"));
     let ast = vec![
         ast::Decl::Let {
             // `let foo: real;`
             name: ast::Ident {
                 name: "foo".to_owned(),
-                span: 4..7,
+                span: Span::new(Rc::clone(&filepath), 4..7),
             },
             ty: Some(Type::Primitive {
                 kind: Real,
-                span: 9..13,
+                span: Span::new(Rc::clone(&filepath), 9..13),
             }),
             init: None,
-            span: 0..14,
+            span: Span::new(Rc::clone(&filepath), 0..14),
         },
         ast::Decl::Let {
             // `let foo: real;`
             name: ast::Ident {
                 name: "foo".to_owned(),
-                span: 19..22,
+                span: Span::new(Rc::clone(&filepath), 19..22),
             },
             ty: Some(Type::Primitive {
                 kind: Real,
-                span: 24..28,
+                span: Span::new(Rc::clone(&filepath), 24..28),
             }),
             init: None,
-            span: 15..29,
+            span: Span::new(filepath, 15..29),
         },
     ];
 
@@ -140,7 +146,7 @@ fn double_let_clash() {
     assert!(res.is_err_and(|e| {
         assert_eq!(
             format!("{e:?}"),
-            r#"NameClash { sym: "foo", span: 19..22, prev_span: 4..7 }"#
+            r#"NameClash { sym: "foo", span: "test":19..22, prev_span: "test":4..7 }"#
         );
         true
     }));
@@ -149,43 +155,44 @@ fn double_let_clash() {
 #[test]
 fn let_fn_clash() {
     use crate::types::{PrimitiveKind::*, Type};
+    let filepath: Rc<std::path::Path> = Rc::from(std::path::Path::new("test"));
     let ast = vec![
         ast::Decl::Let {
             // `let bar: real;`
             name: ast::Ident {
                 name: "bar".to_owned(),
-                span: 4..7,
+                span: Span::new(Rc::clone(&filepath), 4..7),
             },
             ty: Some(Type::Primitive {
                 kind: Real,
-                span: 9..13,
+                span: Span::new(Rc::clone(&filepath), 9..13),
             }),
             init: None,
-            span: 0..14,
+            span: Span::new(Rc::clone(&filepath), 0..14),
         },
         ast::Decl::Fn {
             fn_sig: ast::FnSig {
                 // `fn bar() -> bool { false }`
                 name: ast::Ident {
                     name: "bar".to_owned(),
-                    span: 18..21,
+                    span: Span::new(Rc::clone(&filepath), 18..21),
                 },
                 params: Vec::new(),
                 return_type: Type::Primitive {
                     kind: Bool,
-                    span: 27..31,
+                    span: Span::new(Rc::clone(&filepath), 27..31),
                 },
-                span: 15..31,
+                span: Span::new(Rc::clone(&filepath), 15..31),
             },
             body: ast::Block {
                 statements: Vec::new(),
                 final_expr: Box::new(ast::Expr::Immediate {
                     value: expr::Immediate::Bool(false),
-                    span: 34..39,
+                    span: Span::new(Rc::clone(&filepath), 34..39),
                 }),
-                span: 15..41,
+                span: Span::new(Rc::clone(&filepath), 15..41),
             },
-            span: 15..41,
+            span: Span::new(Rc::clone(&filepath), 15..41),
         },
     ];
 
@@ -194,7 +201,7 @@ fn let_fn_clash() {
     assert!(res.is_err_and(|e| {
         assert_eq!(
             format!("{e:?}"),
-            r#"NameClash { sym: "bar", span: 18..21, prev_span: 4..7 }"#
+            r#"NameClash { sym: "bar", span: "test":18..21, prev_span: "test":4..7 }"#
         );
         true
     }));

--- a/yurtc/src/lexer/tests.rs
+++ b/yurtc/src/lexer/tests.rs
@@ -9,7 +9,7 @@ fn check(actual: &str, expect: expect_test::Expect) {
 #[cfg(test)]
 fn lex_one_success(src: &str) -> Token<'_> {
     // Tokenise src, assume success and that we produce a single token.
-    let (toks, errs) = lex(src);
+    let (toks, errs) = lex(src, Rc::from(Path::new("test")));
     assert!(errs.is_empty(), "Testing for success only.");
     assert_eq!(toks.len(), 1, "Testing for single token only.");
     toks[0].0.clone()
@@ -40,12 +40,12 @@ fn reals() {
     assert_eq!(lex_one_success("1.3E5"), Token::RealLiteral("1.3E5"));
     assert_eq!(lex_one_success("0.34"), Token::RealLiteral("0.34"));
     check(
-        &format!("{:?}", lex(".34")),
-        expect_test::expect![[r#"([(Dot, 0..1), (IntLiteral("34"), 1..3)], [])"#]],
+        &format!("{:?}", lex(".34", Rc::from(Path::new("test")))),
+        expect_test::expect![[r#"([(Dot, "test":0..1), (IntLiteral("34"), "test":1..3)], [])"#]],
     );
     check(
-        &format!("{:?}", lex("12.")),
-        expect_test::expect![[r#"([(IntLiteral("12"), 0..2), (Dot, 2..3)], [])"#]],
+        &format!("{:?}", lex("12.", Rc::from(Path::new("test")))),
+        expect_test::expect![[r#"([(IntLiteral("12"), "test":0..2), (Dot, "test":2..3)], [])"#]],
     );
 }
 
@@ -199,7 +199,7 @@ constraint mid < low_val @ 2;
 solve minimize mid;
 "#;
 
-    let (tokens, errors) = lex(src);
+    let (tokens, errors) = lex(src, Rc::from(Path::new("test")));
 
     // Check errors
     assert_eq!(errors.len(), 2);

--- a/yurtc/src/parser/tests.rs
+++ b/yurtc/src/parser/tests.rs
@@ -4,13 +4,18 @@ use crate::{
     parser::*,
 };
 use chumsky::Stream;
+use std::{path::Path, rc::Rc};
 
 #[cfg(test)]
 macro_rules! run_parser {
     ($parser: expr, $source: expr) => {{
-        let (toks, errs) = lexer::lex($source);
+        let filepath = Rc::from(Path::new("test"));
+        let (toks, errs) = lexer::lex($source, Rc::clone(&filepath));
         assert!(errs.is_empty());
-        let token_stream = Stream::from_iter($source.len()..$source.len(), toks.into_iter());
+        let token_stream = Stream::from_iter(
+            Span::new(filepath, $source.len()..$source.len()),
+            toks.into_iter(),
+        );
         match ($parser.then_ignore(end())).parse(token_stream) {
             Ok(ast) => format!("{:?}", ast),
             Err(errors) => format!(
@@ -24,7 +29,10 @@ macro_rules! run_parser {
                         error.labels().iter().fold(String::new(), |acc, label| {
                             format!(
                                 "\n{}@{}..{}: {}\n",
-                                acc, label.span.start, label.span.end, label.message
+                                acc,
+                                label.span.start(),
+                                label.span.end(),
+                                label.message
                             )
                         })
                     );
@@ -50,28 +58,31 @@ fn check(actual: &str, expect: expect_test::Expect) {
 fn types() {
     check(
         &run_parser!(type_(expr()), "int"),
-        expect_test::expect!["Primitive { kind: Int, span: 0..3 }"],
+        expect_test::expect![[r#"Primitive { kind: Int, span: "test":0..3 }"#]],
     );
     check(
         &run_parser!(type_(expr()), "real"),
-        expect_test::expect!["Primitive { kind: Real, span: 0..4 }"],
+        expect_test::expect![[r#"Primitive { kind: Real, span: "test":0..4 }"#]],
     );
     check(
         &run_parser!(type_(expr()), "bool"),
-        expect_test::expect!["Primitive { kind: Bool, span: 0..4 }"],
+        expect_test::expect![[r#"Primitive { kind: Bool, span: "test":0..4 }"#]],
     );
     check(
         &run_parser!(type_(expr()), "string"),
-        expect_test::expect!["Primitive { kind: String, span: 0..6 }"],
+        expect_test::expect![[r#"Primitive { kind: String, span: "test":0..6 }"#]],
     );
     check(
         &run_parser!(type_(expr()), "{int, real, string}"),
-        expect_test::expect!["Tuple { fields: [(None, Primitive { kind: Int, span: 1..4 }), (None, Primitive { kind: Real, span: 6..10 }), (None, Primitive { kind: String, span: 12..18 })], span: 0..19 }"],
+        expect_test::expect![[
+            r#"Tuple { fields: [(None, Primitive { kind: Int, span: "test":1..4 }), (None, Primitive { kind: Real, span: "test":6..10 }), (None, Primitive { kind: String, span: "test":12..18 })], span: "test":0..19 }"#
+        ]],
     );
     check(
         &run_parser!(type_(expr()), "{int, {real, int}, string}"),
-        expect_test::expect!["Tuple { fields: [(None, Primitive { kind: Int, span: 1..4 }), (None, Tuple { fields: [(None, Primitive { kind: Real, span: 7..11 }), (None, Primitive { kind: Int, span: 13..16 })], span: 6..17 }), (None, Primitive { kind: String, span: 19..25 })], span: 0..26 }"
-        ],
+        expect_test::expect![[
+            r#"Tuple { fields: [(None, Primitive { kind: Int, span: "test":1..4 }), (None, Tuple { fields: [(None, Primitive { kind: Real, span: "test":7..11 }), (None, Primitive { kind: Int, span: "test":13..16 })], span: "test":6..17 }), (None, Primitive { kind: String, span: "test":19..25 })], span: "test":0..26 }"#
+        ]],
     );
 }
 
@@ -111,53 +122,57 @@ fn immediates() {
 fn use_statements() {
     check(
         &run_parser!(yurt_program(), "use *; use ::*;"),
-        expect_test::expect!["[Use { is_absolute: false, use_tree: Glob(4..5), span: 0..6 }, Use { is_absolute: true, use_tree: Glob(13..14), span: 7..15 }]"],
+        expect_test::expect![[
+            r#"[Use { is_absolute: false, use_tree: Glob("test":4..5), span: "test":0..6 }, Use { is_absolute: true, use_tree: Glob("test":13..14), span: "test":7..15 }]"#
+        ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use {}; use ::{};"),
-        expect_test::expect!["[Use { is_absolute: false, use_tree: Group { imports: [], span: 4..6 }, span: 0..7 }, Use { is_absolute: true, use_tree: Group { imports: [], span: 14..16 }, span: 8..17 }]"],
+        expect_test::expect![[
+            r#"[Use { is_absolute: false, use_tree: Group { imports: [], span: "test":4..6 }, span: "test":0..7 }, Use { is_absolute: true, use_tree: Group { imports: [], span: "test":14..16 }, span: "test":8..17 }]"#
+        ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use a; use ::a; use ::a as b;"),
         expect_test::expect![[
-            r#"[Use { is_absolute: false, use_tree: Name { name: Ident { name: "a", span: 4..5 }, span: 4..5 }, span: 0..6 }, Use { is_absolute: true, use_tree: Name { name: Ident { name: "a", span: 13..14 }, span: 13..14 }, span: 7..15 }, Use { is_absolute: true, use_tree: Alias { name: Ident { name: "a", span: 22..23 }, alias: Ident { name: "b", span: 27..28 }, span: 22..28 }, span: 16..29 }]"#
+            r#"[Use { is_absolute: false, use_tree: Name { name: Ident { name: "a", span: "test":4..5 }, span: "test":4..5 }, span: "test":0..6 }, Use { is_absolute: true, use_tree: Name { name: Ident { name: "a", span: "test":13..14 }, span: "test":13..14 }, span: "test":7..15 }, Use { is_absolute: true, use_tree: Alias { name: Ident { name: "a", span: "test":22..23 }, alias: Ident { name: "b", span: "test":27..28 }, span: "test":22..28 }, span: "test":16..29 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use a::b; use ::a::b; use ::a::b as c;"),
         expect_test::expect![[
-            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: 4..5 }, suffix: Name { name: Ident { name: "b", span: 7..8 }, span: 7..8 }, span: 4..8 }, span: 0..9 }, Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 16..17 }, suffix: Name { name: Ident { name: "b", span: 19..20 }, span: 19..20 }, span: 16..20 }, span: 10..21 }, Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 28..29 }, suffix: Alias { name: Ident { name: "b", span: 31..32 }, alias: Ident { name: "c", span: 36..37 }, span: 31..37 }, span: 28..37 }, span: 22..38 }]"#
+            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: "test":4..5 }, suffix: Name { name: Ident { name: "b", span: "test":7..8 }, span: "test":7..8 }, span: "test":4..8 }, span: "test":0..9 }, Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: "test":16..17 }, suffix: Name { name: Ident { name: "b", span: "test":19..20 }, span: "test":19..20 }, span: "test":16..20 }, span: "test":10..21 }, Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: "test":28..29 }, suffix: Alias { name: Ident { name: "b", span: "test":31..32 }, alias: Ident { name: "c", span: "test":36..37 }, span: "test":31..37 }, span: "test":28..37 }, span: "test":22..38 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use a::{b, c as d};"),
         expect_test::expect![[
-            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: 4..5 }, suffix: Group { imports: [Name { name: Ident { name: "b", span: 8..9 }, span: 8..9 }, Alias { name: Ident { name: "c", span: 11..12 }, alias: Ident { name: "d", span: 16..17 }, span: 11..17 }], span: 7..18 }, span: 4..18 }, span: 0..19 }]"#
+            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: "test":4..5 }, suffix: Group { imports: [Name { name: Ident { name: "b", span: "test":8..9 }, span: "test":8..9 }, Alias { name: Ident { name: "c", span: "test":11..12 }, alias: Ident { name: "d", span: "test":16..17 }, span: "test":11..17 }], span: "test":7..18 }, span: "test":4..18 }, span: "test":0..19 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use ::a::{*, c as d};"),
         expect_test::expect![[
-            r#"[Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 6..7 }, suffix: Group { imports: [Glob(10..11), Alias { name: Ident { name: "c", span: 13..14 }, alias: Ident { name: "d", span: 18..19 }, span: 13..19 }], span: 9..20 }, span: 6..20 }, span: 0..21 }]"#
+            r#"[Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: "test":6..7 }, suffix: Group { imports: [Glob("test":10..11), Alias { name: Ident { name: "c", span: "test":13..14 }, alias: Ident { name: "d", span: "test":18..19 }, span: "test":13..19 }], span: "test":9..20 }, span: "test":6..20 }, span: "test":0..21 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use ::a::{*, c as d};"),
         expect_test::expect![[
-            r#"[Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: 6..7 }, suffix: Group { imports: [Glob(10..11), Alias { name: Ident { name: "c", span: 13..14 }, alias: Ident { name: "d", span: 18..19 }, span: 13..19 }], span: 9..20 }, span: 6..20 }, span: 0..21 }]"#
+            r#"[Use { is_absolute: true, use_tree: Path { prefix: Ident { name: "a", span: "test":6..7 }, suffix: Group { imports: [Glob("test":10..11), Alias { name: Ident { name: "c", span: "test":13..14 }, alias: Ident { name: "d", span: "test":18..19 }, span: "test":13..19 }], span: "test":9..20 }, span: "test":6..20 }, span: "test":0..21 }]"#
         ]],
     );
 
     check(
         &run_parser!(yurt_program(), "use a::{{*}, {c as d, { e as f, * }}};"),
         expect_test::expect![[
-            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: 4..5 }, suffix: Group { imports: [Group { imports: [Glob(9..10)], span: 8..11 }, Group { imports: [Alias { name: Ident { name: "c", span: 14..15 }, alias: Ident { name: "d", span: 19..20 }, span: 14..20 }, Group { imports: [Alias { name: Ident { name: "e", span: 24..25 }, alias: Ident { name: "f", span: 29..30 }, span: 24..30 }, Glob(32..33)], span: 22..35 }], span: 13..36 }], span: 7..37 }, span: 4..37 }, span: 0..38 }]"#
+            r#"[Use { is_absolute: false, use_tree: Path { prefix: Ident { name: "a", span: "test":4..5 }, suffix: Group { imports: [Group { imports: [Glob("test":9..10)], span: "test":8..11 }, Group { imports: [Alias { name: Ident { name: "c", span: "test":14..15 }, alias: Ident { name: "d", span: "test":19..20 }, span: "test":14..20 }, Group { imports: [Alias { name: Ident { name: "e", span: "test":24..25 }, alias: Ident { name: "f", span: "test":29..30 }, span: "test":24..30 }, Glob("test":32..33)], span: "test":22..35 }], span: "test":13..36 }], span: "test":7..37 }, span: "test":4..37 }, span: "test":0..38 }]"#
         ]],
     );
 
@@ -215,73 +230,73 @@ fn let_decls() {
     check(
         &run_parser!(let_decl(expr()), "let blah = 1.0;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate { value: Real(1.0), span: 11..14 }), span: 0..15 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: None, init: Some(Immediate { value: Real(1.0), span: "test":11..14 }), span: "test":0..15 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: real = 1.0;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: Real, span: 10..14 }), init: Some(Immediate { value: Real(1.0), span: 17..20 }), span: 0..21 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: Some(Primitive { kind: Real, span: "test":10..14 }), init: Some(Immediate { value: Real(1.0), span: "test":17..20 }), span: "test":0..21 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: real;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: Real, span: 10..14 }), init: None, span: 0..15 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: Some(Primitive { kind: Real, span: "test":10..14 }), init: None, span: "test":0..15 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah = 1;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate { value: Int(1), span: 11..12 }), span: 0..13 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: None, init: Some(Immediate { value: Int(1), span: "test":11..12 }), span: "test":0..13 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: int = 1;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: Int, span: 10..13 }), init: Some(Immediate { value: Int(1), span: 16..17 }), span: 0..18 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: Some(Primitive { kind: Int, span: "test":10..13 }), init: Some(Immediate { value: Int(1), span: "test":16..17 }), span: "test":0..18 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: int;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: Int, span: 10..13 }), init: None, span: 0..14 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: Some(Primitive { kind: Int, span: "test":10..13 }), init: None, span: "test":0..14 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah = true;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate { value: Bool(true), span: 11..15 }), span: 0..16 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: None, init: Some(Immediate { value: Bool(true), span: "test":11..15 }), span: "test":0..16 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: bool = false;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: Bool, span: 10..14 }), init: Some(Immediate { value: Bool(false), span: 17..22 }), span: 0..23 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: Some(Primitive { kind: Bool, span: "test":10..14 }), init: Some(Immediate { value: Bool(false), span: "test":17..22 }), span: "test":0..23 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), "let blah: bool;"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: Bool, span: 10..14 }), init: None, span: 0..15 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: Some(Primitive { kind: Bool, span: "test":10..14 }), init: None, span: "test":0..15 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), r#"let blah = "hello";"#),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate { value: String("hello"), span: 11..18 }), span: 0..19 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: None, init: Some(Immediate { value: String("hello"), span: "test":11..18 }), span: "test":0..19 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), r#"let blah: string = "hello";"#),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: String, span: 10..16 }), init: Some(Immediate { value: String("hello"), span: 19..26 }), span: 0..27 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: Some(Primitive { kind: String, span: "test":10..16 }), init: Some(Immediate { value: String("hello"), span: "test":19..26 }), span: "test":0..27 }"#
         ]],
     );
     check(
         &run_parser!(let_decl(expr()), r#"let blah: string;"#),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: Some(Primitive { kind: String, span: 10..16 }), init: None, span: 0..17 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: Some(Primitive { kind: String, span: "test":10..16 }), init: None, span: "test":0..17 }"#
         ]],
     );
 }
@@ -292,7 +307,7 @@ fn constraint_decls() {
     check(
         &run_parser!(constraint_decl(expr()), "constraint blah;"),
         expect_test::expect![[
-            r#"Constraint { expr: Path(Path { path: [Ident { name: "blah", span: 11..15 }], is_absolute: false, span: 11..15 }), span: 0..16 }"#
+            r#"Constraint { expr: Path(Path { path: [Ident { name: "blah", span: "test":11..15 }], is_absolute: false, span: "test":11..15 }), span: "test":0..16 }"#
         ]],
     );
 }
@@ -301,25 +316,25 @@ fn constraint_decls() {
 fn solve_decls() {
     check(
         &run_parser!(solve_decl(), "solve satisfy;"),
-        expect_test::expect!["Solve { directive: Satisfy, span: 0..14 }"],
+        expect_test::expect![[r#"Solve { directive: Satisfy, span: "test":0..14 }"#]],
     );
     check(
         &run_parser!(solve_decl(), "solve minimize foo;"),
         expect_test::expect![[
-            r#"Solve { directive: Minimize(Path(Path { path: [Ident { name: "foo", span: 15..18 }], is_absolute: false, span: 15..18 })), span: 0..19 }"#
+            r#"Solve { directive: Minimize(Path(Path { path: [Ident { name: "foo", span: "test":15..18 }], is_absolute: false, span: "test":15..18 })), span: "test":0..19 }"#
         ]],
     );
     check(
         &run_parser!(solve_decl(), "solve maximize foo;"),
         expect_test::expect![[
-            r#"Solve { directive: Maximize(Path(Path { path: [Ident { name: "foo", span: 15..18 }], is_absolute: false, span: 15..18 })), span: 0..19 }"#
+            r#"Solve { directive: Maximize(Path(Path { path: [Ident { name: "foo", span: "test":15..18 }], is_absolute: false, span: "test":15..18 })), span: "test":0..19 }"#
         ]],
     );
 
     check(
         &run_parser!(solve_decl(), "solve maximize x + y;"),
         expect_test::expect![[
-            r#"Solve { directive: Maximize(BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "x", span: 15..16 }], is_absolute: false, span: 15..16 }), rhs: Path(Path { path: [Ident { name: "y", span: 19..20 }], is_absolute: false, span: 19..20 }), span: 15..20 }), span: 0..21 }"#
+            r#"Solve { directive: Maximize(BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "x", span: "test":15..16 }], is_absolute: false, span: "test":15..16 }), rhs: Path(Path { path: [Ident { name: "y", span: "test":19..20 }], is_absolute: false, span: "test":19..20 }), span: "test":15..20 }), span: "test":0..21 }"#
         ]],
     );
 
@@ -336,12 +351,12 @@ fn solve_decls() {
 fn basic_exprs() {
     check(
         &run_parser!(expr(), "123"),
-        expect_test::expect!["Immediate { value: Int(123), span: 0..3 }"],
+        expect_test::expect![[r#"Immediate { value: Int(123), span: "test":0..3 }"#]],
     );
     check(
         &run_parser!(expr(), "foo"),
         expect_test::expect![[
-            r#"Path(Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 })"#
+            r#"Path(Path { path: [Ident { name: "foo", span: "test":0..3 }], is_absolute: false, span: "test":0..3 })"#
         ]],
     );
 }
@@ -351,91 +366,97 @@ fn unary_op_exprs() {
     check(
         &run_parser!(expr(), "!a"),
         expect_test::expect![[
-            r#"UnaryOp { op: Not, expr: Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 }), span: 0..2 }"#
+            r#"UnaryOp { op: Not, expr: Path(Path { path: [Ident { name: "a", span: "test":1..2 }], is_absolute: false, span: "test":1..2 }), span: "test":0..2 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "+a"),
         expect_test::expect![[
-            r#"UnaryOp { op: Pos, expr: Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 }), span: 0..2 }"#
+            r#"UnaryOp { op: Pos, expr: Path(Path { path: [Ident { name: "a", span: "test":1..2 }], is_absolute: false, span: "test":1..2 }), span: "test":0..2 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "-a"),
         expect_test::expect![[
-            r#"UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 }), span: 0..2 }"#
+            r#"UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "a", span: "test":1..2 }], is_absolute: false, span: "test":1..2 }), span: "test":0..2 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "+7"),
-        expect_test::expect![
-            "UnaryOp { op: Pos, expr: Immediate { value: Int(7), span: 1..2 }, span: 0..2 }"
-        ],
+        expect_test::expect![[
+            r#"UnaryOp { op: Pos, expr: Immediate { value: Int(7), span: "test":1..2 }, span: "test":0..2 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "+3.4"),
-        expect_test::expect![
-            "UnaryOp { op: Pos, expr: Immediate { value: Real(3.4), span: 1..4 }, span: 0..4 }"
-        ],
+        expect_test::expect![[
+            r#"UnaryOp { op: Pos, expr: Immediate { value: Real(3.4), span: "test":1..4 }, span: "test":0..4 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "+0x456"),
-        expect_test::expect![
-            "UnaryOp { op: Pos, expr: Immediate { value: Int(1110), span: 1..6 }, span: 0..6 }"
-        ],
+        expect_test::expect![[
+            r#"UnaryOp { op: Pos, expr: Immediate { value: Int(1110), span: "test":1..6 }, span: "test":0..6 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "+0b01010101"),
-        expect_test::expect![
-            "UnaryOp { op: Pos, expr: Immediate { value: Int(85), span: 1..11 }, span: 0..11 }"
-        ],
+        expect_test::expect![[
+            r#"UnaryOp { op: Pos, expr: Immediate { value: Int(85), span: "test":1..11 }, span: "test":0..11 }"#
+        ]],
     );
     check(
         &run_parser!(
             expr(),
             "+0b1101000000001100101010101010101111111111101010101101010101010101"
         ),
-        expect_test::expect!["UnaryOp { op: Pos, expr: Immediate { value: BigInt(14991544915315053909), span: 1..67 }, span: 0..67 }"],
+        expect_test::expect![[
+            r#"UnaryOp { op: Pos, expr: Immediate { value: BigInt(14991544915315053909), span: "test":1..67 }, span: "test":0..67 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "-1.0"),
-        expect_test::expect![
-            "UnaryOp { op: Neg, expr: Immediate { value: Real(1.0), span: 1..4 }, span: 0..4 }"
-        ],
+        expect_test::expect![[
+            r#"UnaryOp { op: Neg, expr: Immediate { value: Real(1.0), span: "test":1..4 }, span: "test":0..4 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "-1"),
-        expect_test::expect![
-            "UnaryOp { op: Neg, expr: Immediate { value: Int(1), span: 1..2 }, span: 0..2 }"
-        ],
+        expect_test::expect![[
+            r#"UnaryOp { op: Neg, expr: Immediate { value: Int(1), span: "test":1..2 }, span: "test":0..2 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "-0x133"),
-        expect_test::expect![
-            "UnaryOp { op: Neg, expr: Immediate { value: Int(307), span: 1..6 }, span: 0..6 }"
-        ],
+        expect_test::expect![[
+            r#"UnaryOp { op: Neg, expr: Immediate { value: Int(307), span: "test":1..6 }, span: "test":0..6 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "-0b1101"),
-        expect_test::expect![
-            "UnaryOp { op: Neg, expr: Immediate { value: Int(13), span: 1..7 }, span: 0..7 }"
-        ],
+        expect_test::expect![[
+            r#"UnaryOp { op: Neg, expr: Immediate { value: Int(13), span: "test":1..7 }, span: "test":0..7 }"#
+        ]],
     );
     check(
         &run_parser!(
             expr(),
             "-0b1101000000001100101010101010101010101010101010101101010101010101"
         ),
-        expect_test::expect!["UnaryOp { op: Neg, expr: Immediate { value: BigInt(14991544909594023253), span: 1..67 }, span: 0..67 }"],
+        expect_test::expect![[
+            r#"UnaryOp { op: Neg, expr: Immediate { value: BigInt(14991544909594023253), span: "test":1..67 }, span: "test":0..67 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "! - - !  -+  -1"),
-        expect_test::expect!["UnaryOp { op: Not, expr: UnaryOp { op: Neg, expr: UnaryOp { op: Neg, expr: UnaryOp { op: Not, expr: UnaryOp { op: Neg, expr: UnaryOp { op: Pos, expr: UnaryOp { op: Neg, expr: Immediate { value: Int(1), span: 14..15 }, span: 13..15 }, span: 10..15 }, span: 9..15 }, span: 6..15 }, span: 4..15 }, span: 2..15 }, span: 0..15 }"],
+        expect_test::expect![[
+            r#"UnaryOp { op: Not, expr: UnaryOp { op: Neg, expr: UnaryOp { op: Neg, expr: UnaryOp { op: Not, expr: UnaryOp { op: Neg, expr: UnaryOp { op: Pos, expr: UnaryOp { op: Neg, expr: Immediate { value: Int(1), span: "test":14..15 }, span: "test":13..15 }, span: "test":10..15 }, span: "test":9..15 }, span: "test":6..15 }, span: "test":4..15 }, span: "test":2..15 }, span: "test":0..15 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "+ {- x} '  '  "),
         expect_test::expect![[
-            r#"UnaryOp { op: Pos, expr: UnaryOp { op: NextState, expr: UnaryOp { op: NextState, expr: Block(Block { statements: [], final_expr: UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "x", span: 5..6 }], is_absolute: false, span: 5..6 }), span: 3..6 }, span: 2..7 }), span: 2..9 }, span: 2..12 }, span: 0..12 }"#
+            r#"UnaryOp { op: Pos, expr: UnaryOp { op: NextState, expr: UnaryOp { op: NextState, expr: Block(Block { statements: [], final_expr: UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "x", span: "test":5..6 }], is_absolute: false, span: "test":5..6 }), span: "test":3..6 }, span: "test":2..7 }), span: "test":2..9 }, span: "test":2..12 }, span: "test":0..12 }"#
         ]],
     );
 }
@@ -445,99 +466,99 @@ fn binary_op_exprs() {
     check(
         &run_parser!(expr(), "a * 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
+            r#"BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Immediate { value: Real(2.0), span: "test":4..7 }, span: "test":0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a / 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Div, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
+            r#"BinaryOp { op: Div, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Immediate { value: Real(2.0), span: "test":4..7 }, span: "test":0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a % 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Mod, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
+            r#"BinaryOp { op: Mod, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Immediate { value: Real(2.0), span: "test":4..7 }, span: "test":0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a + 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
+            r#"BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Immediate { value: Real(2.0), span: "test":4..7 }, span: "test":0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a - 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Sub, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
+            r#"BinaryOp { op: Sub, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Immediate { value: Real(2.0), span: "test":4..7 }, span: "test":0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a+2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 2..5 }, span: 0..5 }"#
+            r#"BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Immediate { value: Real(2.0), span: "test":2..5 }, span: "test":0..5 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a-2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Sub, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 2..5 }, span: 0..5 }"#
+            r#"BinaryOp { op: Sub, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Immediate { value: Real(2.0), span: "test":2..5 }, span: "test":0..5 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a < 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
+            r#"BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Immediate { value: Real(2.0), span: "test":4..7 }, span: "test":0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a > 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 4..7 }, span: 0..7 }"#
+            r#"BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Immediate { value: Real(2.0), span: "test":4..7 }, span: "test":0..7 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a <= 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThanOrEqual, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 5..8 }, span: 0..8 }"#
+            r#"BinaryOp { op: LessThanOrEqual, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Immediate { value: Real(2.0), span: "test":5..8 }, span: "test":0..8 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a >= 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: GreaterThanOrEqual, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 5..8 }, span: 0..8 }"#
+            r#"BinaryOp { op: GreaterThanOrEqual, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Immediate { value: Real(2.0), span: "test":5..8 }, span: "test":0..8 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a == 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: Equal, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 5..8 }, span: 0..8 }"#
+            r#"BinaryOp { op: Equal, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Immediate { value: Real(2.0), span: "test":5..8 }, span: "test":0..8 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a != 2.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: NotEqual, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Immediate { value: Real(2.0), span: 5..8 }, span: 0..8 }"#
+            r#"BinaryOp { op: NotEqual, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Immediate { value: Real(2.0), span: "test":5..8 }, span: "test":0..8 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a && b"),
         expect_test::expect![[
-            r#"BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }), span: 0..6 }"#
+            r#"BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Path(Path { path: [Ident { name: "b", span: "test":5..6 }], is_absolute: false, span: "test":5..6 }), span: "test":0..6 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "a || b"),
         expect_test::expect![[
-            r#"BinaryOp { op: LogicalOr, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }), span: 0..6 }"#
+            r#"BinaryOp { op: LogicalOr, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: Path(Path { path: [Ident { name: "b", span: "test":5..6 }], is_absolute: false, span: "test":5..6 }), span: "test":0..6 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "a || b && c || d && !e"),
         expect_test::expect![[
-            r#"BinaryOp { op: LogicalOr, lhs: BinaryOp { op: LogicalOr, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }), rhs: Path(Path { path: [Ident { name: "c", span: 10..11 }], is_absolute: false, span: 10..11 }), span: 5..11 }, span: 0..11 }, rhs: BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "d", span: 15..16 }], is_absolute: false, span: 15..16 }), rhs: UnaryOp { op: Not, expr: Path(Path { path: [Ident { name: "e", span: 21..22 }], is_absolute: false, span: 21..22 }), span: 20..22 }, span: 15..22 }, span: 0..22 }"#
+            r#"BinaryOp { op: LogicalOr, lhs: BinaryOp { op: LogicalOr, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "b", span: "test":5..6 }], is_absolute: false, span: "test":5..6 }), rhs: Path(Path { path: [Ident { name: "c", span: "test":10..11 }], is_absolute: false, span: "test":10..11 }), span: "test":5..11 }, span: "test":0..11 }, rhs: BinaryOp { op: LogicalAnd, lhs: Path(Path { path: [Ident { name: "d", span: "test":15..16 }], is_absolute: false, span: "test":15..16 }), rhs: UnaryOp { op: Not, expr: Path(Path { path: [Ident { name: "e", span: "test":21..22 }], is_absolute: false, span: "test":21..22 }), span: "test":20..22 }, span: "test":15..22 }, span: "test":0..22 }"#
         ]],
     );
 }
@@ -547,82 +568,98 @@ fn complex_exprs() {
     check(
         &run_parser!(expr(), "2 * b * 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), span: 0..5 }, rhs: Immediate { value: Int(3), span: 8..9 }, span: 0..9 }"#
+            r#"BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(2), span: "test":0..1 }, rhs: Path(Path { path: [Ident { name: "b", span: "test":4..5 }], is_absolute: false, span: "test":4..5 }), span: "test":0..5 }, rhs: Immediate { value: Int(3), span: "test":8..9 }, span: "test":0..9 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 < b * 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), rhs: Immediate { value: Int(3), span: 8..9 }, span: 4..9 }, span: 0..9 }"#
+            r#"BinaryOp { op: LessThan, lhs: Immediate { value: Int(2), span: "test":0..1 }, rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: "test":4..5 }], is_absolute: false, span: "test":4..5 }), rhs: Immediate { value: Int(3), span: "test":8..9 }, span: "test":4..9 }, span: "test":0..9 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2.0 > b * 3.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: GreaterThan, lhs: Immediate { value: Real(2.0), span: 0..3 }, rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: 6..7 }], is_absolute: false, span: 6..7 }), rhs: Immediate { value: Real(3.0), span: 10..13 }, span: 6..13 }, span: 0..13 }"#
+            r#"BinaryOp { op: GreaterThan, lhs: Immediate { value: Real(2.0), span: "test":0..3 }, rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: "test":6..7 }], is_absolute: false, span: "test":6..7 }), rhs: Immediate { value: Real(3.0), span: "test":10..13 }, span: "test":6..13 }, span: "test":0..13 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2.0 * b < 3.0"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: Mul, lhs: Immediate { value: Real(2.0), span: 0..3 }, rhs: Path(Path { path: [Ident { name: "b", span: 6..7 }], is_absolute: false, span: 6..7 }), span: 0..7 }, rhs: Immediate { value: Real(3.0), span: 10..13 }, span: 0..13 }"#
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: Mul, lhs: Immediate { value: Real(2.0), span: "test":0..3 }, rhs: Path(Path { path: [Ident { name: "b", span: "test":6..7 }], is_absolute: false, span: "test":6..7 }), span: "test":0..7 }, rhs: Immediate { value: Real(3.0), span: "test":10..13 }, span: "test":0..13 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 > b < 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: GreaterThan, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), span: 0..5 }, rhs: Immediate { value: Int(3), span: 8..9 }, span: 0..9 }"#
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: GreaterThan, lhs: Immediate { value: Int(2), span: "test":0..1 }, rhs: Path(Path { path: [Ident { name: "b", span: "test":4..5 }], is_absolute: false, span: "test":4..5 }), span: "test":0..5 }, rhs: Immediate { value: Int(3), span: "test":8..9 }, span: "test":0..9 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 != b < 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: NotEqual, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: Path(Path { path: [Ident { name: "b", span: 5..6 }], is_absolute: false, span: 5..6 }), span: 0..6 }, rhs: Immediate { value: Int(3), span: 9..10 }, span: 0..10 }"#
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: NotEqual, lhs: Immediate { value: Int(2), span: "test":0..1 }, rhs: Path(Path { path: [Ident { name: "b", span: "test":5..6 }], is_absolute: false, span: "test":5..6 }), span: "test":0..6 }, rhs: Immediate { value: Int(3), span: "test":9..10 }, span: "test":0..10 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 < b != 3"),
         expect_test::expect![[
-            r#"BinaryOp { op: NotEqual, lhs: BinaryOp { op: LessThan, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), span: 0..5 }, rhs: Immediate { value: Int(3), span: 9..10 }, span: 0..10 }"#
+            r#"BinaryOp { op: NotEqual, lhs: BinaryOp { op: LessThan, lhs: Immediate { value: Int(2), span: "test":0..1 }, rhs: Path(Path { path: [Ident { name: "b", span: "test":4..5 }], is_absolute: false, span: "test":4..5 }), span: "test":0..5 }, rhs: Immediate { value: Int(3), span: "test":9..10 }, span: "test":0..10 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "a > b * c < d"),
         expect_test::expect![[
-            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: 4..5 }], is_absolute: false, span: 4..5 }), rhs: Path(Path { path: [Ident { name: "c", span: 8..9 }], is_absolute: false, span: 8..9 }), span: 4..9 }, span: 0..9 }, rhs: Path(Path { path: [Ident { name: "d", span: 12..13 }], is_absolute: false, span: 12..13 }), span: 0..13 }"#
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "b", span: "test":4..5 }], is_absolute: false, span: "test":4..5 }), rhs: Path(Path { path: [Ident { name: "c", span: "test":8..9 }], is_absolute: false, span: "test":8..9 }), span: "test":4..9 }, span: "test":0..9 }, rhs: Path(Path { path: [Ident { name: "d", span: "test":12..13 }], is_absolute: false, span: "test":12..13 }), span: "test":0..13 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "2 + 3 * 4"),
-        expect_test::expect!["BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(3), span: 4..5 }, rhs: Immediate { value: Int(4), span: 8..9 }, span: 4..9 }, span: 0..9 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: "test":0..1 }, rhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(3), span: "test":4..5 }, rhs: Immediate { value: Int(4), span: "test":8..9 }, span: "test":4..9 }, span: "test":0..9 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "10 - 8 / 4"),
-        expect_test::expect!["BinaryOp { op: Sub, lhs: Immediate { value: Int(10), span: 0..2 }, rhs: BinaryOp { op: Div, lhs: Immediate { value: Int(8), span: 5..6 }, rhs: Immediate { value: Int(4), span: 9..10 }, span: 5..10 }, span: 0..10 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: Sub, lhs: Immediate { value: Int(10), span: "test":0..2 }, rhs: BinaryOp { op: Div, lhs: Immediate { value: Int(8), span: "test":5..6 }, rhs: Immediate { value: Int(4), span: "test":9..10 }, span: "test":5..10 }, span: "test":0..10 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "10 + 8 % 4"),
-        expect_test::expect!["BinaryOp { op: Add, lhs: Immediate { value: Int(10), span: 0..2 }, rhs: BinaryOp { op: Mod, lhs: Immediate { value: Int(8), span: 5..6 }, rhs: Immediate { value: Int(4), span: 9..10 }, span: 5..10 }, span: 0..10 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: Add, lhs: Immediate { value: Int(10), span: "test":0..2 }, rhs: BinaryOp { op: Mod, lhs: Immediate { value: Int(8), span: "test":5..6 }, rhs: Immediate { value: Int(4), span: "test":9..10 }, span: "test":5..10 }, span: "test":0..10 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "2 + 3 * 4 < 5"),
-        expect_test::expect!["BinaryOp { op: LessThan, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(3), span: 4..5 }, rhs: Immediate { value: Int(4), span: 8..9 }, span: 4..9 }, span: 0..9 }, rhs: Immediate { value: Int(5), span: 12..13 }, span: 0..13 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: "test":0..1 }, rhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(3), span: "test":4..5 }, rhs: Immediate { value: Int(4), span: "test":8..9 }, span: "test":4..9 }, span: "test":0..9 }, rhs: Immediate { value: Int(5), span: "test":12..13 }, span: "test":0..13 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "2 * 3 / 4 < 5"),
-        expect_test::expect!["BinaryOp { op: LessThan, lhs: BinaryOp { op: Div, lhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: Immediate { value: Int(3), span: 4..5 }, span: 0..5 }, rhs: Immediate { value: Int(4), span: 8..9 }, span: 0..9 }, rhs: Immediate { value: Int(5), span: 12..13 }, span: 0..13 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: Div, lhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(2), span: "test":0..1 }, rhs: Immediate { value: Int(3), span: "test":4..5 }, span: "test":0..5 }, rhs: Immediate { value: Int(4), span: "test":8..9 }, span: "test":0..9 }, rhs: Immediate { value: Int(5), span: "test":12..13 }, span: "test":0..13 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "10 - 5 + 3 > 7"),
-        expect_test::expect!["BinaryOp { op: GreaterThan, lhs: BinaryOp { op: Add, lhs: BinaryOp { op: Sub, lhs: Immediate { value: Int(10), span: 0..2 }, rhs: Immediate { value: Int(5), span: 5..6 }, span: 0..6 }, rhs: Immediate { value: Int(3), span: 9..10 }, span: 0..10 }, rhs: Immediate { value: Int(7), span: 13..14 }, span: 0..14 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: GreaterThan, lhs: BinaryOp { op: Add, lhs: BinaryOp { op: Sub, lhs: Immediate { value: Int(10), span: "test":0..2 }, rhs: Immediate { value: Int(5), span: "test":5..6 }, span: "test":0..6 }, rhs: Immediate { value: Int(3), span: "test":9..10 }, span: "test":0..10 }, rhs: Immediate { value: Int(7), span: "test":13..14 }, span: "test":0..14 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "10 % 2 * 4 < 3"),
-        expect_test::expect!["BinaryOp { op: LessThan, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Mod, lhs: Immediate { value: Int(10), span: 0..2 }, rhs: Immediate { value: Int(2), span: 5..6 }, span: 0..6 }, rhs: Immediate { value: Int(4), span: 9..10 }, span: 0..10 }, rhs: Immediate { value: Int(3), span: 13..14 }, span: 0..14 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: LessThan, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Mod, lhs: Immediate { value: Int(10), span: "test":0..2 }, rhs: Immediate { value: Int(2), span: "test":5..6 }, span: "test":0..6 }, rhs: Immediate { value: Int(4), span: "test":9..10 }, span: "test":0..10 }, rhs: Immediate { value: Int(3), span: "test":13..14 }, span: "test":0..14 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "2 + 3 * 4 - 5 / 2 > 1"),
-        expect_test::expect!["BinaryOp { op: GreaterThan, lhs: BinaryOp { op: Sub, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: 0..1 }, rhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(3), span: 4..5 }, rhs: Immediate { value: Int(4), span: 8..9 }, span: 4..9 }, span: 0..9 }, rhs: BinaryOp { op: Div, lhs: Immediate { value: Int(5), span: 12..13 }, rhs: Immediate { value: Int(2), span: 16..17 }, span: 12..17 }, span: 0..17 }, rhs: Immediate { value: Int(1), span: 20..21 }, span: 0..21 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: GreaterThan, lhs: BinaryOp { op: Sub, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: "test":0..1 }, rhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(3), span: "test":4..5 }, rhs: Immediate { value: Int(4), span: "test":8..9 }, span: "test":4..9 }, span: "test":0..9 }, rhs: BinaryOp { op: Div, lhs: Immediate { value: Int(5), span: "test":12..13 }, rhs: Immediate { value: Int(2), span: "test":16..17 }, span: "test":12..17 }, span: "test":0..17 }, rhs: Immediate { value: Int(1), span: "test":20..21 }, span: "test":0..21 }"#
+        ]],
     );
 }
 
@@ -630,78 +667,108 @@ fn complex_exprs() {
 fn parens_exprs() {
     check(
         &run_parser!(expr(), "(1 + 2) * 3"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: Immediate { value: Int(2), span: 5..6 }, span: 1..6 }, rhs: Immediate { value: Int(3), span: 10..11 }, span: 1..11 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: "test":1..2 }, rhs: Immediate { value: Int(2), span: "test":5..6 }, span: "test":1..6 }, rhs: Immediate { value: Int(3), span: "test":10..11 }, span: "test":1..11 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "1 * (2 + 3)"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: 5..6 }, rhs: Immediate { value: Int(3), span: 9..10 }, span: 5..10 }, span: 0..11 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: Mul, lhs: Immediate { value: Int(1), span: "test":0..1 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: "test":5..6 }, rhs: Immediate { value: Int(3), span: "test":9..10 }, span: "test":5..10 }, span: "test":0..11 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "(1 + 2) * (3 + 4)"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: Immediate { value: Int(2), span: 5..6 }, span: 1..6 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(3), span: 11..12 }, rhs: Immediate { value: Int(4), span: 15..16 }, span: 11..16 }, span: 1..17 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: "test":1..2 }, rhs: Immediate { value: Int(2), span: "test":5..6 }, span: "test":1..6 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(3), span: "test":11..12 }, rhs: Immediate { value: Int(4), span: "test":15..16 }, span: "test":11..16 }, span: "test":1..17 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "(1 + (2 * 3)) * 4"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(2), span: 6..7 }, rhs: Immediate { value: Int(3), span: 10..11 }, span: 6..11 }, span: 1..12 }, rhs: Immediate { value: Int(4), span: 16..17 }, span: 1..17 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: "test":1..2 }, rhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(2), span: "test":6..7 }, rhs: Immediate { value: Int(3), span: "test":10..11 }, span: "test":6..11 }, span: "test":1..12 }, rhs: Immediate { value: Int(4), span: "test":16..17 }, span: "test":1..17 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "(1 * (2 + 3)) * 4"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: 6..7 }, rhs: Immediate { value: Int(3), span: 10..11 }, span: 6..11 }, span: 1..12 }, rhs: Immediate { value: Int(4), span: 16..17 }, span: 1..17 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: Immediate { value: Int(1), span: "test":1..2 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: "test":6..7 }, rhs: Immediate { value: Int(3), span: "test":10..11 }, span: "test":6..11 }, span: "test":1..12 }, rhs: Immediate { value: Int(4), span: "test":16..17 }, span: "test":1..17 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "((1 + 2) * 3) * 4"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 2..3 }, rhs: Immediate { value: Int(2), span: 6..7 }, span: 2..7 }, rhs: Immediate { value: Int(3), span: 11..12 }, span: 2..12 }, rhs: Immediate { value: Int(4), span: 16..17 }, span: 2..17 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: "test":2..3 }, rhs: Immediate { value: Int(2), span: "test":6..7 }, span: "test":2..7 }, rhs: Immediate { value: Int(3), span: "test":11..12 }, span: "test":2..12 }, rhs: Immediate { value: Int(4), span: "test":16..17 }, span: "test":2..17 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "((1 + 2) * (3 + 4)) * 5"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 2..3 }, rhs: Immediate { value: Int(2), span: 6..7 }, span: 2..7 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(3), span: 12..13 }, rhs: Immediate { value: Int(4), span: 16..17 }, span: 12..17 }, span: 2..18 }, rhs: Immediate { value: Int(5), span: 22..23 }, span: 2..23 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: Mul, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: "test":2..3 }, rhs: Immediate { value: Int(2), span: "test":6..7 }, span: "test":2..7 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(3), span: "test":12..13 }, rhs: Immediate { value: Int(4), span: "test":16..17 }, span: "test":12..17 }, span: "test":2..18 }, rhs: Immediate { value: Int(5), span: "test":22..23 }, span: "test":2..23 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "(1 + 2) * 3 / 4"),
-        expect_test::expect!["BinaryOp { op: Div, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: Immediate { value: Int(2), span: 5..6 }, span: 1..6 }, rhs: Immediate { value: Int(3), span: 10..11 }, span: 1..11 }, rhs: Immediate { value: Int(4), span: 14..15 }, span: 1..15 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: Div, lhs: BinaryOp { op: Mul, lhs: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: "test":1..2 }, rhs: Immediate { value: Int(2), span: "test":5..6 }, span: "test":1..6 }, rhs: Immediate { value: Int(3), span: "test":10..11 }, span: "test":1..11 }, rhs: Immediate { value: Int(4), span: "test":14..15 }, span: "test":1..15 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "1 / (2 + 3) * 4"),
-        expect_test::expect!["BinaryOp { op: Mul, lhs: BinaryOp { op: Div, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: 5..6 }, rhs: Immediate { value: Int(3), span: 9..10 }, span: 5..10 }, span: 0..11 }, rhs: Immediate { value: Int(4), span: 14..15 }, span: 0..15 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: Mul, lhs: BinaryOp { op: Div, lhs: Immediate { value: Int(1), span: "test":0..1 }, rhs: BinaryOp { op: Add, lhs: Immediate { value: Int(2), span: "test":5..6 }, rhs: Immediate { value: Int(3), span: "test":9..10 }, span: "test":5..10 }, span: "test":0..11 }, rhs: Immediate { value: Int(4), span: "test":14..15 }, span: "test":0..15 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "(1 < 2) && (3 > 4)"),
-        expect_test::expect!["BinaryOp { op: LogicalAnd, lhs: BinaryOp { op: LessThan, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: Immediate { value: Int(2), span: 5..6 }, span: 1..6 }, rhs: BinaryOp { op: GreaterThan, lhs: Immediate { value: Int(3), span: 12..13 }, rhs: Immediate { value: Int(4), span: 16..17 }, span: 12..17 }, span: 1..18 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: LogicalAnd, lhs: BinaryOp { op: LessThan, lhs: Immediate { value: Int(1), span: "test":1..2 }, rhs: Immediate { value: Int(2), span: "test":5..6 }, span: "test":1..6 }, rhs: BinaryOp { op: GreaterThan, lhs: Immediate { value: Int(3), span: "test":12..13 }, rhs: Immediate { value: Int(4), span: "test":16..17 }, span: "test":12..17 }, span: "test":1..18 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "(1 == 2) || (3 != 4)"),
-        expect_test::expect!["BinaryOp { op: LogicalOr, lhs: BinaryOp { op: Equal, lhs: Immediate { value: Int(1), span: 1..2 }, rhs: Immediate { value: Int(2), span: 6..7 }, span: 1..7 }, rhs: BinaryOp { op: NotEqual, lhs: Immediate { value: Int(3), span: 13..14 }, rhs: Immediate { value: Int(4), span: 18..19 }, span: 13..19 }, span: 1..20 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: LogicalOr, lhs: BinaryOp { op: Equal, lhs: Immediate { value: Int(1), span: "test":1..2 }, rhs: Immediate { value: Int(2), span: "test":6..7 }, span: "test":1..7 }, rhs: BinaryOp { op: NotEqual, lhs: Immediate { value: Int(3), span: "test":13..14 }, rhs: Immediate { value: Int(4), span: "test":18..19 }, span: "test":13..19 }, span: "test":1..20 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "1 < (2 && 3) > 4"),
-        expect_test::expect!["BinaryOp { op: GreaterThan, lhs: BinaryOp { op: LessThan, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: BinaryOp { op: LogicalAnd, lhs: Immediate { value: Int(2), span: 5..6 }, rhs: Immediate { value: Int(3), span: 10..11 }, span: 5..11 }, span: 0..12 }, rhs: Immediate { value: Int(4), span: 15..16 }, span: 0..16 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: GreaterThan, lhs: BinaryOp { op: LessThan, lhs: Immediate { value: Int(1), span: "test":0..1 }, rhs: BinaryOp { op: LogicalAnd, lhs: Immediate { value: Int(2), span: "test":5..6 }, rhs: Immediate { value: Int(3), span: "test":10..11 }, span: "test":5..11 }, span: "test":0..12 }, rhs: Immediate { value: Int(4), span: "test":15..16 }, span: "test":0..16 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "1 && (2 || 3)"),
-        expect_test::expect!["BinaryOp { op: LogicalAnd, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: BinaryOp { op: LogicalOr, lhs: Immediate { value: Int(2), span: 6..7 }, rhs: Immediate { value: Int(3), span: 11..12 }, span: 6..12 }, span: 0..13 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: LogicalAnd, lhs: Immediate { value: Int(1), span: "test":0..1 }, rhs: BinaryOp { op: LogicalOr, lhs: Immediate { value: Int(2), span: "test":6..7 }, rhs: Immediate { value: Int(3), span: "test":11..12 }, span: "test":6..12 }, span: "test":0..13 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "1 == (2 || 3) != 4"),
-        expect_test::expect!["BinaryOp { op: NotEqual, lhs: BinaryOp { op: Equal, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: BinaryOp { op: LogicalOr, lhs: Immediate { value: Int(2), span: 6..7 }, rhs: Immediate { value: Int(3), span: 11..12 }, span: 6..12 }, span: 0..13 }, rhs: Immediate { value: Int(4), span: 17..18 }, span: 0..18 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: NotEqual, lhs: BinaryOp { op: Equal, lhs: Immediate { value: Int(1), span: "test":0..1 }, rhs: BinaryOp { op: LogicalOr, lhs: Immediate { value: Int(2), span: "test":6..7 }, rhs: Immediate { value: Int(3), span: "test":11..12 }, span: "test":6..12 }, span: "test":0..13 }, rhs: Immediate { value: Int(4), span: "test":17..18 }, span: "test":0..18 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "-(1 + 2)"),
-        expect_test::expect!["UnaryOp { op: Neg, expr: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 2..3 }, rhs: Immediate { value: Int(2), span: 6..7 }, span: 2..7 }, span: 0..8 }"],
+        expect_test::expect![[
+            r#"UnaryOp { op: Neg, expr: BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: "test":2..3 }, rhs: Immediate { value: Int(2), span: "test":6..7 }, span: "test":2..7 }, span: "test":0..8 }"#
+        ]],
     );
     check(
         &run_parser!(expr(), "!(a < b)"),
         expect_test::expect![[
-            r#"UnaryOp { op: Not, expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: 2..3 }], is_absolute: false, span: 2..3 }), rhs: Path(Path { path: [Ident { name: "b", span: 6..7 }], is_absolute: false, span: 6..7 }), span: 2..7 }, span: 0..8 }"#
+            r#"UnaryOp { op: Not, expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: "test":2..3 }], is_absolute: false, span: "test":2..3 }), rhs: Path(Path { path: [Ident { name: "b", span: "test":6..7 }], is_absolute: false, span: "test":6..7 }), span: "test":2..7 }, span: "test":0..8 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "(1)"),
-        expect_test::expect!["Immediate { value: Int(1), span: 1..2 }"],
+        expect_test::expect![[r#"Immediate { value: Int(1), span: "test":1..2 }"#]],
     );
     check(
         &run_parser!(expr(), "(a)"),
         expect_test::expect![[
-            r#"Path(Path { path: [Ident { name: "a", span: 1..2 }], is_absolute: false, span: 1..2 })"#
+            r#"Path(Path { path: [Ident { name: "a", span: "test":1..2 }], is_absolute: false, span: "test":1..2 })"#
         ]],
     );
     check(
@@ -714,13 +781,13 @@ fn parens_exprs() {
     check(
         &run_parser!(expr(), "(if a < b { 1 } else { 2 })"),
         expect_test::expect![[
-            r#"If { condition: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: 4..5 }], is_absolute: false, span: 4..5 }), rhs: Path(Path { path: [Ident { name: "b", span: 8..9 }], is_absolute: false, span: 8..9 }), span: 4..9 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 12..13 }, span: 10..15 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: 23..24 }, span: 21..26 }, span: 1..26 }"#
+            r#"If { condition: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "a", span: "test":4..5 }], is_absolute: false, span: "test":4..5 }), rhs: Path(Path { path: [Ident { name: "b", span: "test":8..9 }], is_absolute: false, span: "test":8..9 }), span: "test":4..9 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: "test":12..13 }, span: "test":10..15 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: "test":23..24 }, span: "test":21..26 }, span: "test":1..26 }"#
         ]],
     );
     check(
         &run_parser!(expr(), "(foo(a, b, c))"),
         expect_test::expect![[
-            r#"Call { name: Path { path: [Ident { name: "foo", span: 1..4 }], is_absolute: false, span: 1..4 }, args: [Path(Path { path: [Ident { name: "a", span: 5..6 }], is_absolute: false, span: 5..6 }), Path(Path { path: [Ident { name: "b", span: 8..9 }], is_absolute: false, span: 8..9 }), Path(Path { path: [Ident { name: "c", span: 11..12 }], is_absolute: false, span: 11..12 })], span: 1..13 }"#
+            r#"Call { name: Path { path: [Ident { name: "foo", span: "test":1..4 }], is_absolute: false, span: "test":1..4 }, args: [Path(Path { path: [Ident { name: "a", span: "test":5..6 }], is_absolute: false, span: "test":5..6 }), Path(Path { path: [Ident { name: "b", span: "test":8..9 }], is_absolute: false, span: "test":8..9 }), Path(Path { path: [Ident { name: "c", span: "test":11..12 }], is_absolute: false, span: "test":11..12 })], span: "test":1..13 }"#
         ]],
     );
 }
@@ -730,19 +797,19 @@ fn enums() {
     check(
         &run_parser!(enum_decl(), "enum MyEnum = Variant1 | Variant2;"),
         expect_test::expect![[
-            r#"Enum(EnumDecl { name: Ident { name: "MyEnum", span: 5..11 }, variants: [Ident { name: "Variant1", span: 14..22 }, Ident { name: "Variant2", span: 25..33 }], span: 0..34 })"#
+            r#"Enum(EnumDecl { name: Ident { name: "MyEnum", span: "test":5..11 }, variants: [Ident { name: "Variant1", span: "test":14..22 }, Ident { name: "Variant2", span: "test":25..33 }], span: "test":0..34 })"#
         ]],
     );
     check(
         &run_parser!(enum_decl(), "enum MyEnum = Variant1;"),
         expect_test::expect![[
-            r#"Enum(EnumDecl { name: Ident { name: "MyEnum", span: 5..11 }, variants: [Ident { name: "Variant1", span: 14..22 }], span: 0..23 })"#
+            r#"Enum(EnumDecl { name: Ident { name: "MyEnum", span: "test":5..11 }, variants: [Ident { name: "Variant1", span: "test":14..22 }], span: "test":0..23 })"#
         ]],
     );
     check(
         &run_parser!(expr(), "MyEnum::Variant1"),
         expect_test::expect![[
-            r#"Path(Path { path: [Ident { name: "MyEnum", span: 0..6 }, Ident { name: "Variant1", span: 8..16 }], is_absolute: false, span: 0..16 })"#
+            r#"Path(Path { path: [Ident { name: "MyEnum", span: "test":0..6 }, Ident { name: "Variant1", span: "test":8..16 }], is_absolute: false, span: "test":0..16 })"#
         ]],
     );
     check(
@@ -753,7 +820,7 @@ fn enums() {
             "#
         ),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "x", span: 17..18 }, ty: None, init: Some(Path(Path { path: [Ident { name: "MyEnum", span: 21..27 }, Ident { name: "Variant3", span: 29..37 }], is_absolute: false, span: 21..37 })), span: 13..38 }"#
+            r#"Let { name: Ident { name: "x", span: "test":17..18 }, ty: None, init: Some(Path(Path { path: [Ident { name: "MyEnum", span: "test":21..27 }, Ident { name: "Variant3", span: "test":29..37 }], is_absolute: false, span: "test":21..37 })), span: "test":13..38 }"#
         ]],
     );
     check(
@@ -764,7 +831,7 @@ fn enums() {
             "#
         ),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "e", span: 17..18 }, ty: Some(CustomType { path: Path { path: [Ident { name: "path", span: 22..26 }, Ident { name: "to", span: 28..30 }, Ident { name: "MyEnum", span: 32..38 }], is_absolute: true, span: 20..38 }, span: 20..38 }), init: None, span: 13..39 }"#
+            r#"Let { name: Ident { name: "e", span: "test":17..18 }, ty: Some(CustomType { path: Path { path: [Ident { name: "path", span: "test":22..26 }, Ident { name: "to", span: "test":28..30 }, Ident { name: "MyEnum", span: "test":32..38 }], is_absolute: true, span: "test":20..38 }, span: "test":20..38 }), init: None, span: "test":13..39 }"#
         ]],
     );
 }
@@ -774,50 +841,50 @@ fn custom_types() {
     check(
         &run_parser!(type_(expr()), "custom_type"),
         expect_test::expect![[
-            r#"CustomType { path: Path { path: [Ident { name: "custom_type", span: 0..11 }], is_absolute: false, span: 0..11 }, span: 0..11 }"#
+            r#"CustomType { path: Path { path: [Ident { name: "custom_type", span: "test":0..11 }], is_absolute: false, span: "test":0..11 }, span: "test":0..11 }"#
         ]],
     );
     check(
         &run_parser!(type_decl(), "type MyInt = int;"),
-        expect_test::expect![
-            r#"NewType { name: Ident { name: "MyInt", span: 5..10 }, ty: Primitive { kind: Int, span: 13..16 }, span: 0..17 }"#
-        ],
+        expect_test::expect![[
+            r#"NewType { name: Ident { name: "MyInt", span: "test":5..10 }, ty: Primitive { kind: Int, span: "test":13..16 }, span: "test":0..17 }"#
+        ]],
     );
     check(
         &run_parser!(type_decl(), "type MyReal = real;"),
-        expect_test::expect![
-            r#"NewType { name: Ident { name: "MyReal", span: 5..11 }, ty: Primitive { kind: Real, span: 14..18 }, span: 0..19 }"#
-        ],
+        expect_test::expect![[
+            r#"NewType { name: Ident { name: "MyReal", span: "test":5..11 }, ty: Primitive { kind: Real, span: "test":14..18 }, span: "test":0..19 }"#
+        ]],
     );
     check(
         &run_parser!(type_decl(), "type MyBool = bool;"),
-        expect_test::expect![
-            r#"NewType { name: Ident { name: "MyBool", span: 5..11 }, ty: Primitive { kind: Bool, span: 14..18 }, span: 0..19 }"#
-        ],
+        expect_test::expect![[
+            r#"NewType { name: Ident { name: "MyBool", span: "test":5..11 }, ty: Primitive { kind: Bool, span: "test":14..18 }, span: "test":0..19 }"#
+        ]],
     );
     check(
         &run_parser!(type_decl(), "type MyString = string;"),
-        expect_test::expect![
-            r#"NewType { name: Ident { name: "MyString", span: 5..13 }, ty: Primitive { kind: String, span: 16..22 }, span: 0..23 }"#
-        ],
+        expect_test::expect![[
+            r#"NewType { name: Ident { name: "MyString", span: "test":5..13 }, ty: Primitive { kind: String, span: "test":16..22 }, span: "test":0..23 }"#
+        ]],
     );
     check(
         &run_parser!(type_decl(), "type IntArray = int[5];"),
-        expect_test::expect![
-            r#"NewType { name: Ident { name: "IntArray", span: 5..13 }, ty: Array { ty: Primitive { kind: Int, span: 16..19 }, range: Immediate { value: Int(5), span: 20..21 }, span: 16..22 }, span: 0..23 }"#
-        ],
+        expect_test::expect![[
+            r#"NewType { name: Ident { name: "IntArray", span: "test":5..13 }, ty: Array { ty: Primitive { kind: Int, span: "test":16..19 }, range: Immediate { value: Int(5), span: "test":20..21 }, span: "test":16..22 }, span: "test":0..23 }"#
+        ]],
     );
     check(
         &run_parser!(type_decl(), "type MyTuple = { int, real, z: string };"),
         expect_test::expect![[
-            r#"NewType { name: Ident { name: "MyTuple", span: 5..12 }, ty: Tuple { fields: [(None, Primitive { kind: Int, span: 17..20 }), (None, Primitive { kind: Real, span: 22..26 }), (Some(Ident { name: "z", span: 28..29 }), Primitive { kind: String, span: 31..37 })], span: 15..39 }, span: 0..40 }"#
+            r#"NewType { name: Ident { name: "MyTuple", span: "test":5..12 }, ty: Tuple { fields: [(None, Primitive { kind: Int, span: "test":17..20 }), (None, Primitive { kind: Real, span: "test":22..26 }), (Some(Ident { name: "z", span: "test":28..29 }), Primitive { kind: String, span: "test":31..37 })], span: "test":15..39 }, span: "test":0..40 }"#
         ]],
     );
     check(
         &run_parser!(type_decl(), "type MyAliasInt = MyInt;"),
-        expect_test::expect![
-            r#"NewType { name: Ident { name: "MyAliasInt", span: 5..15 }, ty: CustomType { path: Path { path: [Ident { name: "MyInt", span: 18..23 }], is_absolute: false, span: 18..23 }, span: 18..23 }, span: 0..24 }"#
-        ],
+        expect_test::expect![[
+            r#"NewType { name: Ident { name: "MyAliasInt", span: "test":5..15 }, ty: CustomType { path: Path { path: [Ident { name: "MyInt", span: "test":18..23 }], is_absolute: false, span: "test":18..23 }, span: "test":18..23 }, span: "test":0..24 }"#
+        ]],
     );
 }
 
@@ -825,27 +892,27 @@ fn custom_types() {
 fn idents() {
     check(
         &run_parser!(ident(), "foobar"),
-        expect_test::expect![[r#"Ident { name: "foobar", span: 0..6 }"#]],
+        expect_test::expect![[r#"Ident { name: "foobar", span: "test":0..6 }"#]],
     );
     check(
         &run_parser!(ident(), "foo_bar"),
-        expect_test::expect![[r#"Ident { name: "foo_bar", span: 0..7 }"#]],
+        expect_test::expect![[r#"Ident { name: "foo_bar", span: "test":0..7 }"#]],
     );
     check(
         &run_parser!(ident(), "FOO_bar"),
-        expect_test::expect![[r#"Ident { name: "FOO_bar", span: 0..7 }"#]],
+        expect_test::expect![[r#"Ident { name: "FOO_bar", span: "test":0..7 }"#]],
     );
     check(
         &run_parser!(ident(), "__FOO"),
-        expect_test::expect![[r#"Ident { name: "__FOO", span: 0..5 }"#]],
+        expect_test::expect![[r#"Ident { name: "__FOO", span: "test":0..5 }"#]],
     );
     check(
         &run_parser!(ident(), "_2_FOO1"),
-        expect_test::expect![[r#"Ident { name: "_2_FOO1", span: 0..7 }"#]],
+        expect_test::expect![[r#"Ident { name: "_2_FOO1", span: "test":0..7 }"#]],
     );
     check(
         &run_parser!(ident(), "_"),
-        expect_test::expect![[r#"Ident { name: "_", span: 0..1 }"#]],
+        expect_test::expect![[r#"Ident { name: "_", span: "test":0..1 }"#]],
     );
     check(
         &run_parser!(ident(), "12_ab"),
@@ -870,31 +937,31 @@ fn paths() {
     check(
         &run_parser!(path(), "foo::bar"),
         expect_test::expect![[
-            r#"Path { path: [Ident { name: "foo", span: 0..3 }, Ident { name: "bar", span: 5..8 }], is_absolute: false, span: 0..8 }"#
+            r#"Path { path: [Ident { name: "foo", span: "test":0..3 }, Ident { name: "bar", span: "test":5..8 }], is_absolute: false, span: "test":0..8 }"#
         ]],
     );
     check(
         &run_parser!(path(), "_foo_::_bar"),
         expect_test::expect![[
-            r#"Path { path: [Ident { name: "_foo_", span: 0..5 }, Ident { name: "_bar", span: 7..11 }], is_absolute: false, span: 0..11 }"#
+            r#"Path { path: [Ident { name: "_foo_", span: "test":0..5 }, Ident { name: "_bar", span: "test":7..11 }], is_absolute: false, span: "test":0..11 }"#
         ]],
     );
     check(
         &run_parser!(path(), "_::_"),
         expect_test::expect![[
-            r#"Path { path: [Ident { name: "_", span: 0..1 }, Ident { name: "_", span: 3..4 }], is_absolute: false, span: 0..4 }"#
+            r#"Path { path: [Ident { name: "_", span: "test":0..1 }, Ident { name: "_", span: "test":3..4 }], is_absolute: false, span: "test":0..4 }"#
         ]],
     );
     check(
         &run_parser!(path(), "t2::_3t::t4_::t"),
         expect_test::expect![[
-            r#"Path { path: [Ident { name: "t2", span: 0..2 }, Ident { name: "_3t", span: 4..7 }, Ident { name: "t4_", span: 9..12 }, Ident { name: "t", span: 14..15 }], is_absolute: false, span: 0..15 }"#
+            r#"Path { path: [Ident { name: "t2", span: "test":0..2 }, Ident { name: "_3t", span: "test":4..7 }, Ident { name: "t4_", span: "test":9..12 }, Ident { name: "t", span: "test":14..15 }], is_absolute: false, span: "test":0..15 }"#
         ]],
     );
     check(
         &run_parser!(path(), "::foo::bar"),
         expect_test::expect![[
-            r#"Path { path: [Ident { name: "foo", span: 2..5 }, Ident { name: "bar", span: 7..10 }], is_absolute: true, span: 0..10 }"#
+            r#"Path { path: [Ident { name: "foo", span: "test":2..5 }, Ident { name: "bar", span: "test":7..10 }], is_absolute: true, span: "test":0..10 }"#
         ]],
     );
 
@@ -927,7 +994,7 @@ fn foo(x: real, y: real) -> real {
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Fn { fn_sig: FnSig { name: Ident { name: "foo", span: 4..7 }, params: [(Ident { name: "x", span: 8..9 }, Primitive { kind: Real, span: 11..15 }), (Ident { name: "y", span: 17..18 }, Primitive { kind: Real, span: 20..24 })], return_type: Primitive { kind: Real, span: 29..33 }, span: 1..33 }, body: Block { statements: [Let { name: Ident { name: "z", span: 44..45 }, ty: None, init: Some(Immediate { value: Real(5.0), span: 48..51 }), span: 40..52 }], final_expr: Path(Path { path: [Ident { name: "z", span: 57..58 }], is_absolute: false, span: 57..58 }), span: 34..60 }, span: 1..60 }]"#
+            r#"[Fn { fn_sig: FnSig { name: Ident { name: "foo", span: "test":4..7 }, params: [(Ident { name: "x", span: "test":8..9 }, Primitive { kind: Real, span: "test":11..15 }), (Ident { name: "y", span: "test":17..18 }, Primitive { kind: Real, span: "test":20..24 })], return_type: Primitive { kind: Real, span: "test":29..33 }, span: "test":1..33 }, body: Block { statements: [Let { name: Ident { name: "z", span: "test":44..45 }, ty: None, init: Some(Immediate { value: Real(5.0), span: "test":48..51 }), span: "test":40..52 }], final_expr: Path(Path { path: [Ident { name: "z", span: "test":57..58 }], is_absolute: false, span: "test":57..58 }), span: "test":34..60 }, span: "test":1..60 }]"#
         ]],
     );
 }
@@ -941,14 +1008,14 @@ let x = foo(a*3, c);
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Let { name: Ident { name: "x", span: 5..6 }, ty: None, init: Some(Call { name: Path { path: [Ident { name: "foo", span: 9..12 }], is_absolute: false, span: 9..12 }, args: [BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "a", span: 13..14 }], is_absolute: false, span: 13..14 }), rhs: Immediate { value: Int(3), span: 15..16 }, span: 13..16 }, Path(Path { path: [Ident { name: "c", span: 18..19 }], is_absolute: false, span: 18..19 })], span: 9..20 }), span: 1..21 }]"#
+            r#"[Let { name: Ident { name: "x", span: "test":5..6 }, ty: None, init: Some(Call { name: Path { path: [Ident { name: "foo", span: "test":9..12 }], is_absolute: false, span: "test":9..12 }, args: [BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "a", span: "test":13..14 }], is_absolute: false, span: "test":13..14 }), rhs: Immediate { value: Int(3), span: "test":15..16 }, span: "test":13..16 }, Path(Path { path: [Ident { name: "c", span: "test":18..19 }], is_absolute: false, span: "test":18..19 })], span: "test":9..20 }), span: "test":1..21 }]"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "A::B::foo(-a, b+c)"),
         expect_test::expect![[
-            r#"Call { name: Path { path: [Ident { name: "A", span: 0..1 }, Ident { name: "B", span: 3..4 }, Ident { name: "foo", span: 6..9 }], is_absolute: false, span: 0..9 }, args: [UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "a", span: 11..12 }], is_absolute: false, span: 11..12 }), span: 10..12 }, BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "b", span: 14..15 }], is_absolute: false, span: 14..15 }), rhs: Path(Path { path: [Ident { name: "c", span: 16..17 }], is_absolute: false, span: 16..17 }), span: 14..17 }], span: 0..18 }"#
+            r#"Call { name: Path { path: [Ident { name: "A", span: "test":0..1 }, Ident { name: "B", span: "test":3..4 }, Ident { name: "foo", span: "test":6..9 }], is_absolute: false, span: "test":0..9 }, args: [UnaryOp { op: Neg, expr: Path(Path { path: [Ident { name: "a", span: "test":11..12 }], is_absolute: false, span: "test":11..12 }), span: "test":10..12 }, BinaryOp { op: Add, lhs: Path(Path { path: [Ident { name: "b", span: "test":14..15 }], is_absolute: false, span: "test":14..15 }), rhs: Path(Path { path: [Ident { name: "c", span: "test":16..17 }], is_absolute: false, span: "test":16..17 }), span: "test":14..17 }], span: "test":0..18 }"#
         ]],
     );
 }
@@ -958,14 +1025,14 @@ fn code_blocks() {
     check(
         &run_parser!(let_decl(expr()), "let x = { 0 };"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Block(Block { statements: [], final_expr: Immediate { value: Int(0), span: 10..11 }, span: 8..13 })), span: 0..14 }"#
+            r#"Let { name: Ident { name: "x", span: "test":4..5 }, ty: None, init: Some(Block(Block { statements: [], final_expr: Immediate { value: Int(0), span: "test":10..11 }, span: "test":8..13 })), span: "test":0..14 }"#
         ]],
     );
 
     check(
         &run_parser!(let_decl(expr()), "let x = { constraint x > 0.0; 0.0 };"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Block(Block { statements: [Constraint { expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "x", span: 21..22 }], is_absolute: false, span: 21..22 }), rhs: Immediate { value: Real(0.0), span: 25..28 }, span: 21..28 }, span: 10..29 }], final_expr: Immediate { value: Real(0.0), span: 30..33 }, span: 8..35 })), span: 0..36 }"#
+            r#"Let { name: Ident { name: "x", span: "test":4..5 }, ty: None, init: Some(Block(Block { statements: [Constraint { expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "x", span: "test":21..22 }], is_absolute: false, span: "test":21..22 }), rhs: Immediate { value: Real(0.0), span: "test":25..28 }, span: "test":21..28 }, span: "test":10..29 }], final_expr: Immediate { value: Real(0.0), span: "test":30..33 }, span: "test":8..35 })), span: "test":0..36 }"#
         ]],
     );
 
@@ -975,14 +1042,14 @@ fn code_blocks() {
             "constraint { constraint { true }; x > 0 };"
         ),
         expect_test::expect![[
-            r#"Constraint { expr: Block(Block { statements: [Constraint { expr: Block(Block { statements: [], final_expr: Immediate { value: Bool(true), span: 26..30 }, span: 24..32 }), span: 13..33 }], final_expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "x", span: 34..35 }], is_absolute: false, span: 34..35 }), rhs: Immediate { value: Int(0), span: 38..39 }, span: 34..39 }, span: 11..41 }), span: 0..42 }"#
+            r#"Constraint { expr: Block(Block { statements: [Constraint { expr: Block(Block { statements: [], final_expr: Immediate { value: Bool(true), span: "test":26..30 }, span: "test":24..32 }), span: "test":13..33 }], final_expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "x", span: "test":34..35 }], is_absolute: false, span: "test":34..35 }), rhs: Immediate { value: Int(0), span: "test":38..39 }, span: "test":34..39 }, span: "test":11..41 }), span: "test":0..42 }"#
         ]],
     );
 
     check(
         &run_parser!(let_decl(expr()), "let x = { 1.0 } * { 2.0 };"),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(BinaryOp { op: Mul, lhs: Block(Block { statements: [], final_expr: Immediate { value: Real(1.0), span: 10..13 }, span: 8..15 }), rhs: Block(Block { statements: [], final_expr: Immediate { value: Real(2.0), span: 20..23 }, span: 18..25 }), span: 8..25 }), span: 0..26 }"#
+            r#"Let { name: Ident { name: "x", span: "test":4..5 }, ty: None, init: Some(BinaryOp { op: Mul, lhs: Block(Block { statements: [], final_expr: Immediate { value: Real(1.0), span: "test":10..13 }, span: "test":8..15 }), rhs: Block(Block { statements: [], final_expr: Immediate { value: Real(2.0), span: "test":20..23 }, span: "test":18..25 }), span: "test":8..25 }), span: "test":0..26 }"#
         ]],
     );
 
@@ -1008,21 +1075,21 @@ fn if_exprs() {
     check(
         &run_parser!(if_expr(expr()), "if c { 1 } else { 0 }"),
         expect_test::expect![[
-            r#"If { condition: Path(Path { path: [Ident { name: "c", span: 3..4 }], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 7..8 }, span: 5..10 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(0), span: 18..19 }, span: 16..21 }, span: 0..21 }"#
+            r#"If { condition: Path(Path { path: [Ident { name: "c", span: "test":3..4 }], is_absolute: false, span: "test":3..4 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: "test":7..8 }, span: "test":5..10 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(0), span: "test":18..19 }, span: "test":16..21 }, span: "test":0..21 }"#
         ]],
     );
 
     check(
         &run_parser!(if_expr(expr()), "if c { if c { 1 } else { 0 } } else { 2 }"),
         expect_test::expect![[
-            r#"If { condition: Path(Path { path: [Ident { name: "c", span: 3..4 }], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: If { condition: Path(Path { path: [Ident { name: "c", span: 10..11 }], is_absolute: false, span: 10..11 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 14..15 }, span: 12..17 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(0), span: 25..26 }, span: 23..28 }, span: 7..28 }, span: 5..30 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: 38..39 }, span: 36..41 }, span: 0..41 }"#
+            r#"If { condition: Path(Path { path: [Ident { name: "c", span: "test":3..4 }], is_absolute: false, span: "test":3..4 }), then_block: Block { statements: [], final_expr: If { condition: Path(Path { path: [Ident { name: "c", span: "test":10..11 }], is_absolute: false, span: "test":10..11 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: "test":14..15 }, span: "test":12..17 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(0), span: "test":25..26 }, span: "test":23..28 }, span: "test":7..28 }, span: "test":5..30 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: "test":38..39 }, span: "test":36..41 }, span: "test":0..41 }"#
         ]],
     );
 
     check(
         &run_parser!(if_expr(expr()), "if c { if c { 1 } else { 0 } } else { 2 }"),
         expect_test::expect![[
-            r#"If { condition: Path(Path { path: [Ident { name: "c", span: 3..4 }], is_absolute: false, span: 3..4 }), then_block: Block { statements: [], final_expr: If { condition: Path(Path { path: [Ident { name: "c", span: 10..11 }], is_absolute: false, span: 10..11 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 14..15 }, span: 12..17 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(0), span: 25..26 }, span: 23..28 }, span: 7..28 }, span: 5..30 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: 38..39 }, span: 36..41 }, span: 0..41 }"#
+            r#"If { condition: Path(Path { path: [Ident { name: "c", span: "test":3..4 }], is_absolute: false, span: "test":3..4 }), then_block: Block { statements: [], final_expr: If { condition: Path(Path { path: [Ident { name: "c", span: "test":10..11 }], is_absolute: false, span: "test":10..11 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: "test":14..15 }, span: "test":12..17 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(0), span: "test":25..26 }, span: "test":23..28 }, span: "test":7..28 }, span: "test":5..30 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: "test":38..39 }, span: "test":36..41 }, span: "test":0..41 }"#
         ]],
     );
 }
@@ -1031,20 +1098,22 @@ fn if_exprs() {
 fn array_type() {
     check(
         &run_parser!(type_(expr()), r#"int[5]"#),
-        expect_test::expect![["Array { ty: Primitive { kind: Int, span: 0..3 }, range: Immediate { value: Int(5), span: 4..5 }, span: 0..6 }"]],
+        expect_test::expect![[
+            r#"Array { ty: Primitive { kind: Int, span: "test":0..3 }, range: Immediate { value: Int(5), span: "test":4..5 }, span: "test":0..6 }"#
+        ]],
     );
 
     check(
         &run_parser!(type_(expr()), r#"int[MyEnum]"#),
         expect_test::expect![[
-            r#"Array { ty: Primitive { kind: Int, span: 0..3 }, range: Path(Path { path: [Ident { name: "MyEnum", span: 4..10 }], is_absolute: false, span: 4..10 }), span: 0..11 }"#
+            r#"Array { ty: Primitive { kind: Int, span: "test":0..3 }, range: Path(Path { path: [Ident { name: "MyEnum", span: "test":4..10 }], is_absolute: false, span: "test":4..10 }), span: "test":0..11 }"#
         ]],
     );
 
     check(
         &run_parser!(type_(expr()), r#"int[N]"#),
         expect_test::expect![[
-            r#"Array { ty: Primitive { kind: Int, span: 0..3 }, range: Path(Path { path: [Ident { name: "N", span: 4..5 }], is_absolute: false, span: 4..5 }), span: 0..6 }"#
+            r#"Array { ty: Primitive { kind: Int, span: "test":0..3 }, range: Path(Path { path: [Ident { name: "N", span: "test":4..5 }], is_absolute: false, span: "test":4..5 }), span: "test":0..6 }"#
         ]],
     );
 
@@ -1054,21 +1123,21 @@ fn array_type() {
             r#"string[foo()][{ 7 }][if true { 1 } else { 2 }]"#
         ),
         expect_test::expect![[
-            r#"Array { ty: Array { ty: Array { ty: Primitive { kind: String, span: 0..6 }, range: If { condition: Immediate { value: Bool(true), span: 24..28 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 31..32 }, span: 29..34 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: 42..43 }, span: 40..45 }, span: 21..45 }, span: 0..46 }, range: Block(Block { statements: [], final_expr: Immediate { value: Int(7), span: 16..17 }, span: 14..19 }), span: 0..20 }, range: Call { name: Path { path: [Ident { name: "foo", span: 7..10 }], is_absolute: false, span: 7..10 }, args: [], span: 7..12 }, span: 0..13 }"#
+            r#"Array { ty: Array { ty: Array { ty: Primitive { kind: String, span: "test":0..6 }, range: If { condition: Immediate { value: Bool(true), span: "test":24..28 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: "test":31..32 }, span: "test":29..34 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: "test":42..43 }, span: "test":40..45 }, span: "test":21..45 }, span: "test":0..46 }, range: Block(Block { statements: [], final_expr: Immediate { value: Int(7), span: "test":16..17 }, span: "test":14..19 }), span: "test":0..20 }, range: Call { name: Path { path: [Ident { name: "foo", span: "test":7..10 }], is_absolute: false, span: "test":7..10 }, args: [], span: "test":7..12 }, span: "test":0..13 }"#
         ]],
     );
 
     check(
         &run_parser!(type_(expr()), r#"real[N][9][M][3]"#),
         expect_test::expect![[
-            r#"Array { ty: Array { ty: Array { ty: Array { ty: Primitive { kind: Real, span: 0..4 }, range: Immediate { value: Int(3), span: 14..15 }, span: 0..16 }, range: Path(Path { path: [Ident { name: "M", span: 11..12 }], is_absolute: false, span: 11..12 }), span: 0..13 }, range: Immediate { value: Int(9), span: 8..9 }, span: 0..10 }, range: Path(Path { path: [Ident { name: "N", span: 5..6 }], is_absolute: false, span: 5..6 }), span: 0..7 }"#
+            r#"Array { ty: Array { ty: Array { ty: Array { ty: Primitive { kind: Real, span: "test":0..4 }, range: Immediate { value: Int(3), span: "test":14..15 }, span: "test":0..16 }, range: Path(Path { path: [Ident { name: "M", span: "test":11..12 }], is_absolute: false, span: "test":11..12 }), span: "test":0..13 }, range: Immediate { value: Int(9), span: "test":8..9 }, span: "test":0..10 }, range: Path(Path { path: [Ident { name: "N", span: "test":5..6 }], is_absolute: false, span: "test":5..6 }), span: "test":0..7 }"#
         ]],
     );
 
     check(
         &run_parser!(type_(expr()), r#"{int, { real, string }}[N][9]"#),
         expect_test::expect![[
-            r#"Array { ty: Array { ty: Tuple { fields: [(None, Primitive { kind: Int, span: 1..4 }), (None, Tuple { fields: [(None, Primitive { kind: Real, span: 8..12 }), (None, Primitive { kind: String, span: 14..20 })], span: 6..22 })], span: 0..23 }, range: Immediate { value: Int(9), span: 27..28 }, span: 0..29 }, range: Path(Path { path: [Ident { name: "N", span: 24..25 }], is_absolute: false, span: 24..25 }), span: 0..26 }"#
+            r#"Array { ty: Array { ty: Tuple { fields: [(None, Primitive { kind: Int, span: "test":1..4 }), (None, Tuple { fields: [(None, Primitive { kind: Real, span: "test":8..12 }), (None, Primitive { kind: String, span: "test":14..20 })], span: "test":6..22 })], span: "test":0..23 }, range: Immediate { value: Int(9), span: "test":27..28 }, span: "test":0..29 }, range: Path(Path { path: [Ident { name: "N", span: "test":24..25 }], is_absolute: false, span: "test":24..25 }), span: "test":0..26 }"#
         ]],
     );
 
@@ -1084,36 +1153,44 @@ fn array_type() {
 fn array_expressions() {
     check(
         &run_parser!(expr(), r#"[5]"#),
-        expect_test::expect![
-            "Array { elements: [Immediate { value: Int(5), span: 1..2 }], span: 0..3 }"
-        ],
+        expect_test::expect![[
+            r#"Array { elements: [Immediate { value: Int(5), span: "test":1..2 }], span: "test":0..3 }"#
+        ]],
     );
 
     check(
         &run_parser!(expr(), r#"[5,]"#),
-        expect_test::expect![
-            "Array { elements: [Immediate { value: Int(5), span: 1..2 }], span: 0..4 }"
-        ],
+        expect_test::expect![[
+            r#"Array { elements: [Immediate { value: Int(5), span: "test":1..2 }], span: "test":0..4 }"#
+        ]],
     );
 
     check(
         &run_parser!(expr(), r#"[5, 4]"#),
-        expect_test::expect!["Array { elements: [Immediate { value: Int(5), span: 1..2 }, Immediate { value: Int(4), span: 4..5 }], span: 0..6 }"],
+        expect_test::expect![[
+            r#"Array { elements: [Immediate { value: Int(5), span: "test":1..2 }, Immediate { value: Int(4), span: "test":4..5 }], span: "test":0..6 }"#
+        ]],
     );
 
     check(
         &run_parser!(expr(), r#"[[ 1 ],]"#),
-        expect_test::expect!["Array { elements: [Array { elements: [Immediate { value: Int(1), span: 3..4 }], span: 1..6 }], span: 0..8 }"],
+        expect_test::expect![[
+            r#"Array { elements: [Array { elements: [Immediate { value: Int(1), span: "test":3..4 }], span: "test":1..6 }], span: "test":0..8 }"#
+        ]],
     );
 
     check(
         &run_parser!(expr(), r#"[[1, 2], 3]"#), // This should fail in semantic analysis
-        expect_test::expect!["Array { elements: [Array { elements: [Immediate { value: Int(1), span: 2..3 }, Immediate { value: Int(2), span: 5..6 }], span: 1..7 }, Immediate { value: Int(3), span: 9..10 }], span: 0..11 }"]
+        expect_test::expect![[
+            r#"Array { elements: [Array { elements: [Immediate { value: Int(1), span: "test":2..3 }, Immediate { value: Int(2), span: "test":5..6 }], span: "test":1..7 }, Immediate { value: Int(3), span: "test":9..10 }], span: "test":0..11 }"#
+        ]],
     );
 
     check(
         &run_parser!(expr(), r#"[[1, 2], [3, 4]]"#),
-        expect_test::expect!["Array { elements: [Array { elements: [Immediate { value: Int(1), span: 2..3 }, Immediate { value: Int(2), span: 5..6 }], span: 1..7 }, Array { elements: [Immediate { value: Int(3), span: 10..11 }, Immediate { value: Int(4), span: 13..14 }], span: 9..15 }], span: 0..16 }"],
+        expect_test::expect![[
+            r#"Array { elements: [Array { elements: [Immediate { value: Int(1), span: "test":2..3 }, Immediate { value: Int(2), span: "test":5..6 }], span: "test":1..7 }, Array { elements: [Immediate { value: Int(3), span: "test":10..11 }, Immediate { value: Int(4), span: "test":13..14 }], span: "test":9..15 }], span: "test":0..16 }"#
+        ]],
     );
 
     check(
@@ -1122,7 +1199,7 @@ fn array_expressions() {
             r#"[[foo(), { 2 }], [if true { 1 } else { 2 }, t.0]]"#
         ),
         expect_test::expect![[
-            r#"Array { elements: [Array { elements: [Call { name: Path { path: [Ident { name: "foo", span: 2..5 }], is_absolute: false, span: 2..5 }, args: [], span: 2..7 }, Block(Block { statements: [], final_expr: Immediate { value: Int(2), span: 11..12 }, span: 9..14 })], span: 1..15 }, Array { elements: [If { condition: Immediate { value: Bool(true), span: 21..25 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 28..29 }, span: 26..31 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: 39..40 }, span: 37..42 }, span: 18..42 }, TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 44..45 }], is_absolute: false, span: 44..45 }), field: Left(0), span: 44..47 }], span: 17..48 }], span: 0..49 }"#
+            r#"Array { elements: [Array { elements: [Call { name: Path { path: [Ident { name: "foo", span: "test":2..5 }], is_absolute: false, span: "test":2..5 }, args: [], span: "test":2..7 }, Block(Block { statements: [], final_expr: Immediate { value: Int(2), span: "test":11..12 }, span: "test":9..14 })], span: "test":1..15 }, Array { elements: [If { condition: Immediate { value: Bool(true), span: "test":21..25 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: "test":28..29 }, span: "test":26..31 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: "test":39..40 }, span: "test":37..42 }, span: "test":18..42 }, TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: "test":44..45 }], is_absolute: false, span: "test":44..45 }), field: Left(0), span: "test":44..47 }], span: "test":17..48 }], span: "test":0..49 }"#
         ]],
     );
 }
@@ -1132,21 +1209,21 @@ fn array_field_accesss() {
     check(
         &run_parser!(expr(), r#"a[5]"#),
         expect_test::expect![[
-            r#"ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), index: Immediate { value: Int(5), span: 2..3 }, span: 0..4 }"#
+            r#"ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), index: Immediate { value: Int(5), span: "test":2..3 }, span: "test":0..4 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{ a }[N][foo()][M][4]"#),
         expect_test::expect![[
-            r#"ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "a", span: 2..3 }], is_absolute: false, span: 2..3 }), span: 0..5 }), index: Immediate { value: Int(4), span: 19..20 }, span: 0..21 }, index: Path(Path { path: [Ident { name: "M", span: 16..17 }], is_absolute: false, span: 16..17 }), span: 0..18 }, index: Call { name: Path { path: [Ident { name: "foo", span: 9..12 }], is_absolute: false, span: 9..12 }, args: [], span: 9..14 }, span: 0..15 }, index: Path(Path { path: [Ident { name: "N", span: 6..7 }], is_absolute: false, span: 6..7 }), span: 0..8 }"#
+            r#"ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: ArrayElementAccess { array: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "a", span: "test":2..3 }], is_absolute: false, span: "test":2..3 }), span: "test":0..5 }), index: Immediate { value: Int(4), span: "test":19..20 }, span: "test":0..21 }, index: Path(Path { path: [Ident { name: "M", span: "test":16..17 }], is_absolute: false, span: "test":16..17 }), span: "test":0..18 }, index: Call { name: Path { path: [Ident { name: "foo", span: "test":9..12 }], is_absolute: false, span: "test":9..12 }, args: [], span: "test":9..14 }, span: "test":0..15 }, index: Path(Path { path: [Ident { name: "N", span: "test":6..7 }], is_absolute: false, span: "test":6..7 }), span: "test":0..8 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"foo()[{ M }][if true { 1 } else { 3 }]"#),
         expect_test::expect![[
-            r#"ArrayElementAccess { array: ArrayElementAccess { array: Call { name: Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 }, args: [], span: 0..5 }, index: If { condition: Immediate { value: Bool(true), span: 16..20 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 23..24 }, span: 21..26 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(3), span: 34..35 }, span: 32..37 }, span: 13..37 }, span: 0..38 }, index: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "M", span: 8..9 }], is_absolute: false, span: 8..9 }), span: 6..11 }), span: 0..12 }"#
+            r#"ArrayElementAccess { array: ArrayElementAccess { array: Call { name: Path { path: [Ident { name: "foo", span: "test":0..3 }], is_absolute: false, span: "test":0..3 }, args: [], span: "test":0..5 }, index: If { condition: Immediate { value: Bool(true), span: "test":16..20 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: "test":23..24 }, span: "test":21..26 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(3), span: "test":34..35 }, span: "test":32..37 }, span: "test":13..37 }, span: "test":0..38 }, index: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "M", span: "test":8..9 }], is_absolute: false, span: "test":8..9 }), span: "test":6..11 }), span: "test":0..12 }"#
         ]],
     );
 
@@ -1161,7 +1238,7 @@ fn array_field_accesss() {
     check(
         &run_parser!(expr(), r#"a[MyEnum::Variant1]"#),
         expect_test::expect![[
-            r#"ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: 0..1 }], is_absolute: false, span: 0..1 }), index: Path(Path { path: [Ident { name: "MyEnum", span: 2..8 }, Ident { name: "Variant1", span: 10..18 }], is_absolute: false, span: 2..18 }), span: 0..19 }"#
+            r#"ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), index: Path(Path { path: [Ident { name: "MyEnum", span: "test":2..8 }, Ident { name: "Variant1", span: "test":10..18 }], is_absolute: false, span: "test":2..18 }), span: "test":0..19 }"#
         ]],
     );
 }
@@ -1170,62 +1247,64 @@ fn array_field_accesss() {
 fn tuple_expressions() {
     check(
         &run_parser!(expr(), r#"{0}"#), // This is not a tuple. It is a code block expr.
-        expect_test::expect!["Block(Block { statements: [], final_expr: Immediate { value: Int(0), span: 1..2 }, span: 0..3 })"],
+        expect_test::expect![[
+            r#"Block(Block { statements: [], final_expr: Immediate { value: Int(0), span: "test":1..2 }, span: "test":0..3 })"#
+        ]],
     );
 
     check(
         &run_parser!(expr(), r#"{x: 0}"#), // This is a tuple because the field is named so there is no ambiguity
         expect_test::expect![[
-            r#"Tuple { fields: [(Some(Ident { name: "x", span: 1..2 }), Immediate { value: Int(0), span: 4..5 })], span: 0..6 }"#
+            r#"Tuple { fields: [(Some(Ident { name: "x", span: "test":1..2 }), Immediate { value: Int(0), span: "test":4..5 })], span: "test":0..6 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{0,}"#), // This is a tuple
-        expect_test::expect![
-            "Tuple { fields: [(None, Immediate { value: Int(0), span: 1..2 })], span: 0..4 }"
-        ],
+        expect_test::expect![[
+            r#"Tuple { fields: [(None, Immediate { value: Int(0), span: "test":1..2 })], span: "test":0..4 }"#
+        ]],
     );
 
     check(
         &run_parser!(expr(), r#"{x: 0,}"#), // This is a tuple
         expect_test::expect![[
-            r#"Tuple { fields: [(Some(Ident { name: "x", span: 1..2 }), Immediate { value: Int(0), span: 4..5 })], span: 0..7 }"#
+            r#"Tuple { fields: [(Some(Ident { name: "x", span: "test":1..2 }), Immediate { value: Int(0), span: "test":4..5 })], span: "test":0..7 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{0, 1.0, "foo"}"#),
         expect_test::expect![[
-            r#"Tuple { fields: [(None, Immediate { value: Int(0), span: 1..2 }), (None, Immediate { value: Real(1.0), span: 4..7 }), (None, Immediate { value: String("foo"), span: 9..14 })], span: 0..15 }"#
+            r#"Tuple { fields: [(None, Immediate { value: Int(0), span: "test":1..2 }), (None, Immediate { value: Real(1.0), span: "test":4..7 }), (None, Immediate { value: String("foo"), span: "test":9..14 })], span: "test":0..15 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{x: 0, y: 1.0, z: "foo"}"#),
         expect_test::expect![[
-            r#"Tuple { fields: [(Some(Ident { name: "x", span: 1..2 }), Immediate { value: Int(0), span: 4..5 }), (Some(Ident { name: "y", span: 7..8 }), Immediate { value: Real(1.0), span: 10..13 }), (Some(Ident { name: "z", span: 15..16 }), Immediate { value: String("foo"), span: 18..23 })], span: 0..24 }"#
+            r#"Tuple { fields: [(Some(Ident { name: "x", span: "test":1..2 }), Immediate { value: Int(0), span: "test":4..5 }), (Some(Ident { name: "y", span: "test":7..8 }), Immediate { value: Real(1.0), span: "test":10..13 }), (Some(Ident { name: "z", span: "test":15..16 }), Immediate { value: String("foo"), span: "test":18..23 })], span: "test":0..24 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{0, {1.0, "bar"}, "foo"}"#),
         expect_test::expect![[
-            r#"Tuple { fields: [(None, Immediate { value: Int(0), span: 1..2 }), (None, Tuple { fields: [(None, Immediate { value: Real(1.0), span: 5..8 }), (None, Immediate { value: String("bar"), span: 10..15 })], span: 4..16 }), (None, Immediate { value: String("foo"), span: 18..23 })], span: 0..24 }"#
+            r#"Tuple { fields: [(None, Immediate { value: Int(0), span: "test":1..2 }), (None, Tuple { fields: [(None, Immediate { value: Real(1.0), span: "test":5..8 }), (None, Immediate { value: String("bar"), span: "test":10..15 })], span: "test":4..16 }), (None, Immediate { value: String("foo"), span: "test":18..23 })], span: "test":0..24 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{x: 0, {y: 1.0, "bar"}, z: "foo"}"#),
         expect_test::expect![[
-            r#"Tuple { fields: [(Some(Ident { name: "x", span: 1..2 }), Immediate { value: Int(0), span: 4..5 }), (None, Tuple { fields: [(Some(Ident { name: "y", span: 8..9 }), Immediate { value: Real(1.0), span: 11..14 }), (None, Immediate { value: String("bar"), span: 16..21 })], span: 7..22 }), (Some(Ident { name: "z", span: 24..25 }), Immediate { value: String("foo"), span: 27..32 })], span: 0..33 }"#
+            r#"Tuple { fields: [(Some(Ident { name: "x", span: "test":1..2 }), Immediate { value: Int(0), span: "test":4..5 }), (None, Tuple { fields: [(Some(Ident { name: "y", span: "test":8..9 }), Immediate { value: Real(1.0), span: "test":11..14 }), (None, Immediate { value: String("bar"), span: "test":16..21 })], span: "test":7..22 }), (Some(Ident { name: "z", span: "test":24..25 }), Immediate { value: String("foo"), span: "test":27..32 })], span: "test":0..33 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{ { 42 }, if c { 2 } else { 3 }, foo() }"#),
         expect_test::expect![[
-            r#"Tuple { fields: [(None, Block(Block { statements: [], final_expr: Immediate { value: Int(42), span: 4..6 }, span: 2..8 })), (None, If { condition: Path(Path { path: [Ident { name: "c", span: 13..14 }], is_absolute: false, span: 13..14 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: 17..18 }, span: 15..20 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(3), span: 28..29 }, span: 26..31 }, span: 10..31 }), (None, Call { name: Path { path: [Ident { name: "foo", span: 33..36 }], is_absolute: false, span: 33..36 }, args: [], span: 33..38 })], span: 0..40 }"#
+            r#"Tuple { fields: [(None, Block(Block { statements: [], final_expr: Immediate { value: Int(42), span: "test":4..6 }, span: "test":2..8 })), (None, If { condition: Path(Path { path: [Ident { name: "c", span: "test":13..14 }], is_absolute: false, span: "test":13..14 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: "test":17..18 }, span: "test":15..20 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(3), span: "test":28..29 }, span: "test":26..31 }, span: "test":10..31 }), (None, Call { name: Path { path: [Ident { name: "foo", span: "test":33..36 }], is_absolute: false, span: "test":33..36 }, args: [], span: "test":33..38 })], span: "test":0..40 }"#
         ]],
     );
 
@@ -1235,7 +1314,7 @@ fn tuple_expressions() {
             r#"{ x: { 42 }, y: if c { 2 } else { 3 }, z: foo() }"#
         ),
         expect_test::expect![[
-            r#"Tuple { fields: [(Some(Ident { name: "x", span: 2..3 }), Block(Block { statements: [], final_expr: Immediate { value: Int(42), span: 7..9 }, span: 5..11 })), (Some(Ident { name: "y", span: 13..14 }), If { condition: Path(Path { path: [Ident { name: "c", span: 19..20 }], is_absolute: false, span: 19..20 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: 23..24 }, span: 21..26 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(3), span: 34..35 }, span: 32..37 }, span: 16..37 }), (Some(Ident { name: "z", span: 39..40 }), Call { name: Path { path: [Ident { name: "foo", span: 42..45 }], is_absolute: false, span: 42..45 }, args: [], span: 42..47 })], span: 0..49 }"#
+            r#"Tuple { fields: [(Some(Ident { name: "x", span: "test":2..3 }), Block(Block { statements: [], final_expr: Immediate { value: Int(42), span: "test":7..9 }, span: "test":5..11 })), (Some(Ident { name: "y", span: "test":13..14 }), If { condition: Path(Path { path: [Ident { name: "c", span: "test":19..20 }], is_absolute: false, span: "test":19..20 }), then_block: Block { statements: [], final_expr: Immediate { value: Int(2), span: "test":23..24 }, span: "test":21..26 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(3), span: "test":34..35 }, span: "test":32..37 }, span: "test":16..37 }), (Some(Ident { name: "z", span: "test":39..40 }), Call { name: Path { path: [Ident { name: "foo", span: "test":42..45 }], is_absolute: false, span: "test":42..45 }, args: [], span: "test":42..47 })], span: "test":0..49 }"#
         ]],
     );
 }
@@ -1245,99 +1324,107 @@ fn tuple_field_accesses() {
     check(
         &run_parser!(expr(), r#"t.0 + t.9999999 + t.x"#),
         expect_test::expect![[
-            r#"BinaryOp { op: Add, lhs: BinaryOp { op: Add, lhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(0), span: 0..3 }, rhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 6..7 }], is_absolute: false, span: 6..7 }), field: Left(9999999), span: 6..15 }, span: 0..15 }, rhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 18..19 }], is_absolute: false, span: 18..19 }), field: Right(Ident { name: "x", span: 20..21 }), span: 18..21 }, span: 0..21 }"#
+            r#"BinaryOp { op: Add, lhs: BinaryOp { op: Add, lhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), field: Left(0), span: "test":0..3 }, rhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: "test":6..7 }], is_absolute: false, span: "test":6..7 }), field: Left(9999999), span: "test":6..15 }, span: "test":0..15 }, rhs: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: "test":18..19 }], is_absolute: false, span: "test":18..19 }), field: Right(Ident { name: "x", span: "test":20..21 }), span: "test":18..21 }, span: "test":0..21 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{0, 1}.0"#),
-        expect_test::expect!["TupleFieldAccess { tuple: Tuple { fields: [(None, Immediate { value: Int(0), span: 1..2 }), (None, Immediate { value: Int(1), span: 4..5 })], span: 0..6 }, field: Left(0), span: 0..8 }"],
+        expect_test::expect![[
+            r#"TupleFieldAccess { tuple: Tuple { fields: [(None, Immediate { value: Int(0), span: "test":1..2 }), (None, Immediate { value: Int(1), span: "test":4..5 })], span: "test":0..6 }, field: Left(0), span: "test":0..8 }"#
+        ]],
     );
 
     check(
         &run_parser!(expr(), r#"{0, 1}.x"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: Tuple { fields: [(None, Immediate { value: Int(0), span: 1..2 }), (None, Immediate { value: Int(1), span: 4..5 })], span: 0..6 }, field: Right(Ident { name: "x", span: 7..8 }), span: 0..8 }"#
+            r#"TupleFieldAccess { tuple: Tuple { fields: [(None, Immediate { value: Int(0), span: "test":1..2 }), (None, Immediate { value: Int(1), span: "test":4..5 })], span: "test":0..6 }, field: Right(Ident { name: "x", span: "test":7..8 }), span: "test":0..8 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"t.0 .0"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(0), span: 0..3 }, field: Left(0), span: 0..6 }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), field: Left(0), span: "test":0..3 }, field: Left(0), span: "test":0..6 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"t.x .y"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Right(Ident { name: "x", span: 2..3 }), span: 0..3 }, field: Right(Ident { name: "y", span: 5..6 }), span: 0..6 }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), field: Right(Ident { name: "x", span: "test":2..3 }), span: "test":0..3 }, field: Right(Ident { name: "y", span: "test":5..6 }), span: "test":0..6 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "t \r .1 .2.2. \n 3 . \t 13 . 1.1"),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(1), span: 0..6 }, field: Left(2), span: 0..9 }, field: Left(2), span: 0..11 }, field: Left(3), span: 0..16 }, field: Left(13), span: 0..23 }, field: Left(1), span: 0..27 }, field: Left(1), span: 0..29 }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), field: Left(1), span: "test":0..6 }, field: Left(2), span: "test":0..11 }, field: Left(2), span: "test":0..11 }, field: Left(3), span: "test":0..16 }, field: Left(13), span: "test":0..23 }, field: Left(1), span: "test":0..29 }, field: Left(1), span: "test":0..29 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), "t \r .x .1.2. \n w . \t t. 3.4"),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Right(Ident { name: "x", span: 5..6 }), span: 0..6 }, field: Left(1), span: 0..9 }, field: Left(2), span: 0..11 }, field: Right(Ident { name: "w", span: 15..16 }), span: 0..16 }, field: Right(Ident { name: "t", span: 21..22 }), span: 0..22 }, field: Left(3), span: 0..25 }, field: Left(4), span: 0..27 }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), field: Right(Ident { name: "x", span: "test":5..6 }), span: "test":0..6 }, field: Left(1), span: "test":0..11 }, field: Left(2), span: "test":0..11 }, field: Right(Ident { name: "w", span: "test":15..16 }), span: "test":0..16 }, field: Right(Ident { name: "t", span: "test":21..22 }), span: "test":0..22 }, field: Left(3), span: "test":0..27 }, field: Left(4), span: "test":0..27 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"foo().0.1"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Call { name: Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 }, args: [], span: 0..5 }, field: Left(0), span: 0..7 }, field: Left(1), span: 0..9 }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: Call { name: Path { path: [Ident { name: "foo", span: "test":0..3 }], is_absolute: false, span: "test":0..3 }, args: [], span: "test":0..5 }, field: Left(0), span: "test":0..9 }, field: Left(1), span: "test":0..9 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"foo().a.b.0.1"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Call { name: Path { path: [Ident { name: "foo", span: 0..3 }], is_absolute: false, span: 0..3 }, args: [], span: 0..5 }, field: Right(Ident { name: "a", span: 6..7 }), span: 0..7 }, field: Right(Ident { name: "b", span: 8..9 }), span: 0..9 }, field: Left(0), span: 0..11 }, field: Left(1), span: 0..13 }"#
+            r#"TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Call { name: Path { path: [Ident { name: "foo", span: "test":0..3 }], is_absolute: false, span: "test":0..3 }, args: [], span: "test":0..5 }, field: Right(Ident { name: "a", span: "test":6..7 }), span: "test":0..7 }, field: Right(Ident { name: "b", span: "test":8..9 }), span: "test":0..9 }, field: Left(0), span: "test":0..13 }, field: Left(1), span: "test":0..13 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"{ {0, 0} }.0"#),
-        expect_test::expect!["TupleFieldAccess { tuple: Block(Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: 3..4 }), (None, Immediate { value: Int(0), span: 6..7 })], span: 2..8 }, span: 0..10 }), field: Left(0), span: 0..12 }"],
+        expect_test::expect![[
+            r#"TupleFieldAccess { tuple: Block(Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: "test":3..4 }), (None, Immediate { value: Int(0), span: "test":6..7 })], span: "test":2..8 }, span: "test":0..10 }), field: Left(0), span: "test":0..12 }"#
+        ]],
     );
 
     check(
         &run_parser!(expr(), r#"{ {0, 0} }.a"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: Block(Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: 3..4 }), (None, Immediate { value: Int(0), span: 6..7 })], span: 2..8 }, span: 0..10 }), field: Right(Ident { name: "a", span: 11..12 }), span: 0..12 }"#
+            r#"TupleFieldAccess { tuple: Block(Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: "test":3..4 }), (None, Immediate { value: Int(0), span: "test":6..7 })], span: "test":2..8 }, span: "test":0..10 }), field: Right(Ident { name: "a", span: "test":11..12 }), span: "test":0..12 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"if true { {0, 0} } else { {0, 0} }.0"#),
-        expect_test::expect!["TupleFieldAccess { tuple: If { condition: Immediate { value: Bool(true), span: 3..7 }, then_block: Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: 11..12 }), (None, Immediate { value: Int(0), span: 14..15 })], span: 10..16 }, span: 8..18 }, else_block: Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: 27..28 }), (None, Immediate { value: Int(0), span: 30..31 })], span: 26..32 }, span: 24..34 }, span: 0..34 }, field: Left(0), span: 0..36 }"],
+        expect_test::expect![[
+            r#"TupleFieldAccess { tuple: If { condition: Immediate { value: Bool(true), span: "test":3..7 }, then_block: Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: "test":11..12 }), (None, Immediate { value: Int(0), span: "test":14..15 })], span: "test":10..16 }, span: "test":8..18 }, else_block: Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: "test":27..28 }), (None, Immediate { value: Int(0), span: "test":30..31 })], span: "test":26..32 }, span: "test":24..34 }, span: "test":0..34 }, field: Left(0), span: "test":0..36 }"#
+        ]],
     );
 
     check(
         &run_parser!(expr(), r#"if true { {0, 0} } else { {0, 0} }.x"#),
         expect_test::expect![[
-            r#"TupleFieldAccess { tuple: If { condition: Immediate { value: Bool(true), span: 3..7 }, then_block: Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: 11..12 }), (None, Immediate { value: Int(0), span: 14..15 })], span: 10..16 }, span: 8..18 }, else_block: Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: 27..28 }), (None, Immediate { value: Int(0), span: 30..31 })], span: 26..32 }, span: 24..34 }, span: 0..34 }, field: Right(Ident { name: "x", span: 35..36 }), span: 0..36 }"#
+            r#"TupleFieldAccess { tuple: If { condition: Immediate { value: Bool(true), span: "test":3..7 }, then_block: Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: "test":11..12 }), (None, Immediate { value: Int(0), span: "test":14..15 })], span: "test":10..16 }, span: "test":8..18 }, else_block: Block { statements: [], final_expr: Tuple { fields: [(None, Immediate { value: Int(0), span: "test":27..28 }), (None, Immediate { value: Int(0), span: "test":30..31 })], span: "test":26..32 }, span: "test":24..34 }, span: "test":0..34 }, field: Right(Ident { name: "x", span: "test":35..36 }), span: "test":0..36 }"#
         ]],
     );
 
     // This parses because `1 + 2` is an expression, but it should fail in semantic analysis.
     check(
         &run_parser!(expr(), "1 + 2 .3"),
-        expect_test::expect!["BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: TupleFieldAccess { tuple: Immediate { value: Int(2), span: 4..5 }, field: Left(3), span: 4..8 }, span: 0..8 }"],
+        expect_test::expect![[
+            r#"BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: "test":0..1 }, rhs: TupleFieldAccess { tuple: Immediate { value: Int(2), span: "test":4..5 }, field: Left(3), span: "test":4..8 }, span: "test":0..8 }"#
+        ]],
     );
 
     // This parses because `1 + 2` is an expression, but it should fail in semantic analysis.
     check(
         &run_parser!(expr(), "1 + 2 .a"),
         expect_test::expect![[
-            r#"BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: 0..1 }, rhs: TupleFieldAccess { tuple: Immediate { value: Int(2), span: 4..5 }, field: Right(Ident { name: "a", span: 7..8 }), span: 4..8 }, span: 0..8 }"#
+            r#"BinaryOp { op: Add, lhs: Immediate { value: Int(1), span: "test":0..1 }, rhs: TupleFieldAccess { tuple: Immediate { value: Int(2), span: "test":4..5 }, field: Right(Ident { name: "a", span: "test":7..8 }), span: "test":4..8 }, span: "test":0..8 }"#
         ]],
     );
 
@@ -1408,28 +1495,28 @@ fn cond_exprs() {
     check(
         &run_parser!(cond_expr(expr()), r#"cond { else => a }"#),
         expect_test::expect![[
-            r#"Cond { branches: [], else_result: Path(Path { path: [Ident { name: "a", span: 15..16 }], is_absolute: false, span: 15..16 }), span: 0..18 }"#
+            r#"Cond { branches: [], else_result: Path(Path { path: [Ident { name: "a", span: "test":15..16 }], is_absolute: false, span: "test":15..16 }), span: "test":0..18 }"#
         ]],
     );
 
     check(
         &run_parser!(cond_expr(expr()), r#"cond { else => { a } }"#),
         expect_test::expect![[
-            r#"Cond { branches: [], else_result: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "a", span: 17..18 }], is_absolute: false, span: 17..18 }), span: 15..20 }), span: 0..22 }"#
+            r#"Cond { branches: [], else_result: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "a", span: "test":17..18 }], is_absolute: false, span: "test":17..18 }), span: "test":15..20 }), span: "test":0..22 }"#
         ]],
     );
 
     check(
         &run_parser!(cond_expr(expr()), r#"cond { a => b, else => c }"#),
         expect_test::expect![[
-            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: 7..8 }], is_absolute: false, span: 7..8 }), result: Path(Path { path: [Ident { name: "b", span: 12..13 }], is_absolute: false, span: 12..13 }), span: 7..14 }], else_result: Path(Path { path: [Ident { name: "c", span: 23..24 }], is_absolute: false, span: 23..24 }), span: 0..26 }"#
+            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: "test":7..8 }], is_absolute: false, span: "test":7..8 }), result: Path(Path { path: [Ident { name: "b", span: "test":12..13 }], is_absolute: false, span: "test":12..13 }), span: "test":7..14 }], else_result: Path(Path { path: [Ident { name: "c", span: "test":23..24 }], is_absolute: false, span: "test":23..24 }), span: "test":0..26 }"#
         ]],
     );
 
     check(
         &run_parser!(cond_expr(expr()), r#"cond { a => { b }, else => c, }"#),
         expect_test::expect![[
-            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: 7..8 }], is_absolute: false, span: 7..8 }), result: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "b", span: 14..15 }], is_absolute: false, span: 14..15 }), span: 12..17 }), span: 7..18 }], else_result: Path(Path { path: [Ident { name: "c", span: 27..28 }], is_absolute: false, span: 27..28 }), span: 0..31 }"#
+            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: "test":7..8 }], is_absolute: false, span: "test":7..8 }), result: Block(Block { statements: [], final_expr: Path(Path { path: [Ident { name: "b", span: "test":14..15 }], is_absolute: false, span: "test":14..15 }), span: "test":12..17 }), span: "test":7..18 }], else_result: Path(Path { path: [Ident { name: "c", span: "test":27..28 }], is_absolute: false, span: "test":27..28 }), span: "test":0..31 }"#
         ]],
     );
 
@@ -1439,7 +1526,7 @@ fn cond_exprs() {
             r#"cond { a => b, { true } => d, else => f, }"#
         ),
         expect_test::expect![[
-            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: 7..8 }], is_absolute: false, span: 7..8 }), result: Path(Path { path: [Ident { name: "b", span: 12..13 }], is_absolute: false, span: 12..13 }), span: 7..14 }, CondBranch { condition: Block(Block { statements: [], final_expr: Immediate { value: Bool(true), span: 17..21 }, span: 15..23 }), result: Path(Path { path: [Ident { name: "d", span: 27..28 }], is_absolute: false, span: 27..28 }), span: 15..29 }], else_result: Path(Path { path: [Ident { name: "f", span: 38..39 }], is_absolute: false, span: 38..39 }), span: 0..42 }"#
+            r#"Cond { branches: [CondBranch { condition: Path(Path { path: [Ident { name: "a", span: "test":7..8 }], is_absolute: false, span: "test":7..8 }), result: Path(Path { path: [Ident { name: "b", span: "test":12..13 }], is_absolute: false, span: "test":12..13 }), span: "test":7..14 }, CondBranch { condition: Block(Block { statements: [], final_expr: Immediate { value: Bool(true), span: "test":17..21 }, span: "test":15..23 }), result: Path(Path { path: [Ident { name: "d", span: "test":27..28 }], is_absolute: false, span: "test":27..28 }), span: "test":15..29 }], else_result: Path(Path { path: [Ident { name: "f", span: "test":38..39 }], is_absolute: false, span: "test":38..39 }), span: "test":0..42 }"#
         ]],
     );
 
@@ -1464,13 +1551,15 @@ fn cond_exprs() {
 fn casting() {
     check(
         &run_parser!(expr(), r#"(5 as int) as real as int"#),
-        expect_test::expect!["Cast { value: Cast { value: Cast { value: Immediate { value: Int(5), span: 1..2 }, ty: Primitive { kind: Int, span: 6..9 }, span: 1..9 }, ty: Primitive { kind: Real, span: 14..18 }, span: 1..18 }, ty: Primitive { kind: Int, span: 22..25 }, span: 1..25 }"],
+        expect_test::expect![[
+            r#"Cast { value: Cast { value: Cast { value: Immediate { value: Int(5), span: "test":1..2 }, ty: Primitive { kind: Int, span: "test":6..9 }, span: "test":1..9 }, ty: Primitive { kind: Real, span: "test":14..18 }, span: "test":1..18 }, ty: Primitive { kind: Int, span: "test":22..25 }, span: "test":1..25 }"#
+        ]],
     );
 
     check(
         &run_parser!(expr(), r#"t.0.1 as real * a[5][3] as int"#),
         expect_test::expect![[
-            r#"BinaryOp { op: Mul, lhs: Cast { value: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: 0..1 }], is_absolute: false, span: 0..1 }), field: Left(0), span: 0..3 }, field: Left(1), span: 0..5 }, ty: Primitive { kind: Real, span: 9..13 }, span: 0..13 }, rhs: Cast { value: ArrayElementAccess { array: ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: 16..17 }], is_absolute: false, span: 16..17 }), index: Immediate { value: Int(3), span: 21..22 }, span: 16..23 }, index: Immediate { value: Int(5), span: 18..19 }, span: 16..20 }, ty: Primitive { kind: Int, span: 27..30 }, span: 16..30 }, span: 0..30 }"#
+            r#"BinaryOp { op: Mul, lhs: Cast { value: TupleFieldAccess { tuple: TupleFieldAccess { tuple: Path(Path { path: [Ident { name: "t", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), field: Left(0), span: "test":0..5 }, field: Left(1), span: "test":0..5 }, ty: Primitive { kind: Real, span: "test":9..13 }, span: "test":0..13 }, rhs: Cast { value: ArrayElementAccess { array: ArrayElementAccess { array: Path(Path { path: [Ident { name: "a", span: "test":16..17 }], is_absolute: false, span: "test":16..17 }), index: Immediate { value: Int(3), span: "test":21..22 }, span: "test":16..23 }, index: Immediate { value: Int(5), span: "test":18..19 }, span: "test":16..20 }, ty: Primitive { kind: Int, span: "test":27..30 }, span: "test":16..30 }, span: "test":0..30 }"#
         ]],
     );
 
@@ -1480,7 +1569,7 @@ fn casting() {
             r#"let x = foo() as real as { int, real };"#
         ),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Cast { value: Cast { value: Call { name: Path { path: [Ident { name: "foo", span: 8..11 }], is_absolute: false, span: 8..11 }, args: [], span: 8..13 }, ty: Primitive { kind: Real, span: 17..21 }, span: 8..21 }, ty: Tuple { fields: [(None, Primitive { kind: Int, span: 27..30 }), (None, Primitive { kind: Real, span: 32..36 })], span: 25..38 }, span: 8..38 }), span: 0..39 }"#
+            r#"Let { name: Ident { name: "x", span: "test":4..5 }, ty: None, init: Some(Cast { value: Cast { value: Call { name: Path { path: [Ident { name: "foo", span: "test":8..11 }], is_absolute: false, span: "test":8..11 }, args: [], span: "test":8..13 }, ty: Primitive { kind: Real, span: "test":17..21 }, span: "test":8..21 }, ty: Tuple { fields: [(None, Primitive { kind: Int, span: "test":27..30 }), (None, Primitive { kind: Real, span: "test":32..36 })], span: "test":25..38 }, span: "test":8..38 }), span: "test":0..39 }"#
         ]],
     );
 
@@ -1498,28 +1587,28 @@ fn in_expr() {
     check(
         &run_parser!(expr(), r#"x in { 1, 2 }"#),
         expect_test::expect![[
-            r#"In { value: Path(Path { path: [Ident { name: "x", span: 0..1 }], is_absolute: false, span: 0..1 }), collection: Tuple { fields: [(None, Immediate { value: Int(1), span: 7..8 }), (None, Immediate { value: Int(2), span: 10..11 })], span: 5..13 }, span: 0..13 }"#
+            r#"In { value: Path(Path { path: [Ident { name: "x", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), collection: Tuple { fields: [(None, Immediate { value: Int(1), span: "test":7..8 }), (None, Immediate { value: Int(2), span: "test":10..11 })], span: "test":5..13 }, span: "test":0..13 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"x in [ 1, 2 ] in { true, false }"#),
         expect_test::expect![[
-            r#"In { value: Path(Path { path: [Ident { name: "x", span: 0..1 }], is_absolute: false, span: 0..1 }), collection: In { value: Array { elements: [Immediate { value: Int(1), span: 7..8 }, Immediate { value: Int(2), span: 10..11 }], span: 5..13 }, collection: Tuple { fields: [(None, Immediate { value: Bool(true), span: 19..23 }), (None, Immediate { value: Bool(false), span: 25..30 })], span: 17..32 }, span: 5..32 }, span: 0..32 }"#
+            r#"In { value: Path(Path { path: [Ident { name: "x", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), collection: In { value: Array { elements: [Immediate { value: Int(1), span: "test":7..8 }, Immediate { value: Int(2), span: "test":10..11 }], span: "test":5..13 }, collection: Tuple { fields: [(None, Immediate { value: Bool(true), span: "test":19..23 }), (None, Immediate { value: Bool(false), span: "test":25..30 })], span: "test":17..32 }, span: "test":5..32 }, span: "test":0..32 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"x as int in { 1, 2 }"#),
         expect_test::expect![[
-            r#"In { value: Cast { value: Path(Path { path: [Ident { name: "x", span: 0..1 }], is_absolute: false, span: 0..1 }), ty: Primitive { kind: Int, span: 5..8 }, span: 0..8 }, collection: Tuple { fields: [(None, Immediate { value: Int(1), span: 14..15 }), (None, Immediate { value: Int(2), span: 17..18 })], span: 12..20 }, span: 0..20 }"#
+            r#"In { value: Cast { value: Path(Path { path: [Ident { name: "x", span: "test":0..1 }], is_absolute: false, span: "test":0..1 }), ty: Primitive { kind: Int, span: "test":5..8 }, span: "test":0..8 }, collection: Tuple { fields: [(None, Immediate { value: Int(1), span: "test":14..15 }), (None, Immediate { value: Int(2), span: "test":17..18 })], span: "test":12..20 }, span: "test":0..20 }"#
         ]],
     );
 
     check(
         &run_parser!(expr(), r#"[1] in foo() in [[1]]"#),
         expect_test::expect![[
-            r#"In { value: Array { elements: [Immediate { value: Int(1), span: 1..2 }], span: 0..3 }, collection: In { value: Call { name: Path { path: [Ident { name: "foo", span: 7..10 }], is_absolute: false, span: 7..10 }, args: [], span: 7..12 }, collection: Array { elements: [Array { elements: [Immediate { value: Int(1), span: 18..19 }], span: 17..20 }], span: 16..21 }, span: 7..21 }, span: 0..21 }"#
+            r#"In { value: Array { elements: [Immediate { value: Int(1), span: "test":1..2 }], span: "test":0..3 }, collection: In { value: Call { name: Path { path: [Ident { name: "foo", span: "test":7..10 }], is_absolute: false, span: "test":7..10 }, args: [], span: "test":7..12 }, collection: Array { elements: [Array { elements: [Immediate { value: Int(1), span: "test":18..19 }], span: "test":17..20 }], span: "test":16..21 }, span: "test":7..21 }, span: "test":0..21 }"#
         ]],
     );
 
@@ -1548,7 +1637,7 @@ solve minimize mid;
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Let { name: Ident { name: "low_val", span: 5..12 }, ty: Some(Primitive { kind: Real, span: 14..18 }), init: Some(Immediate { value: Real(1.23), span: 21..25 }), span: 1..26 }, Let { name: Ident { name: "high_val", span: 31..39 }, ty: None, init: Some(Immediate { value: Real(4.56), span: 42..46 }), span: 27..47 }, Constraint { expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "mid", span: 112..115 }], is_absolute: false, span: 112..115 }), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "low_val", span: 118..125 }], is_absolute: false, span: 118..125 }), rhs: Immediate { value: Real(2.0), span: 128..131 }, span: 118..131 }, span: 112..131 }, span: 101..132 }, Constraint { expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "mid", span: 144..147 }], is_absolute: false, span: 144..147 }), rhs: Path(Path { path: [Ident { name: "high_val", span: 150..158 }], is_absolute: false, span: 150..158 }), span: 144..158 }, span: 133..159 }, Solve { directive: Minimize(Path(Path { path: [Ident { name: "mid", span: 176..179 }], is_absolute: false, span: 176..179 })), span: 161..180 }]"#
+            r#"[Let { name: Ident { name: "low_val", span: "test":5..12 }, ty: Some(Primitive { kind: Real, span: "test":14..18 }), init: Some(Immediate { value: Real(1.23), span: "test":21..25 }), span: "test":1..26 }, Let { name: Ident { name: "high_val", span: "test":31..39 }, ty: None, init: Some(Immediate { value: Real(4.56), span: "test":42..46 }), span: "test":27..47 }, Constraint { expr: BinaryOp { op: GreaterThan, lhs: Path(Path { path: [Ident { name: "mid", span: "test":112..115 }], is_absolute: false, span: "test":112..115 }), rhs: BinaryOp { op: Mul, lhs: Path(Path { path: [Ident { name: "low_val", span: "test":118..125 }], is_absolute: false, span: "test":118..125 }), rhs: Immediate { value: Real(2.0), span: "test":128..131 }, span: "test":118..131 }, span: "test":112..131 }, span: "test":101..132 }, Constraint { expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "mid", span: "test":144..147 }], is_absolute: false, span: "test":144..147 }), rhs: Path(Path { path: [Ident { name: "high_val", span: "test":150..158 }], is_absolute: false, span: "test":150..158 }), span: "test":144..158 }, span: "test":133..159 }, Solve { directive: Minimize(Path(Path { path: [Ident { name: "mid", span: "test":176..179 }], is_absolute: false, span: "test":176..179 })), span: "test":161..180 }]"#
         ]],
     );
 }
@@ -1585,7 +1674,7 @@ let low = 1.0;
     check(
         &run_parser!(yurt_program(), src),
         expect_test::expect![[
-            r#"[Solve { directive: Maximize(Path(Path { path: [Ident { name: "low", span: 16..19 }], is_absolute: false, span: 16..19 })), span: 1..20 }, Constraint { expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "low", span: 32..35 }], is_absolute: false, span: 32..35 }), rhs: Path(Path { path: [Ident { name: "high", span: 38..42 }], is_absolute: false, span: 38..42 }), span: 32..42 }, span: 21..43 }, Let { name: Ident { name: "high", span: 48..52 }, ty: None, init: Some(Immediate { value: Real(2.0), span: 55..58 }), span: 44..59 }, Solve { directive: Satisfy, span: 60..74 }, Let { name: Ident { name: "low", span: 79..82 }, ty: None, init: Some(Immediate { value: Real(1.0), span: 85..88 }), span: 75..89 }]"#
+            r#"[Solve { directive: Maximize(Path(Path { path: [Ident { name: "low", span: "test":16..19 }], is_absolute: false, span: "test":16..19 })), span: "test":1..20 }, Constraint { expr: BinaryOp { op: LessThan, lhs: Path(Path { path: [Ident { name: "low", span: "test":32..35 }], is_absolute: false, span: "test":32..35 }), rhs: Path(Path { path: [Ident { name: "high", span: "test":38..42 }], is_absolute: false, span: "test":38..42 }), span: "test":32..42 }, span: "test":21..43 }, Let { name: Ident { name: "high", span: "test":48..52 }, ty: None, init: Some(Immediate { value: Real(2.0), span: "test":55..58 }), span: "test":44..59 }, Solve { directive: Satisfy, span: "test":60..74 }, Let { name: Ident { name: "low", span: "test":79..82 }, ty: None, init: Some(Immediate { value: Real(1.0), span: "test":85..88 }), span: "test":75..89 }]"#
         ]],
     );
 }
@@ -1605,19 +1694,24 @@ fn keywords_as_identifiers_errors() {
 
 #[test]
 fn test_parse_str_to_ast() {
+    let filepath: Rc<Path> = Rc::from(Path::new("test"));
     check(
-        &format!("{:?}", parse_str_to_ast("let x = 5;")),
+        &format!("{:?}", parse_str_to_ast("let x = 5;", filepath.clone())),
         expect_test::expect![[
-            r#"Ok([Let { name: Ident { name: "x", span: 4..5 }, ty: None, init: Some(Immediate { value: Int(5), span: 8..9 }), span: 0..10 }])"#
+            r#"Ok([Let { name: Ident { name: "x", span: "test":4..5 }, ty: None, init: Some(Immediate { value: Int(5), span: "test":8..9 }), span: "test":0..10 }])"#
         ]],
     );
     check(
-        &format!("{:?}", parse_str_to_ast("let x = 5")),
-        expect_test::expect!["Err([Parse { error: ExpectedFound { span: 9..9, expected: [Some(Semi), Some(DoublePipe), Some(DoubleAmpersand), Some(NotEq), Some(EqEq), Some(GtEq), Some(LtEq), Some(Gt), Some(Lt), Some(Plus), Some(Minus), Some(Star), Some(Div), Some(Mod), Some(In), Some(As), Some(Dot), Some(BracketOpen), Some(SingleQuote)], found: None } }])"],
+        &format!("{:?}", parse_str_to_ast("let x = 5", filepath.clone())),
+        expect_test::expect![[
+            r#"Err([Parse { error: ExpectedFound { span: "test":9..9, expected: [Some(Semi), Some(DoublePipe), Some(DoubleAmpersand), Some(NotEq), Some(EqEq), Some(GtEq), Some(LtEq), Some(Gt), Some(Lt), Some(Plus), Some(Minus), Some(Star), Some(Div), Some(Mod), Some(In), Some(As), Some(Dot), Some(BracketOpen), Some(SingleQuote)], found: None } }])"#
+        ]],
     );
     check(
-        &format!("{:?}", parse_str_to_ast("@ @")),
-        expect_test::expect!["Err([Lex { span: 0..1, error: InvalidToken }, Lex { span: 2..3, error: InvalidToken }])"],
+        &format!("{:?}", parse_str_to_ast("@ @", filepath.clone())),
+        expect_test::expect![[
+            r#"Err([Lex { span: "test":0..1, error: InvalidToken }, Lex { span: "test":2..3, error: InvalidToken }])"#
+        ]],
     );
 }
 
@@ -1629,7 +1723,7 @@ fn big_ints() {
             "let blah = 1234567890123456789012345678901234567890;"
         ),
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate { value: BigInt(1234567890123456789012345678901234567890), span: 11..51 }), span: 0..52 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: None, init: Some(Immediate { value: BigInt(1234567890123456789012345678901234567890), span: "test":11..51 }), span: "test":0..52 }"#
         ]],
     );
     check(
@@ -1639,7 +1733,7 @@ fn big_ints() {
         ),
         // Confirmed by using the Python REPL to convert from hex to dec...
         expect_test::expect![[
-            r#"Let { name: Ident { name: "blah", span: 4..8 }, ty: None, init: Some(Immediate { value: BigInt(5421732407698601623698172315373246806734), span: 11..46 }), span: 0..47 }"#
+            r#"Let { name: Ident { name: "blah", span: "test":4..8 }, ty: None, init: Some(Immediate { value: BigInt(5421732407698601623698172315373246806734), span: "test":11..46 }), span: "test":0..47 }"#
         ]],
     );
     check(
@@ -1649,7 +1743,9 @@ fn big_ints() {
             0b01001001010110101010101001010101010010100100101001010010100100100001010"
         ),
         // Again confirmed using the Python REPL.  Handy.
-        expect_test::expect!["BinaryOp { op: Add, lhs: Immediate { value: BigInt(31076614848392666458794), span: 0..77 }, rhs: Immediate { value: BigInt(676572722683907229962), span: 80..153 }, span: 0..153 }"]
+        expect_test::expect![[
+            r#"BinaryOp { op: Add, lhs: Immediate { value: BigInt(31076614848392666458794), span: "test":0..77 }, rhs: Immediate { value: BigInt(676572722683907229962), span: "test":80..153 }, span: "test":0..153 }"#
+        ]],
     );
 }
 
@@ -1666,14 +1762,14 @@ interface Foo {
     check(
         &run_parser!(interface_decl(), src),
         expect_test::expect![[
-            r#"Interface(InterfaceDecl { name: Ident { name: "Foo", span: 11..14 }, functions: [FnSig { name: Ident { name: "foo", span: 24..27 }, params: [(Ident { name: "x", span: 28..29 }, Primitive { kind: Real, span: 31..35 }), (Ident { name: "y", span: 37..38 }, Array { ty: Primitive { kind: Int, span: 40..43 }, range: Immediate { value: Int(5), span: 44..45 }, span: 40..46 })], return_type: Primitive { kind: Real, span: 51..55 }, span: 21..55 }, FnSig { name: Ident { name: "bar", span: 64..67 }, params: [(Ident { name: "x", span: 68..69 }, Primitive { kind: Bool, span: 71..75 })], return_type: Primitive { kind: Real, span: 81..85 }, span: 61..85 }, FnSig { name: Ident { name: "baz", span: 94..97 }, params: [], return_type: Tuple { fields: [(None, Primitive { kind: Int, span: 105..108 }), (None, Primitive { kind: Real, span: 110..114 })], span: 103..116 }, span: 91..116 }], span: 1..119 })"#
+            r#"Interface(InterfaceDecl { name: Ident { name: "Foo", span: "test":11..14 }, functions: [FnSig { name: Ident { name: "foo", span: "test":24..27 }, params: [(Ident { name: "x", span: "test":28..29 }, Primitive { kind: Real, span: "test":31..35 }), (Ident { name: "y", span: "test":37..38 }, Array { ty: Primitive { kind: Int, span: "test":40..43 }, range: Immediate { value: Int(5), span: "test":44..45 }, span: "test":40..46 })], return_type: Primitive { kind: Real, span: "test":51..55 }, span: "test":21..55 }, FnSig { name: Ident { name: "bar", span: "test":64..67 }, params: [(Ident { name: "x", span: "test":68..69 }, Primitive { kind: Bool, span: "test":71..75 })], return_type: Primitive { kind: Real, span: "test":81..85 }, span: "test":61..85 }, FnSig { name: Ident { name: "baz", span: "test":94..97 }, params: [], return_type: Tuple { fields: [(None, Primitive { kind: Int, span: "test":105..108 }), (None, Primitive { kind: Real, span: "test":110..114 })], span: "test":103..116 }, span: "test":91..116 }], span: "test":1..119 })"#
         ]],
     );
 
     check(
         &run_parser!(interface_decl(), "interface Foo {}"),
         expect_test::expect![[
-            r#"Interface(InterfaceDecl { name: Ident { name: "Foo", span: 10..13 }, functions: [], span: 0..16 })"#
+            r#"Interface(InterfaceDecl { name: Ident { name: "Foo", span: "test":10..13 }, functions: [], span: "test":0..16 })"#
         ]],
     );
 }
@@ -1683,14 +1779,14 @@ fn contract_test() {
     check(
         &run_parser!(contract_decl(), "contract Foo(0) {}"),
         expect_test::expect![[
-            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: Immediate { value: Int(0), span: 13..14 }, interfaces: [], functions: [], span: 0..18 })"#
+            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: "test":9..12 }, id: Immediate { value: Int(0), span: "test":13..14 }, interfaces: [], functions: [], span: "test":0..18 })"#
         ]],
     );
 
     check(
         &run_parser!(contract_decl(), "contract Foo(if true {0} else {1}) {}"),
         expect_test::expect![[
-            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: If { condition: Immediate { value: Bool(true), span: 16..20 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(0), span: 22..23 }, span: 21..24 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: 31..32 }, span: 30..33 }, span: 13..33 }, interfaces: [], functions: [], span: 0..37 })"#
+            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: "test":9..12 }, id: If { condition: Immediate { value: Bool(true), span: "test":16..20 }, then_block: Block { statements: [], final_expr: Immediate { value: Int(0), span: "test":22..23 }, span: "test":21..24 }, else_block: Block { statements: [], final_expr: Immediate { value: Int(1), span: "test":31..32 }, span: "test":30..33 }, span: "test":13..33 }, interfaces: [], functions: [], span: "test":0..37 })"#
         ]],
     );
 
@@ -1700,7 +1796,7 @@ fn contract_test() {
             "contract Foo(0) implements X::Bar, ::Y::Baz {}"
         ),
         expect_test::expect![[
-            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: Immediate { value: Int(0), span: 13..14 }, interfaces: [Path { path: [Ident { name: "X", span: 27..28 }, Ident { name: "Bar", span: 30..33 }], is_absolute: false, span: 27..33 }, Path { path: [Ident { name: "Y", span: 37..38 }, Ident { name: "Baz", span: 40..43 }], is_absolute: true, span: 35..43 }], functions: [], span: 0..46 })"#
+            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: "test":9..12 }, id: Immediate { value: Int(0), span: "test":13..14 }, interfaces: [Path { path: [Ident { name: "X", span: "test":27..28 }, Ident { name: "Bar", span: "test":30..33 }], is_absolute: false, span: "test":27..33 }, Path { path: [Ident { name: "Y", span: "test":37..38 }, Ident { name: "Baz", span: "test":40..43 }], is_absolute: true, span: "test":35..43 }], functions: [], span: "test":0..46 })"#
         ]],
     );
 
@@ -1710,7 +1806,7 @@ fn contract_test() {
             "contract Foo(0) implements Bar { fn baz(x: real) -> int; }"
         ),
         expect_test::expect![[
-            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: 9..12 }, id: Immediate { value: Int(0), span: 13..14 }, interfaces: [Path { path: [Ident { name: "Bar", span: 27..30 }], is_absolute: false, span: 27..30 }], functions: [FnSig { name: Ident { name: "baz", span: 36..39 }, params: [(Ident { name: "x", span: 40..41 }, Primitive { kind: Real, span: 43..47 })], return_type: Primitive { kind: Int, span: 52..55 }, span: 33..55 }], span: 0..58 })"#
+            r#"Contract(ContractDecl { name: Ident { name: "Foo", span: "test":9..12 }, id: Immediate { value: Int(0), span: "test":13..14 }, interfaces: [Path { path: [Ident { name: "Bar", span: "test":27..30 }], is_absolute: false, span: "test":27..30 }], functions: [FnSig { name: Ident { name: "baz", span: "test":36..39 }, params: [(Ident { name: "x", span: "test":40..41 }, Primitive { kind: Real, span: "test":43..47 })], return_type: Primitive { kind: Int, span: "test":52..55 }, span: "test":33..55 }], span: "test":0..58 })"#
         ]],
     );
 
@@ -1735,18 +1831,18 @@ fn contract_test() {
 fn extern_test() {
     check(
         &run_parser!(extern_decl(), "extern {}"),
-        expect_test::expect!["Extern { functions: [], span: 0..9 }"],
+        expect_test::expect![[r#"Extern { functions: [], span: "test":0..9 }"#]],
     );
     check(
         &run_parser!(extern_decl(), "extern { fn foo() -> string; }"),
         expect_test::expect![[
-            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: 12..15 }, params: [], return_type: Primitive { kind: String, span: 21..27 }, span: 9..27 }], span: 0..30 }"#
+            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: "test":12..15 }, params: [], return_type: Primitive { kind: String, span: "test":21..27 }, span: "test":9..27 }], span: "test":0..30 }"#
         ]],
     );
     check(
         &run_parser!(extern_decl(), "extern { fn foo(x: int, y: real) -> int; }"),
         expect_test::expect![[
-            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: 12..15 }, params: [(Ident { name: "x", span: 16..17 }, Primitive { kind: Int, span: 19..22 }), (Ident { name: "y", span: 24..25 }, Primitive { kind: Real, span: 27..31 })], return_type: Primitive { kind: Int, span: 36..39 }, span: 9..39 }], span: 0..42 }"#
+            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: "test":12..15 }, params: [(Ident { name: "x", span: "test":16..17 }, Primitive { kind: Int, span: "test":19..22 }), (Ident { name: "y", span: "test":24..25 }, Primitive { kind: Real, span: "test":27..31 })], return_type: Primitive { kind: Int, span: "test":36..39 }, span: "test":9..39 }], span: "test":0..42 }"#
         ]],
     );
     check(
@@ -1755,7 +1851,7 @@ fn extern_test() {
             "extern { fn foo() -> int; fn bar() -> real; }"
         ),
         expect_test::expect![[
-            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: 12..15 }, params: [], return_type: Primitive { kind: Int, span: 21..24 }, span: 9..24 }, FnSig { name: Ident { name: "bar", span: 29..32 }, params: [], return_type: Primitive { kind: Real, span: 38..42 }, span: 26..42 }], span: 0..45 }"#
+            r#"Extern { functions: [FnSig { name: Ident { name: "foo", span: "test":12..15 }, params: [], return_type: Primitive { kind: Int, span: "test":21..24 }, span: "test":9..24 }, FnSig { name: Ident { name: "bar", span: "test":29..32 }, params: [], return_type: Primitive { kind: Real, span: "test":38..42 }, span: "test":26..42 }], span: "test":0..45 }"#
         ]],
     );
     check(

--- a/yurtc/src/span.rs
+++ b/yurtc/src/span.rs
@@ -1,7 +1,44 @@
-pub(super) type Span = std::ops::Range<usize>;
+use std::{fmt, ops::Range, path::Path, rc::Rc};
+
+#[derive(Clone, PartialEq)]
+pub(super) struct Span {
+    pub(super) context: Rc<Path>,
+    pub(super) range: Range<usize>,
+}
+
+impl chumsky::Span for Span {
+    // For now, the context is just a `Path`. This may change in the future
+    type Context = Rc<Path>;
+
+    type Offset = usize;
+
+    fn new(context: Self::Context, range: Range<Self::Offset>) -> Self {
+        Self { context, range }
+    }
+
+    fn context(&self) -> Self::Context {
+        Rc::clone(&self.context)
+    }
+
+    fn start(&self) -> Self::Offset {
+        self.range.start
+    }
+    fn end(&self) -> Self::Offset {
+        self.range.end
+    }
+}
+
+impl fmt::Debug for Span {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}:{:?}", self.context, self.range)
+    }
+}
 
 pub(super) fn empty_span() -> Span {
-    0..0
+    Span {
+        range: 0..0,
+        context: Rc::from(Path::new("")),
+    }
 }
 
 pub(super) trait Spanned {


### PR DESCRIPTION
Closes #219

This includes an `Rc<Path>` in each span. Hopefully this is light enough to not blow up the AST. Printing of errors now relies on the file path and source code _from the spans themselves_ which allows us to point to multiple files in the same error message.

Most of the change is trivial, though the `print` function took a bit of time to get right. Hopefully this is efficient enough. Long term, we should reuse read files using a cache instead of re-reading them every time.

Also, since spans are more complex now, I decided to reduce their footprint by reimplementing `Debug` for them. We should do that for the whole AST. See https://github.com/essential-contributions/yurt/issues/226