### PR TITLE
Disallow `let` and `state` declarations inside blocks

### DIFF
--- a/docs/specs/src/yurt/expressions/atoms/block.md
+++ b/docs/specs/src/yurt/expressions/atoms/block.md
@@ -3,18 +3,15 @@
 Block expressions are expressions that contain a list of _statements_ followed by an expression within curly bracket `{ .. }`. Formally:
 
 ```bnf
-<block-expr> ::= "{" ( <block-statement> )* <expr> "}"
-
-<block-statement> ::= <let-item>
-                    | <state-item>
-                    | <constraint-item>
+<block-expr> ::= "{" ( <constraint-item> )* <expr> "}"
 ```
 
 The type of the block expression is the type of the final expression. For example:
 
 ```yurt
+let y: int;
 let x: int = {
-    let y: int = 2;
+    constraint y == 2;
     y + 1 // returned final expression of type `int`
 }
 ```
@@ -22,8 +19,8 @@ let x: int = {
 the above is equivalent to the following:
 
 ```yurt
-let x: int;
 let y: int;
+let x: int;
 constraint y == 2;
 constraint x == y + 1;
 ```

--- a/docs/specs/src/yurt/structure/namespaces.md
+++ b/docs/specs/src/yurt/structure/namespaces.md
@@ -10,7 +10,7 @@ All names declared at the top-level of a Yurt file belong to a single namespace.
 
 ### Name Shadowing
 
-Name shadowing in Yurt is not allowed. For example, both examples below should fail to compile:
+Name shadowing in Yurt is not allowed. For example, the following should fail to compile:
 
 ```yurt
 let x = 5;
@@ -19,10 +19,7 @@ let x = 6;
 
 ```yurt
 let x = 5;
-let y = {
-    let x = 6; // shadows the `x` outside the block expression
-    x
-}
+state x = MyContract::bar();
 ```
 
 Note, however, that [macro](../items/macros.md) bodies **are allowed** to declare new variables with names that have been used outside the macro body, because macro expansion is designed to be [hygienic](../items/macros.md#hygiene). For example, the following is allowed:

--- a/yurtc/src/yurt_parser.lalrpop
+++ b/yurtc/src/yurt_parser.lalrpop
@@ -686,13 +686,8 @@ TermInner: Expr = {
     <l:@L> <path:Path> <r:@R> => Expr::PathByName(path, (context.span_from)(l, r)),
 };
 
-BlockDecl: () = {
-    LetDecl ";",
-    ConstraintDecl ";",
-};
-
 BlockExpr: ExprKey = {
-    "{" BlockDecl* <Expr> "}"
+    "{" (ConstraintDecl ";")* <Expr> "}"
 };
 
 IfExpr: Expr = {


### PR DESCRIPTION
Closes #367 

As discussed offline, with name shadowing disallowed, there is no point in allowing `let` and `state` variables in code blocks.