### PR TITLE
Check all diagnostics, not just top level errors, in the e2e tests

### DIFF
--- a/yurtc/src/error/compile_error.rs
+++ b/yurtc/src/error/compile_error.rs
@@ -56,7 +56,7 @@ impl ReportableError for CompileError {
                 path_full, span, ..
             } => {
                 vec![ErrorLabel {
-                    message: format!("failed to resolve path {path_full} "),
+                    message: format!("failed to resolve path {path_full}"),
                     span: span.clone(),
                     color: Color::Red,
                 }]

--- a/yurtc/src/parser/tests.rs
+++ b/yurtc/src/parser/tests.rs
@@ -92,27 +92,7 @@ impl DisplayWithII for (&'static str, usize) {
 fn display_errors(errors: &[Error]) -> String {
     // Print each error on one line. For each error, start with the span.
     errors.iter().fold(String::new(), |acc, error| {
-        let mut all_diagnostics = format!("{}{}", acc, error);
-        all_diagnostics = format!(
-            "{}{}",
-            all_diagnostics,
-            error.labels().iter().fold(String::new(), |acc, label| {
-                format!(
-                    "\n{}@{}..{}: {}\n",
-                    acc,
-                    label.span.start(),
-                    label.span.end(),
-                    label.message
-                )
-            })
-        );
-        if let Some(note) = error.note() {
-            all_diagnostics = format!("{}{}", all_diagnostics, note);
-        }
-        if let Some(help) = error.help() {
-            all_diagnostics = format!("{}{}", all_diagnostics, help);
-        }
-        all_diagnostics
+        format!("{}{}", acc, error.display_raw())
     })
 }
 
@@ -312,7 +292,8 @@ fn let_decls() {
         expect_test::expect![[r#"
             type annotation or initializer needed for variable `blah`
             @0..8: type annotation or initializer needed
-            consider giving `blah` an explicit type or an initializer"#]],
+            consider giving `blah` an explicit type or an initializer
+        "#]],
     );
     check(
         &run_let_parser("let blah = 1.0"),
@@ -1851,30 +1832,31 @@ let parse_error
     check(
         &run_yurt_parser(src),
         expect_test::expect![[r#"
-        type annotation or initializer needed for variable `untyped`
-        @1..12: type annotation or initializer needed
-        consider giving `untyped` an explicit type or an initializersymbol `clash` has already been declared
-
-        @18..23: previous declaration of the value `clash` here
-        @33..38: `clash` redeclared here
-        `clash` must be declared or imported only once in this scopesymbol `clash` has already been declared
-
-        @18..23: previous declaration of the value `clash` here
-        @48..53: `clash` redeclared here
-        `clash` must be declared or imported only once in this scopeempty tuple types are not allowed
-        @76..78: empty tuple type found
-        empty tuple expressions are not allowed
-        @81..83: empty tuple expression found
-        empty array types are not allowed
-        @102..107: empty array type found
-        missing array index
-        @132..135: missing array element index
-        invalid integer `0x5` as tuple index
-        @163..166: invalid integer as tuple index
-        invalid value `1e5` as tuple index
-        @191..194: invalid value as tuple index
-        expected `:`, `;`, or `=`, found `end of file`
-        @211..211: expected `:`, `;`, or `=`
-    "#]],
+            type annotation or initializer needed for variable `untyped`
+            @1..12: type annotation or initializer needed
+            consider giving `untyped` an explicit type or an initializer
+            symbol `clash` has already been declared
+            @18..23: previous declaration of the value `clash` here
+            @33..38: `clash` redeclared here
+            `clash` must be declared or imported only once in this scope
+            symbol `clash` has already been declared
+            @18..23: previous declaration of the value `clash` here
+            @48..53: `clash` redeclared here
+            `clash` must be declared or imported only once in this scope
+            empty tuple types are not allowed
+            @76..78: empty tuple type found
+            empty tuple expressions are not allowed
+            @81..83: empty tuple expression found
+            empty array types are not allowed
+            @102..107: empty array type found
+            missing array index
+            @132..135: missing array element index
+            invalid integer `0x5` as tuple index
+            @163..166: invalid integer as tuple index
+            invalid value `1e5` as tuple index
+            @191..194: invalid value as tuple index
+            expected `:`, `;`, or `=`, found `end of file`
+            @211..211: expected `:`, `;`, or `=`
+        "#]],
     );
 }

--- a/yurtc/src/span.rs
+++ b/yurtc/src/span.rs
@@ -51,6 +51,6 @@ pub(super) fn join(lhs: &Span, rhs: &Span) -> Span {
     }
 }
 
-pub(super) trait Spanned {
+pub trait Spanned {
     fn span(&self) -> &Span;
 }

--- a/yurtc/tests/basic_tests/parse_failure.yrt
+++ b/yurtc/tests/basic_tests/parse_failure.yrt
@@ -11,13 +11,28 @@ let parse_error
 
 // parse_failure <<<
 // type annotation or initializer needed for variable `untyped`
+// @0..11: type annotation or initializer needed
+// consider giving `untyped` an explicit type or an initializer
 // symbol `clash` has already been declared
+// @17..22: previous declaration of the value `clash` here
+// @32..37: `clash` redeclared here
+// `clash` must be declared or imported only once in this scope
 // symbol `clash` has already been declared
+// @17..22: previous declaration of the value `clash` here
+// @47..52: `clash` redeclared here
+// `clash` must be declared or imported only once in this scope
 // empty tuple types are not allowed
+// @75..77: empty tuple type found
 // empty tuple expressions are not allowed
+// @80..82: empty tuple expression found
 // empty array types are not allowed
+// @101..106: empty array type found
 // missing array index
+// @131..134: missing array element index
 // invalid integer `0x5` as tuple index
+// @162..165: invalid integer as tuple index
 // invalid value `1e5` as tuple index
+// @190..193: invalid value as tuple index
 // expected `:`, `;`, or `=`, found `end of file`
+// @210..210: expected `:`, `;`, or `=`
 // >>>

--- a/yurtc/tests/basic_tests/use_let_name_clash.yrt
+++ b/yurtc/tests/basic_tests/use_let_name_clash.yrt
@@ -4,5 +4,8 @@ let b: int;
 
 // parse_failure <<<
 // symbol `b` has already been declared
+// @7..8: previous declaration of the value `b` here
+// @15..16: `b` redeclared here
+// `b` must be declared or imported only once in this scope
 // >>>
 

--- a/yurtc/tests/basic_tests/use_use_name_clash.yrt
+++ b/yurtc/tests/basic_tests/use_use_name_clash.yrt
@@ -5,5 +5,8 @@ let d: int;
 
 // parse_failure <<<
 // symbol `b` has already been declared
+// @7..8: previous declaration of the value `b` here
+// @17..18: `b` redeclared here
+// `b` must be declared or imported only once in this scope
 // >>>
 

--- a/yurtc/tests/modules/03/main.yrt
+++ b/yurtc/tests/modules/03/main.yrt
@@ -9,6 +9,15 @@ solve minimize a;
 
 // parse_failure <<<
 // symbol `a` has already been declared
+// @7..8: previous declaration of the value `a` here
+// @83..84: `a` redeclared here
+// `a` must be declared or imported only once in this scope
 // symbol `a` has already been declared
+// @7..8: previous declaration of the value `a` here
+// @90..91: `a` redeclared here
+// `a` must be declared or imported only once in this scope
 // symbol `a` has already been declared
+// @7..8: previous declaration of the value `a` here
+// @102..103: `a` redeclared here
+// `a` must be declared or imported only once in this scope
 // >>>

--- a/yurtc/tests/modules/07/main.yrt
+++ b/yurtc/tests/modules/07/main.yrt
@@ -10,9 +10,21 @@ let v5 = b::c::d;
 
 // parse_failure <<<
 // no file found for path
+// @51..52: failed to resolve path b::c::d::e
+// one of the modules `b::c::d` or `b::c` must exist
 // no file found for path
+// @63..67: failed to resolve path b::c::d::e
+// one of the modules `b::c::d` or `b::c` must exist
 // multiple source files found for module
+// @78..84: multiple source files found for module b
+// both the files `tests/modules/07/b.yrt` and `tests/modules/07/b/b.yrt` exist, where only one or the other is allowed
 // multiple source files found for module
+// @95..96: multiple source files found for module b
+// both the files `tests/modules/07/b.yrt` and `tests/modules/07/b/b.yrt` exist, where only one or the other is allowed
 // multiple source files found for module
+// @107..114: multiple source files found for module b
+// both the files `tests/modules/07/b.yrt` and `tests/modules/07/b/b.yrt` exist, where only one or the other is allowed
 // no file found for path
+// @107..114: failed to resolve path b::c::d
+// one of the modules `b::c` or `b` must exist
 // >>>

--- a/yurtc/tests/tests.rs
+++ b/yurtc/tests/tests.rs
@@ -3,8 +3,8 @@ use std::{
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
 };
-
 use yansi::Color::{Cyan, Red, Yellow};
+use yurtc::error::ReportableError;
 
 #[cfg(test)]
 mod e2e {
@@ -59,9 +59,10 @@ fn run_tests(sub_dir: &str) -> anyhow::Result<()> {
                 // separate all the errors using a `\n`
                 let errs_str = errs
                     .iter()
-                    .map(|err| err.to_string())
-                    .collect::<Vec<_>>()
-                    .join("\n");
+                    .map(|err| err.display_raw())
+                    .collect::<String>()
+                    .trim_end()
+                    .to_string();
 
                 if let Some(parse_error_str) = expectations.parse_failure {
                     similar_asserts::assert_eq!(parse_error_str.trim_end(), errs_str);


### PR DESCRIPTION
Close #341 

Fairly straightforward change. Use a common method to display errors in all tests.