### PR TITLE
Alternative install step for `cargo-udeps` to enable caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-udeps
-        run: cargo install --locked cargo-udeps
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-udeps
+          locked: true
 
       - name: Check Unused Deps
         run: cargo udeps --locked --all-targets


### PR DESCRIPTION
This seems to work better. The `udeps` step was taking > 10min before.