### PR TITLE
Allow self in use statements

### DIFF
--- a/yurtc/src/error/parse_error.rs
+++ b/yurtc/src/error/parse_error.rs
@@ -49,6 +49,10 @@ pub enum ParseError {
     },
     #[error("leading `+` is not supported")]
     UnsupportedLeadingPlus { span: Span },
+    #[error("`self` import can only appear in an import list with a non-empty prefix")]
+    SelfWithEmptyPrefix { span: Span },
+    #[error("`self` is only allowed at the end of a use path")]
+    SelfNotAtTheEnd { span: Span },
 }
 
 impl ReportableError for ParseError {
@@ -158,6 +162,21 @@ impl ReportableError for ParseError {
                     color: Color::Red,
                 }]
             }
+            SelfWithEmptyPrefix { span } => {
+                vec![ErrorLabel {
+                    message: "can only appear in an import list with a non-empty prefix"
+                        .to_string(),
+                    span: span.clone(),
+                    color: Color::Red,
+                }]
+            }
+            SelfNotAtTheEnd { span } => {
+                vec![ErrorLabel {
+                    message: "`self` can only appear at the end of a use path".to_string(),
+                    span: span.clone(),
+                    color: Color::Red,
+                }]
+            }
         }
     }
 
@@ -244,6 +263,8 @@ impl Spanned for ParseError {
             | EmptyTupleType { span, .. }
             | NameClash { span, .. }
             | UnsupportedLeadingPlus { span, .. }
+            | SelfWithEmptyPrefix { span, .. }
+            | SelfNotAtTheEnd { span, .. }
             | Lex { span } => span,
 
             InvalidToken => unreachable!("The `InvalidToken` error is always wrapped in `Lex`."),

--- a/yurtc/src/lexer.rs
+++ b/yurtc/src/lexer.rs
@@ -126,6 +126,8 @@ pub enum Token {
 
     #[token("use")]
     Use,
+    #[token("self")]
+    SelfTok,
     #[token("as")]
     As,
 
@@ -182,6 +184,7 @@ pub(super) static KEYWORDS: &[Token] = &[
     Token::Solve,
     Token::Satisfy,
     Token::Use,
+    Token::SelfTok,
     Token::As,
     Token::Enum,
     Token::Interface,
@@ -270,6 +273,7 @@ impl fmt::Display for Token {
             Token::Solve => write!(f, "solve"),
             Token::Satisfy => write!(f, "satisfy"),
             Token::Use => write!(f, "use"),
+            Token::SelfTok => write!(f, "self"),
             Token::As => write!(f, "as"),
             Token::Interface => write!(f, "interface"),
             Token::Contract => write!(f, "contract"),

--- a/yurtc/src/lexer/tests.rs
+++ b/yurtc/src/lexer/tests.rs
@@ -211,6 +211,11 @@ fn r#use() {
 }
 
 #[test]
+fn self_tok() {
+    assert_eq!(lex_one_success("self"), Token::SelfTok);
+}
+
+#[test]
 fn r#as() {
     assert_eq!(lex_one_success("as"), Token::As);
 }

--- a/yurtc/src/parser/tests.rs
+++ b/yurtc/src/parser/tests.rs
@@ -239,24 +239,24 @@ fn use_statements() {
     check(
         &run_parser!(yurt, "use ;", mod_path),
         expect_test::expect![[r#"
-            expected `::`, `ident`, or `{`, found `;`
-            @4..5: expected `::`, `ident`, or `{`
+            expected `::`, `ident`, `self`, or `{`, found `;`
+            @4..5: expected `::`, `ident`, `self`, or `{`
         "#]],
     );
 
     check(
         &run_parser!(yurt, "use ::;", mod_path),
         expect_test::expect![[r#"
-            expected `ident`, or `{`, found `;`
-            @6..7: expected `ident`, or `{`
+            expected `ident`, `self`, or `{`, found `;`
+            @6..7: expected `ident`, `self`, or `{`
         "#]],
     );
 
     check(
         &run_parser!(yurt, "use a::;", mod_path),
         expect_test::expect![[r#"
-            expected `ident`, or `{`, found `;`
-            @7..8: expected `ident`, or `{`
+            expected `ident`, `self`, or `{`, found `;`
+            @7..8: expected `ident`, `self`, or `{`
         "#]],
     );
 
@@ -271,6 +271,36 @@ fn use_statements() {
             @7..8: previous declaration of the value `b` here
             @34..40: `b` redeclared here
             `b` must be declared or imported only once in this scope
+        "#]],
+    );
+
+    check(
+        &run_parser!(yurt, "use a::{{self as t}, b, c::{self, d}, e};", mod_path),
+        expect_test::expect![[r#"
+            use foo::a as t;
+            use foo::a::b;
+            use foo::a::c;
+            use foo::a::c::d;
+            use foo::a::e"#]],
+    );
+
+    check(
+        &run_parser!(
+            yurt,
+            "use {self}; use self; use self::a; use self::self; use a::{b as self}",
+            mod_path
+        ),
+        expect_test::expect![[r#"
+            `self` import can only appear in an import list with a non-empty prefix
+            @5..9: can only appear in an import list with a non-empty prefix
+            `self` import can only appear in an import list with a non-empty prefix
+            @16..20: can only appear in an import list with a non-empty prefix
+            `self` is only allowed at the end of a use path
+            @26..33: `self` can only appear at the end of a use path
+            `self` is only allowed at the end of a use path
+            @39..49: `self` can only appear at the end of a use path
+            expected `ident`, found `self`
+            @64..68: expected `ident`
         "#]],
     );
 }

--- a/yurtc/src/yurt_parser.lalrpop
+++ b/yurtc/src/yurt_parser.lalrpop
@@ -37,22 +37,63 @@ Decl: () = {
 };
 
 UseStatement: () = {
-    "use" <abs:"::"?> <ut:UseTree> => {
-        // Convert the use tree into use paths, prepend the current mod path
-        // prefix to each iff the use tree is not absolute, and append to the
-        // current list of use paths in our context.
+    "use" <l:@L> <abs:"::"?> <ut:UseTree> <r:@R> => {
+        // Convert the use tree into use paths, prepend the current mod path prefix to each iff the
+        // use tree is not absolute, and append to the current list of use paths in our context.
+        let mut local_errors = Vec::new();
         let mut new_use_paths = ut
             .gather_paths()
             .into_iter()
-            .map(|mut use_path| {
+            .filter_map(|mut use_path| {
                 if abs.is_none() {
                     use_path.add_prefix(context.mod_path.to_vec());
                 }
 
-                // This is a bit strange.  We're taking the alias or the last
-                // element of the use path, prefixing it with the current mod
-                // path and inserting that as a top-level symbol.  This is to
-                // avoid local decls clashing with the `use` path, though those
+                // If any of the idents in the path, other than the last one, is a `self`,
+                // immediately error out
+                if use_path
+                    .path
+                    .iter()
+                    .take(use_path.path.len() - 1)
+                    .any(|elem| elem == "self")
+                {
+                    local_errors.push(Error::Parse {
+                        error: ParseError::SelfNotAtTheEnd {
+                            // We can use a better span here but that's okay for now. Ideally, we
+                            // would use the span of the `self` ident itself, but we don't have that
+                            // right now.
+                            span: (context.span_from)(l, r),
+                        },
+                    });
+                    return None;
+                }
+
+                // Paths that end in `self` get a special handling
+                if use_path.path[use_path.path.len() - 1] == "self" {
+                    // First, remove `self` because a path that ends in `self` is the same as its
+                    // prefix For example: `a::b::self` is the same as `a::b`
+                    use_path.path.pop();
+
+                    // Paths with only `self` (i.e. nothing before it) are not valid
+                    //
+                    // Check that the prefix `use_path.path` matches the current `mod_path` because
+                    // we may in a module other than the root module
+                    if use_path.path == context.mod_path {
+                        local_errors.push(Error::Parse {
+                            error: ParseError::SelfWithEmptyPrefix {
+                                span: use_path.span.clone(),
+                            },
+                        });
+                        return None;
+                    }
+                }
+
+                Some(use_path.clone())
+            })
+            .map(|use_path| {
+                // This is a bit strange.  We're taking the alias or the last element of the use
+                // path, prefixing it with the current mod path and inserting that as a top-level
+                // symbol.  This is to avoid local decls clashing with the `use` path, though those
                 // symbols are all absolute.
                 //
                 // e.g.,
@@ -61,6 +102,12 @@ UseStatement: () = {
                 //
                 // use some::other::mod::b as c;  // Inserted as ::local::mod::c
                 // let c: int;                    // Inserted as ::local::mod::c
+                //
+                // There is one special case with `self` where the previous ident in the path is
+                // considered instead. This is automatically handled by the `filter_map` above. For
+                // example:
+                //
+                // use a::b::mod::my_mod::self;    // Inserted as ::local::mod::my_mod
                 context
                     .ii
                     .add_top_level_symbol(
@@ -82,15 +129,21 @@ UseStatement: () = {
             })
             .collect::<Vec<_>>();
 
+        errors.extend(local_errors);
         context.use_paths.append(&mut new_use_paths);
     }
 };
 
+pub UsePathIdent: Ident = {
+    IdentFromToken<"ident">,
+    IdentFromToken<"self">,
+}
+
 pub UseTree: UseTree = {
-    <name:Ident> => UseTree::Name { name },
-    <prefix:Ident> "::" <suffix:UseTree> => UseTreePath { prefix, suffix: Box::new(suffix) },
+    <name:UsePathIdent> => UseTree::Name { name },
+    <prefix:UsePathIdent> "::" <suffix:UseTree> => UseTreePath { prefix, suffix: Box::new(suffix) },
     "{" <imports:SepList<UseTree, ",">> "}" => UseTree::Group { imports },
-    <name:Ident> "as" <alias:Ident> => UseTree::Alias { name, alias },
+    <name:UsePathIdent> "as" <alias:Ident> => UseTree::Alias { name, alias },
 };
 
 pub LetDecl: () = {
@@ -1014,6 +1067,7 @@ extern {
         "cond" => lexer::Token::Cond,
 
         "use" => lexer::Token::Use,
+        "self" => lexer::Token::SelfTok,
         "let" => lexer::Token::Let,
         "state" => lexer::Token::State,
         "enum" => lexer::Token::Enum,


### PR DESCRIPTION
Closes #359

- Add `self` as a keyword
- Use it only in use path (not aliases)
- Disallow various unwanted cases

Error messages:

![image](https://github.com/essential-contributions/yurt/assets/59666792/8ace45e5-be7e-4abc-ac81-df00c9f2edcb)
