### PR TITLE
Revert trufflehog to previous version in Trunk.

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -12,7 +12,7 @@ lint:
     - osv-scanner@1.4.3
     - oxipng@9.0.0
     - trivy@0.47.0
-    - trufflehog@3.63.2-rc0
+    - trufflehog@3.63.1
     - actionlint@1.6.26
     - clippy@1.74.0
     - git-diff-check


### PR DESCRIPTION
It looks like they might've pulled the RC release we were using.