### PR TITLE
Support Single Line Comments

### DIFF
--- a/yurtfmt/src/ast.rs
+++ b/yurtfmt/src/ast.rs
@@ -56,6 +56,9 @@ pub(super) enum Decl<'sc> {
         name: String,
         variants: Vec<String>,
     },
+    Comment {
+        content: String,
+    },
 }
 
 impl<'sc> Format for Decl<'sc> {
@@ -194,6 +197,9 @@ impl<'sc> Format for Decl<'sc> {
             }
             Self::Enum { name, variants } => {
                 formatted_code.write(&format!("enum {name} = {};", &variants.join(" | ")));
+            }
+            Self::Comment { content } => {
+                formatted_code.write_line(content);
             }
         }
 

--- a/yurtfmt/src/ast/tests.rs
+++ b/yurtfmt/src/ast/tests.rs
@@ -1333,3 +1333,61 @@ fn array_element_accesses() {
         expect_test::expect!["a[MyEnum::Variant1]"],
     );
 }
+
+#[test]
+fn single_line_comments() {
+    check(
+        &run_formatter!(yurt_program(), r#"// Hello"#),
+        expect_test::expect!["// Hello\n"],
+    );
+    check(
+        &run_formatter!(
+            yurt_program(),
+            r#"//Hello
+            //World"#
+        ),
+        expect_test::expect!["//Hello\n//World\n"],
+    );
+    check(
+        &run_formatter!(
+            yurt_program(),
+            r#"// Hello
+        // World
+        // !"#
+        ),
+        expect_test::expect!["// Hello\n// World\n// !\n"],
+    );
+    check(
+        &run_formatter!(
+            yurt_program(),
+            r#"//       Hello
+            // World
+            // !
+            // "#
+        ),
+        expect_test::expect!["//       Hello\n// World\n// !\n// \n"],
+    );
+    check(
+        &run_formatter!(
+            yurt_program(),
+            r#"// This comment is allowed
+            constraint h1 + h2 + h3 + h4 + h5 + h6 + h7 + h8 
+                     + h9 + h10 + h11 + h12 + h13 + h14 + h15 
+                     + h16 + h17 + h18 == 72;"#
+        ),
+        expect_test::expect!["// This comment is allowed\nconstraint h1 + h2 + h3 + h4 + h5 + h6 + h7 + h8 + h9 + h10 + h11 + h12 + h13 + h14 + h15 + h16 + h17 + h18 == 72;\n"],
+    );
+    check(
+        &run_formatter!(
+            yurt_program(),
+            r#"constraint h1 + h2 + h3 + h4 + h5 + h6 + h7 + h8 // this is not supported for now
+            + h9 + h10 + h11 + h12 + h13 + h14 + h15 
+            + h16 + h17 + h18 == 72;"#
+        ),
+        expect_test::expect![
+            r#"
+            Error formatting starting at location 49 and ending at location 81
+            "#
+        ],
+    );
+}

--- a/yurtfmt/src/lexer.rs
+++ b/yurtfmt/src/lexer.rs
@@ -103,8 +103,8 @@ pub(super) enum Token<'sc> {
     )]
     Literal(&'sc str),
 
-    #[regex(r"//[^\n\r]*", logos::skip)]
-    Comment,
+    #[regex(r"//[^\n\r]*", |lex| lex.slice())]
+    Comment(&'sc str),
 }
 
 pub(super) fn lex(src: &str) -> (Vec<(Token, Span)>, Vec<FormatterError>) {
@@ -160,7 +160,7 @@ impl<'sc> fmt::Display for Token<'sc> {
             Token::Solve => write!(f, "solve"),
             Token::Ident(ident) => write!(f, "{ident}"),
             Token::Literal(contents) => write!(f, "{contents}"),
-            Token::Comment => write!(f, "comment"),
+            Token::Comment(contents) => write!(f, "{contents}"),
         }
     }
 }

--- a/yurtfmt/src/lexer/tests.rs
+++ b/yurtfmt/src/lexer/tests.rs
@@ -12,6 +12,16 @@ fn lex_one_success(src: &str) -> Token<'_> {
 }
 
 #[test]
+fn comments() {
+    assert_eq!(lex_one_success("//"), Token::Comment("//"));
+    assert_eq!(lex_one_success("// Hello"), Token::Comment("// Hello"));
+    assert_eq!(lex_one_success("// Hello\n"), Token::Comment("// Hello"));
+    assert_eq!(lex_one_success("// Hello\r\n"), Token::Comment("// Hello"));
+    assert_eq!(lex_one_success("// Hello\r"), Token::Comment("// Hello"));
+    assert_eq!(lex_one_success("// Hello\n\r"), Token::Comment("// Hello"));
+}
+
+#[test]
 fn control_tokens() {
     assert_eq!(lex_one_success(":"), Token::Colon);
     assert_eq!(lex_one_success("::"), Token::DoubleColon);

--- a/yurtfmt/src/parser.rs
+++ b/yurtfmt/src/parser.rs
@@ -50,6 +50,7 @@ pub(super) fn yurt_program<'sc>(
         interface_decl(),
         contract_decl(),
         extern_decl(),
+        comment_decl(),
     ))
     .repeated()
     .then_ignore(end())
@@ -208,6 +209,12 @@ fn enum_decl<'sc>() -> impl Parser<Token<'sc>, ast::Decl<'sc>, Error = ParseErro
         .then(variants)
         .then_ignore(just(Token::Semi))
         .map(|(name, variants)| ast::Decl::Enum { name, variants })
+        .boxed()
+}
+
+fn comment_decl<'sc>() -> impl Parser<Token<'sc>, ast::Decl<'sc>, Error = ParseError> + Clone {
+    select! { Token::Comment(content) => content.to_owned() }
+        .map(|content| ast::Decl::Comment { content })
         .boxed()
 }
 


### PR DESCRIPTION
Closes #394 

After discussion with @mohammadfawaz we decided to support single line comments for the time being. Since he's actually writing in yurt now, it's been a big pain point having comments just get deleted.

I chose to modify our lexer and recognize anything starting from // up to \n\r. I do not do any formatting for the comment, we just recognize and pass it through. All comments have to be alone and not inside of another node.