### PR TITLE
Yurt and BNF syntax highlighting in the specs

### DIFF
--- a/specs/book.toml
+++ b/specs/book.toml
@@ -6,6 +6,7 @@ src = "src"
 title = "Yurt Specification"
 
 [output.html]
+additional-js = ["theme/yurt.js", "theme/bnf.js"]
 git-repository-url = "https://github.com/essential-contributions/yurt"
 
 [preprocessor.katex]

--- a/specs/src/lang/language_primitives.md
+++ b/specs/src/lang/language_primitives.md
@@ -20,7 +20,7 @@ This document has the following structure. [Notation](#notation) introduces the 
 
 ## Notation
 
-The specification of the Yurt programming language presented in this document follows the [EBNF format](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form). The basics of the EBNF used are as follows:
+The specification of the Yurt programming language presented in this document follows the [BNF format](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form). The basics of the BNF used are as follows:
 
 - Non-terminals are written between angle brackets, e.g. `<item>`.
 - Terminals are written in double quotes, e.g. `"solve"`. A double quote terminal is written as a sequence of three double quotes: `"""`.
@@ -58,7 +58,7 @@ A `//` indicates that the rest of the line is a comment.
 
 Identifiers have the following syntax:
 
-```ebnf
+```bnf
 <ident> ::= _?[A-Za-z][A-Za-z0-9]*     % excluding keywords
 ```
 
@@ -70,13 +70,13 @@ A path is a sequence of one ore more path segments logically separated by a name
 
 Paths have the following syntax:
 
-```ebnf
+```bnf
 <path> ::= [ "::" ] <ident> ( "::" <ident> )*
 ```
 
 For example:
 
-```rust
+```yurt
 ::x;
 x::y::z;
 x;
@@ -90,13 +90,13 @@ Paths that start with `::` are absolute paths from the root of the project. Path
 
 A Yurt intent consists of one or more semicolon separated `items`:
 
-```ebnf
+```bnf
 <intent> ::= ( <item> ";" )*
 ```
 
 Items can occur in any order; identifiers need not be declared before they are used. Items have the following top-level syntax:
 
-```ebnf
+```bnf
 <item> ::= <import-item>
          | <let-item>
          | <state-item>
@@ -166,7 +166,7 @@ Yurt provides 4 scalar types built-in: Booleans, integers, reals and strings. Yu
 
 The syntax for types is as follows:
 
-```ebnf
+```bnf
 <ty> ::= "bool"
        | "int"
        | "real"
@@ -180,7 +180,7 @@ The syntax for types is as follows:
 
 A tuple type represents a collection of items that may have different types. Tuple types have the following syntax:
 
-```ebnf
+```bnf
 <tuple-ty> ::= "{" ( [ <ident> ":" ] <ty> "," ... ) "}"
 ```
 
@@ -194,7 +194,7 @@ Note that the grammar disallows empty tuple types `{ }`.
 
 An array type represents a collection of items that share the same type. Arrays can be multi-dimensional and have the following syntax:
 
-```ebnf
+```bnf
 <array-ty> ::= <ty> ( "[" <expr> | <custom-ty> "]" )+
 ```
 
@@ -206,7 +206,7 @@ An array dimension can be indexed using non-negative integers. It can also be in
 
 For example, in:
 
-```rust
+```yurt
 let N = 5;
 enum Colour = Red | Green | Blue;
 let a: real[N][Colour];`
@@ -218,7 +218,7 @@ let a: real[N][Colour];`
 
 An enum type refers to an [enum declaration](#enum-declaration-items) using its path and has the following syntax:
 
-```ebnf
+```bnf
 <enum-ty> ::= <path>
 ```
 
@@ -228,7 +228,7 @@ An enum type refers to an [enum declaration](#enum-declaration-items) using its 
 
 Expressions represent values and have the following syntax:
 
-```ebnf
+```bnf
 <expr> ::= <un-op> <expr>
          | <expr> <bin-op> <expr>
          | <block-expr>
@@ -266,7 +266,7 @@ There are two kinds of operators:
 1. Unary operators which can be applied in a prefix manner without parentheses, e.g. `-x`.
 1. Binary operator which can be applied in an infix manner, e.g. `3 + 4`.
 
-```ebnf
+```bnf
 <un-op> ::= "+" | "-" | "!"
 
 <bin-op> ::= "<" | ">" | "<=" | ">=" | "==" | "!="
@@ -280,7 +280,7 @@ There are two kinds of operators:
 
 Block expressions are expressions that contains a list of _statements_ followed by an expression within curly bracket `{ .. }`. Formally:
 
-```ebnf
+```bnf
 <block-expr> ::= "{" ( <block-statement> ";" )* <expr> "}"
 
 <block-statement> ::= <let-item>
@@ -290,7 +290,7 @@ Block expressions are expressions that contains a list of _statements_ followed 
 
 The type of the block expression is the type of the final expression. For example:
 
-```rust
+```yurt
 let x: int = {
     let y: int = 2;
     y + 1
@@ -301,7 +301,7 @@ let x: int = {
 
 Boolean literals have this syntax:
 
-```ebnf
+```bnf
 <bool-literal> ::= "false" | "true"
 ```
 
@@ -309,7 +309,7 @@ Boolean literals have this syntax:
 
 There are three forms of integer literals: decimal, hexadecimal, and binary:
 
-```ebnf
+```bnf
 <int-literal> ::= [0-9]+
                 | 0x[0-9A-Fa-f]+
                 | 0b[0-1]+
@@ -319,7 +319,7 @@ For example: `1`, `0030`, `0x333`, `0b1010`.
 
 Real literals have the following form:
 
-```ebnf
+```bnf
 <real-literal> ::= [0-9]+"."[0-9]+
                   | [0-9]+"."[0-9]+[Ee][-+]?[0-9]+
                   | [0-9]+[Ee][-+]?[0-9]+
@@ -333,7 +333,7 @@ A `-` preceding an integer or real literal is parsed as a unary minus, not as pa
 
 String literals are written as:
 
-```ebnf
+```bnf
 <string-literal> ::= "\"" ([^"\n] | "\\" ("x" [0-9a-fA-F][0-9a-fA-F] | "n" | "t" | "\"" | "\\")) "\""
 ```
 
@@ -341,7 +341,7 @@ For example: `"Hello, world!\n"`.
 
 String literals can be broken across multiple lines by escaping the newline and leading whitespace with a `\`. For example:
 
-```rust
+```yurt
 let string = "first line\
              second line\
              third line";
@@ -351,7 +351,7 @@ let string = "first line\
 
 Tuple expressions are written as:
 
-```ebnf
+```bnf
 <tuple-expr> ::= "{" ( [ <ident> ":" ] <expr> "," ... ) "}"
 ```
 
@@ -359,7 +359,7 @@ For example: `let t = { x: 5, 3, "foo" };`. The type of this tuple can be inferr
 
 The following is another example:
 
-```rust
+```yurt
 let t: { x: int, real } = { 6, 5.0 }
 ```
 
@@ -367,13 +367,13 @@ where the type of the tuple is indicated by the type annotation and has a named 
 
 Tuple fields can be initialized out of order only if all the fields have names and their names are used in the tuple expression. For example, the following is allowed:
 
-```rust
+```yurt
 let t: { x: int, y: real } = { y: 5.0, x: 6 };
 ```
 
 while the following are not:
 
-```rust
+```yurt
 let t: { x: int, real } = { 5.0, x: 6 };
 let t: { x: int, y: real } = { 5.0, x: 6 };
 let t: { x: int, y: real } = { 5.0, 6 }; // This is a type mismatch!
@@ -385,7 +385,7 @@ Note that the grammar disallows empty tuple expressions `{ }`.
 
 Tuple field access expressions are written as:
 
-```ebnf
+```bnf
 <tuple-field-access-expr> ::= <expr> "." ( [0-9]+ | <ident> )
 ```
 
@@ -395,7 +395,7 @@ For example, `t.1;` refers to the second field of tuple `t`. Named field can be 
 
 Array expressions are written as:
 
-```ebnf
+```bnf
 <array-expr> ::= "[" ( <expr> "," ... ) "]"
 ```
 
@@ -403,7 +403,7 @@ For example: `let a = [ 1, 2, 3 ];`. The type of this array can be inferred by t
 
 The following is another example:
 
-```rust
+```yurt
 let b: real[2][3] = [ [ 1.0, 2.0, 3.0], [4.0, 5.0, 6.0] ];
 ```
 
@@ -415,7 +415,7 @@ All element expressions used in an array expression must have the exact same typ
 
 Array element access expressions are written as:
 
-```ebnf
+```bnf
 <array-element-access-expr> ::= <expr> ( "[" expr "]" )+
 ```
 
@@ -430,7 +430,7 @@ Yurt also requires that each array index is known (i.e. evaluatable) at compile-
 
 Below is an example where both an integer and an enum variant are used to index into an two-dimensional array:
 
-```rust
+```yurt
 let N = 5;
 enum Colour = Red | Green | Blue;
 let a: real[N][Colour];`
@@ -442,7 +442,7 @@ let a_3_g = a[3][Colour::Green];
 
 Yurt has `if` expressions which provide selection from two alternatives based on a condition. They have this syntax:
 
-```ebnf
+```bnf
 <if-expr> ::= "if" <expr> <block-expr> "else" <block-expr>
 ```
 
@@ -454,7 +454,7 @@ Note that the `else` block is not optional and the `else if { .. }` syntax is no
 
 Yurt provides `cond` expressions which are generalized `if` expressions with more than two branches. That is, they provide selection from multiple alternatives, each based on some condition. They have the following syntax:
 
-```ebnf
+```bnf
 <cond-branch> ::= <expr> "=>" <expr>
 
 <else-branch> ::= "else" "=>" <expr>
@@ -472,7 +472,7 @@ Similarly to `if` expressions, all candidate expressions must have the same type
 
 Call expressions are used to call macros or functions and have the following syntax:
 
-```ebnf
+```bnf
 <func-call-expr> ::= <path> "(" [ <expr> "," ... ] ")"
 <macro-call-expr> ::= <path> "(" [ <tok>+ ";" ... ] ")"
 ```
@@ -487,7 +487,7 @@ See [Macro Items](#macro-items) for the distinction between regular and function
 
 Cast expressions are used to cast one value to a different type. They have the following syntax:
 
-```ebnf
+```bnf
 <cast-expr> ::= <expr> "as" <ty>
 ```
 
@@ -511,7 +511,7 @@ Any cast that does not fit an entry in the table below is a compiler error:
 
 Casts an enum to its discriminant. For example:
 
-```rust
+```yurt
 enum MyEnum = V0 | V1 | V2;
 
 let d = MyEnum::V1 as int; // `d` is equal to `1`.
@@ -526,7 +526,7 @@ let d = MyEnum::V1 as int; // `d` is equal to `1`.
 
 "In" expressions are used to detect whether a value belongs to an array. They have the following syntax:
 
-```ebnf
+```bnf
 <in-expr> ::= <expr> "in" <expr>
 ```
 
@@ -552,7 +552,7 @@ Note that two values of different types cannot be compared and should result in 
 
 Range expressions are used to refer to ranges between a lower bound value and an upper bound value:
 
-```ebnf
+```bnf
 <range-expr> ::= <expr> ".." <expr>
 ```
 
@@ -567,20 +567,20 @@ Range expressions can only be used in two contexts:
 
 For example,
 
-```rust
+```yurt
 let x: int = 3..5;
 ```
 
 is equivalent to;
 
-```rust
+```yurt
 let x: int;
 constraint x in 3..5;
 ```
 
 which is equivalent to:
 
-```rust
+```yurt
 let x: int;
 constraint x >= 3;
 constraint x <= 5;
@@ -590,13 +590,13 @@ constraint x <= 5;
 
 Prime expressions are used to refer to the _future_ value of a [state variable](#state-declaration-items). They have the following syntax:
 
-```ebnf
+```bnf
 <prime-expr> ::= <expr> "'"
 ```
 
 For example:
 
-```rust
+```yurt
 state u = MyContract::foo();
 constraint u' - u > 10;
 ```
@@ -630,7 +630,7 @@ This section describes the top-level program items.
 
 Within a scope, import items create shortcuts to items defined in other files. Import items have the following syntax:
 
-```ebnf
+```bnf
 <use-tree> ::= [ [ <path> ] "::" ] "*"
              | [ [ <path> ] "::" ] "{" [ <use-tree> "," ... ] "}"
              | <path> [ "as" <ident> ]
@@ -653,13 +653,13 @@ These are variables whose values may or may not be unknown for a given _instance
 
 Variable declaration items have the following syntax:
 
-```ebnf
+```bnf
 <let-item> ::= "let" <ident> ( ( ":" <ty> ) | ("=" <expr> ) | ( ":" <ty> "=" <expr> ) )
 ```
 
 For example:
 
-```rust
+```yurt
 let x: int;
 let y = 5;
 ```
@@ -672,13 +672,13 @@ These are variables that represent blockchain _state_ and require an initializer
 
 State declaration items have the following syntax:
 
-```ebnf
+```bnf
 <state-item> ::= "state" <ident> [ ":" <ty> ] "=" <expr>
 ```
 
 For example:
 
-```rust
+```yurt
 state x: int = MyContract::foo();
 state y = MyContract::bar();
 ```
@@ -691,13 +691,13 @@ Constraint items represent the core of any intent. Any solution to the intent mu
 
 Constraint items have this syntax:
 
-```ebnf
+```bnf
 <constraint-item> ::= "constraint" <expr>
 ```
 
 For example:
 
-```rust
+```yurt
 constraint a + b <= c
 ```
 
@@ -709,7 +709,7 @@ Macro items describe user defined operations. They can take the form of a 'regul
 
 Regular macros have the following syntax:
 
-```ebnf
+```bnf
 <macro-name> ::= @[A-Za-z_][A-Za-z0-9_]*
 
 <macro-param> ::= $[A-Za-z0-9]+
@@ -932,7 +932,7 @@ Yurt also supports 'function-style' macros which are more constrained but also s
 
 Function-style macros must have a final expression in their body and they may only be called as a sub-expression. Each parameter is a typed identifier and a return type (i.e., the type of the final body expression) must be specified.
 
-```ebnf
+```bnf
 <function-sig> ::= "fn" <ident> "(" [ <param> "," ... ] ")" "->" <ty>
 
 <function-item> ::= <function-sig> <block-expr>
@@ -954,7 +954,7 @@ The extra type information is used to confirm correct use, which is not directly
 
 In Yurt, an enum type is a named enumeration of integer constants. Unlike sum types found in some functional languages, each member of an enum in Yurt is associated with an integer discriminant, making it similar to C-style enums. The syntax for declaring an enum is:
 
-```ebnf
+```bnf
 <enum-decl-item> ::= "enum" <ident> "=" <ident> ( "|" <ident> )*
 ```
 
@@ -966,7 +966,7 @@ Each enum variant must be assigned a discriminant that matches the index of its 
 
 Every intent must have at most one solve item. Solve items have the following syntax:
 
-```ebnf
+```bnf
 <solve-item> ::= "solve" "satisfy"
                | "solve" "minimize" <expr>
                | "solve" "maximize" <expr>
@@ -974,7 +974,7 @@ Every intent must have at most one solve item. Solve items have the following sy
 
 Example solve items:
 
-```rust
+```yurt
 solve satisfy;
 solve maximize a + b - c;
 ```
@@ -987,13 +987,13 @@ Interface items contain lists of smart contract functions that a smart [contract
 
 Interface items describe lists of smart contract functions, in the form of function signatures, that a contract can have. An interface item has the following syntax:
 
-```ebnf
+```bnf
 <interface-item> ::= "interface" <ident> "{" ( <function-sig> ";" )* "}"
 ```
 
 For example, the following is a simple interface with 3 functions:
 
-```rust
+```yurt
 interface IERC20 {
     fn totalSupply() -> int;
     fn balanceOf(account: int) -> int;
@@ -1007,7 +1007,7 @@ Interface functions are not callable directly. Instead, they have to be called t
 
 Contract items describe actual deployed contracts with a known contract ID and a list of available functions. Contract items require a known integer ID and a list of function signatures. Contract can also "inherit" functions from [interfaces](#interface-items). Contract items have the following syntax:
 
-```ebnf
+```bnf
 <contract-item> ::= "contract" <ident> "(" <expr> ")"
                     [ "implements" <path> ( "," <path> )* ]
                     "{" ( <function-sig> ";" )* "}"
@@ -1015,7 +1015,7 @@ Contract items describe actual deployed contracts with a known contract ID and a
 
 For example, consider the contract item below:
 
-```rust
+```yurt
 contract MyToken(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48) implements IERC20, Ownable {
     fn foo() -> int;
     fn bar() -> int;
@@ -1036,13 +1036,13 @@ A call to any of these functions can be made using a `<call-expr>` with the name
 
 The syntax for extern items is as follows:
 
-```ebnf
+```bnf
 <extern-item> ::= "extern" "{" ( <function-sig> ";" )* "}"
 ```
 
 For example:
 
-```rust
+```yurt
 extern {
     fn eth_getBalance(address: string) -> string;
 
@@ -1060,13 +1060,13 @@ New Type items introduce a distinct type that is not directly interchangeable wi
 
 The syntax for declaring a new type is:
 
-```ebnf
+```bnf
 <new-type-item> ::= "type" <ident> "=" <ty>
 ```
 
 For example:
 
-```rust
+```yurt
 type AccountTuple = { id: int, balance: real, address: string };
 
 type IdArray = int[5];
@@ -1084,7 +1084,7 @@ New type values may be initialized through:
 
 - Literals of primitive types (`int`, `real`, `bool`, `string`) as long as they are compatible with the new type's underlying definition.
 
-```rust
+```yurt
 let walletDetails: AccountTuple = {id: 1, balance: 2.0, address: "0x1234...ABCD"};
 
 let ids: IdArray = [1, 2, 3, 4, 5];

--- a/specs/theme/bnf.js
+++ b/specs/theme/bnf.js
@@ -1,0 +1,31 @@
+hljs.registerLanguage("bnf", (hljs) => ({
+  name: "BNF",
+  contains: [
+    // Attribute
+    {
+      className: "attribute",
+      begin: /</,
+      end: />/,
+    },
+    // Specific
+    {
+      begin: /::=/,
+      starts: {
+        end: /$/,
+        contains: [
+          {
+            begin: /</,
+            end: />/,
+          },
+          // Common
+          hljs.C_LINE_COMMENT_MODE,
+          hljs.C_BLOCK_COMMENT_MODE,
+          hljs.APOS_STRING_MODE,
+          hljs.QUOTE_STRING_MODE,
+        ],
+      },
+    },
+  ],
+}));
+
+hljs.initHighlightingOnLoad();

--- a/specs/theme/yurt.js
+++ b/specs/theme/yurt.js
@@ -1,0 +1,15 @@
+hljs.registerLanguage("yurt", (hljs) => ({
+  name: "Yurt",
+  keywords: {
+    keyword:
+      "as bool cond constraint contract else enum extern fn if implements in interface int let macro maximize minimize real satisfy solve state string type use",
+    literal: "false true",
+  },
+  contains: [
+    hljs.QUOTE_STRING_MODE,
+    hljs.C_NUMBER_MODE,
+    hljs.C_LINE_COMMENT_MODE,
+  ],
+}));
+
+hljs.initHighlightingOnLoad();


### PR DESCRIPTION
Closes #327

This is pretty basic for now. Probably both can be improved over time. The BNF file is obtained from [here](https://github.com/Sannis/highlight.js/blob/master/src/languages/bnf.js). I'd like to make modifications to it in the future as I don't think what they have is ideal.

Eventually, `yurt.js` will also be used by the Yurt documentation.

Also, `BNF` is really a better fit right now, at least syntax-wise. That may or may not change once #335 is tackled.

