### PR TITLE
Enable state_decls in blocks

### DIFF
--- a/docs/specs/src/yurt/items/states.md
+++ b/docs/specs/src/yurt/items/states.md
@@ -1,6 +1,6 @@
 ### State Declaration Items
 
-These are variables that represent blockchain _state_ and **require** an initializer in the form of a [contract](./contracts.md) method call or a call to an [`extern` function](./externs.md)). State variables are _not_ decision variables and the solver is not required to find values for them as their true value is determined by the blockchain. That being said, state variables can still be used in [constraint items](./constraints.md) to enforce various restrictions on the current and [future state values](../expressions/atoms/prime.md).
+These are variables that represent blockchain _state_ and **require** an initializer in the form of a [contract](./contracts.md) method call or a call to an [`extern` function](./externs.md). State variables are _not_ decision variables and the solver is not required to find values for them as their true value is determined by the blockchain. That being said, state variables can still be used in [constraint items](./constraints.md) to enforce various restrictions on the current and [future state values](../expressions/atoms/prime.md).
 
 State declaration items have the following syntax:
 

--- a/yurtfmt/src/parser.rs
+++ b/yurtfmt/src/parser.rs
@@ -247,7 +247,7 @@ pub(super) fn code_block_expr<'sc>(
 ) -> impl Parser<Token<'sc>, ast::Block<'sc>, Error = ParseError> + Clone {
     let code_block_body = choice((
         value_decl(expr.clone()),
-        // state_decl(expr.clone()), TODO: add when state is supported
+        state_decl(),
         constraint_decl(expr.clone()),
     ))
     .repeated()


### PR DESCRIPTION
Not sure if this should be here or not. It's an old TODO item I had.

Once upon a time it was in the spec that we have state_decls in blocks. @mohammadfawaz I don't see that anywhere in the spec anymore. Am I missing it, or was it modified so we don't support this anymore?