### PR TITLE
Implement the core support for macros.

### DIFF
--- a/yurtc/src/error/parse_error.rs
+++ b/yurtc/src/error/parse_error.rs
@@ -137,6 +137,7 @@ impl ReportableError for ParseError {
                     color: Color::Red,
                 }]
             }
+
             NameClash {
                 sym,
                 span,

--- a/yurtc/src/expr.rs
+++ b/yurtc/src/expr.rs
@@ -4,6 +4,8 @@ use crate::{
     types::{Path, Type},
 };
 
+use std::collections::HashMap;
+
 mod display;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -143,5 +145,68 @@ impl Spanned for Expr {
             | Expr::In { span, .. }
             | Expr::Range { span, .. } => span,
         }
+    }
+}
+
+impl Expr {
+    pub fn replace_ref<F: FnMut(&mut ExprKey)>(&mut self, mut replace: F) {
+        match self {
+            Expr::UnaryOp { expr, .. } => replace(expr),
+            Expr::BinaryOp { lhs, rhs, .. } => {
+                replace(lhs);
+                replace(rhs);
+            }
+            Expr::FnCall { args, .. } => args.iter_mut().for_each(replace),
+            Expr::If {
+                condition,
+                then_block,
+                else_block,
+                ..
+            } => {
+                replace(condition);
+                replace(then_block);
+                replace(else_block);
+            }
+            Expr::Array { elements, .. } => elements.iter_mut().for_each(replace),
+            Expr::ArrayElementAccess { array, index, .. } => {
+                replace(array);
+                replace(index);
+            }
+            Expr::Tuple { fields, .. } => fields.iter_mut().for_each(|(_, expr)| replace(expr)),
+            Expr::TupleFieldAccess { tuple, .. } => replace(tuple),
+            Expr::Cast { value, .. } => replace(value),
+            Expr::In {
+                value, collection, ..
+            } => {
+                replace(value);
+                replace(collection);
+            }
+            Expr::Range { lb, ub, .. } => {
+                replace(lb);
+                replace(ub);
+            }
+
+            Expr::MacroCall { .. }
+            | Expr::PathByName(_, _)
+            | Expr::PathByKey(_, _)
+            | Expr::Immediate { .. }
+            | Expr::Error(_) => {}
+        }
+    }
+
+    pub fn replace_one_to_one(&mut self, old_key: ExprKey, new_key: ExprKey) {
+        self.replace_ref(|expr: &mut ExprKey| {
+            if *expr == old_key {
+                *expr = new_key
+            }
+        })
+    }
+
+    pub fn replace_ref_by_map(&mut self, keys: &HashMap<ExprKey, ExprKey>) {
+        self.replace_ref(|old_key: &mut ExprKey| {
+            if let Some(new_key) = keys.get(old_key) {
+                *old_key = *new_key;
+            }
+        })
     }
 }

--- a/yurtc/src/lexer/tests.rs
+++ b/yurtc/src/lexer/tests.rs
@@ -255,7 +255,7 @@ solve minimize mid;
     use Token::*;
     assert_eq!(tokens.len(), 23);
     assert!(matches!(tokens[0].0, Let));
-    assert_eq!(tokens[1].0, Ident("low_val".to_owned()));
+    assert_eq!(tokens[1].0, Ident(("low_val".to_owned(), false)));
     assert!(matches!(tokens[2].0, Colon));
     assert!(matches!(tokens[3].0, Int));
     assert!(matches!(tokens[4].0, Eq));
@@ -263,22 +263,22 @@ solve minimize mid;
     assert!(matches!(tokens[6].0, Semi));
 
     assert!(matches!(tokens[7].0, Constraint));
-    assert_eq!(tokens[8].0, Ident("mid".to_owned()));
+    assert_eq!(tokens[8].0, Ident(("mid".to_owned(), false)));
     assert!(matches!(tokens[9].0, Gt));
-    assert_eq!(tokens[10].0, Ident("low_val".to_owned()));
+    assert_eq!(tokens[10].0, Ident(("low_val".to_owned(), false)));
     assert_eq!(tokens[11].0, IntLiteral("2".to_owned()));
     assert!(matches!(tokens[12].0, Semi));
 
     assert!(matches!(tokens[13].0, Constraint));
-    assert_eq!(tokens[14].0, Ident("mid".to_owned()));
+    assert_eq!(tokens[14].0, Ident(("mid".to_owned(), false)));
     assert!(matches!(tokens[15].0, Lt));
-    assert_eq!(tokens[16].0, Ident("low_val".to_owned()));
+    assert_eq!(tokens[16].0, Ident(("low_val".to_owned(), false)));
     assert_eq!(tokens[17].0, IntLiteral("2".to_owned()));
     assert!(matches!(tokens[18].0, Semi));
 
     assert!(matches!(tokens[19].0, Solve));
     assert!(matches!(tokens[20].0, Minimize));
-    assert_eq!(tokens[21].0, Ident("mid".to_owned()));
+    assert_eq!(tokens[21].0, Ident(("mid".to_owned(), false)));
     assert!(matches!(tokens[22].0, Semi));
 }
 
@@ -366,13 +366,13 @@ fn macros_success() {
     assert!(matches!(body, (_, MacroBody(_), _)));
     if let MacroBody(body_toks) = body.1 {
         assert_eq!(body_toks.len(), 7);
-        assert!(matches!(body_toks[0], BraceOpen));
-        assert!(matches!(body_toks[1], Let));
-        assert_eq!(body_toks[2], Ident("it".to_owned()));
-        assert!(matches!(body_toks[3], StringLiteral(_)));
-        assert_eq!(body_toks[4], IntLiteral("88".to_owned()));
-        assert!(matches!(body_toks[5], Semi));
-        assert!(matches!(body_toks[6], BraceClose));
+        assert!(matches!(body_toks[0], (_, BraceOpen, _)));
+        assert!(matches!(body_toks[1], (_, Let, _)));
+        assert_eq!(body_toks[2].1, Ident(("it".to_owned(), false)));
+        assert!(matches!(body_toks[3], (_, StringLiteral(_), _)));
+        assert_eq!(body_toks[4].1, IntLiteral("88".to_owned()));
+        assert!(matches!(body_toks[5], (_, Semi, _)));
+        assert!(matches!(body_toks[6], (_, BraceClose, _)));
     } else {
         unreachable!()
     }
@@ -393,20 +393,20 @@ fn macros_success() {
 
     if let MacroBody(body_toks) = body.1 {
         assert_eq!(body_toks.len(), 14);
-        assert!(matches!(body_toks[0], BraceOpen));
-        assert_eq!(body_toks[1], Ident("a".to_owned()));
-        assert!(matches!(body_toks[2], BraceOpen));
-        assert_eq!(body_toks[3], Ident("b".to_owned()));
-        assert!(matches!(body_toks[4], BraceClose));
-        assert!(matches!(body_toks[5], BraceOpen));
-        assert!(matches!(body_toks[6], BraceOpen));
-        assert!(matches!(body_toks[7], BraceClose));
-        assert_eq!(body_toks[8], Ident("c".to_owned()));
-        assert!(matches!(body_toks[9], BraceClose));
-        assert!(matches!(body_toks[10], BraceOpen));
-        assert_eq!(body_toks[11], Ident("d".to_owned()));
-        assert!(matches!(body_toks[12], BraceClose));
-        assert!(matches!(body_toks[13], BraceClose));
+        assert!(matches!(body_toks[0], (_, BraceOpen, _)));
+        assert_eq!(body_toks[1].1, Ident(("a".to_owned(), false)));
+        assert!(matches!(body_toks[2], (_, BraceOpen, _)));
+        assert_eq!(body_toks[3].1, Ident(("b".to_owned(), false)));
+        assert!(matches!(body_toks[4], (_, BraceClose, _)));
+        assert!(matches!(body_toks[5], (_, BraceOpen, _)));
+        assert!(matches!(body_toks[6], (_, BraceOpen, _)));
+        assert!(matches!(body_toks[7], (_, BraceClose, _)));
+        assert_eq!(body_toks[8].1, Ident(("c".to_owned(), false)));
+        assert!(matches!(body_toks[9], (_, BraceClose, _)));
+        assert!(matches!(body_toks[10], (_, BraceOpen, _)));
+        assert_eq!(body_toks[11].1, Ident(("d".to_owned(), false)));
+        assert!(matches!(body_toks[12], (_, BraceClose, _)));
+        assert!(matches!(body_toks[13], (_, BraceClose, _)));
     } else {
         unreachable!()
     }
@@ -421,7 +421,10 @@ fn macros_badly_formed() {
     // Macro name has no `@`, should not parse the body.
     let mut toks = Lexer::new("macro bad() { 11 }", &Rc::clone(&path));
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Macro, _)));
-    assert_eq!(toks.next().unwrap().unwrap().1, Ident("bad".to_owned()),);
+    assert_eq!(
+        toks.next().unwrap().unwrap().1,
+        Ident(("bad".to_owned(), false)),
+    );
     assert!(matches!(toks.next().unwrap().unwrap(), (_, ParenOpen, _)));
     assert!(matches!(toks.next().unwrap().unwrap(), (_, ParenClose, _)));
     assert!(matches!(toks.next().unwrap().unwrap(), (_, BraceOpen, _)));
@@ -437,9 +440,15 @@ fn macros_badly_formed() {
         MacroName("@name".to_owned()),
     );
     assert!(matches!(toks.next().unwrap().unwrap(), (_, ParenOpen, _)));
-    assert_eq!(toks.next().unwrap().unwrap().1, Ident("bad".to_owned()),);
+    assert_eq!(
+        toks.next().unwrap().unwrap().1,
+        Ident(("bad".to_owned(), false)),
+    );
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Comma, _)));
-    assert_eq!(toks.next().unwrap().unwrap().1, Ident("param".to_owned()),);
+    assert_eq!(
+        toks.next().unwrap().unwrap().1,
+        Ident(("param".to_owned(), false)),
+    );
     assert!(matches!(toks.next().unwrap().unwrap(), (_, ParenClose, _)));
     assert!(matches!(toks.next().unwrap().unwrap(), (_, BraceOpen, _)));
     assert_eq!(toks.next().unwrap().unwrap().1, IntLiteral("22".to_owned()),);
@@ -458,7 +467,10 @@ fn macros_badly_formed() {
         MacroParam("$good".to_owned()),
     );
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Comma, _)));
-    assert_eq!(toks.next().unwrap().unwrap().1, Ident("bad".to_owned()),);
+    assert_eq!(
+        toks.next().unwrap().unwrap().1,
+        Ident(("bad".to_owned(), false)),
+    );
     assert!(matches!(toks.next().unwrap().unwrap(), (_, ParenClose, _)));
     assert!(matches!(toks.next().unwrap().unwrap(), (_, BraceOpen, _)));
     assert_eq!(toks.next().unwrap().unwrap().1, IntLiteral("33".to_owned()),);
@@ -526,7 +538,7 @@ fn macros_call_success() {
     if let MacroCallArgs(args) = args.1 {
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].len(), 1);
-        assert!(matches!(args[0][0], Int));
+        assert!(matches!(args[0][0], (_, Int, _)));
     } else {
         unreachable!()
     }
@@ -544,9 +556,9 @@ fn macros_call_success() {
     if let MacroCallArgs(args) = args.1 {
         assert_eq!(args.len(), 2);
         assert_eq!(args[0].len(), 1);
-        assert!(matches!(args[0][0], Int));
+        assert!(matches!(args[0][0], (_, Int, _)));
         assert_eq!(args[1].len(), 1);
-        assert!(matches!(args[1][0], Ident(_)));
+        assert!(matches!(args[1][0], (_, Ident(_), _)));
     } else {
         unreachable!()
     }
@@ -562,15 +574,15 @@ fn macros_call_success() {
     if let MacroCallArgs(args) = args.1 {
         assert_eq!(args.len(), 2);
         assert_eq!(args[0].len(), 3);
-        assert_eq!(args[0][0], IntLiteral("1".to_owned()));
-        assert!(matches!(args[0][1], Plus));
-        assert_eq!(args[0][2], IntLiteral("2".to_owned()));
+        assert_eq!(args[0][0].1, IntLiteral("1".to_owned()));
+        assert!(matches!(args[0][1], (_, Plus, _)));
+        assert_eq!(args[0][2].1, IntLiteral("2".to_owned()));
         assert_eq!(args[1].len(), 5);
-        assert!(matches!(args[1][0], BracketOpen));
-        assert_eq!(args[1][1], IntLiteral("1".to_owned()));
-        assert!(matches!(args[1][2], Comma));
-        assert_eq!(args[1][3], IntLiteral("2".to_owned()));
-        assert!(matches!(args[1][4], BracketClose));
+        assert!(matches!(args[1][0], (_, BracketOpen, _)));
+        assert_eq!(args[1][1].1, IntLiteral("1".to_owned()));
+        assert!(matches!(args[1][2], (_, Comma, _)));
+        assert_eq!(args[1][3].1, IntLiteral("2".to_owned()));
+        assert!(matches!(args[1][4], (_, BracketClose, _)));
     } else {
         unreachable!()
     }
@@ -586,12 +598,12 @@ fn macros_call_success() {
     if let MacroCallArgs(args) = args.1 {
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].len(), 6);
-        assert!(matches!(args[0][0], Let));
-        assert!(matches!(args[0][1], Ident(_)));
-        assert!(matches!(args[0][2], Colon));
-        assert!(matches!(args[0][3], Int));
-        assert!(matches!(args[0][4], Eq));
-        assert_eq!(args[0][5], IntLiteral("0".to_owned()));
+        assert!(matches!(args[0][0], (_, Let, _)));
+        assert!(matches!(args[0][1], (_, Ident(_), _)));
+        assert!(matches!(args[0][2], (_, Colon, _)));
+        assert!(matches!(args[0][3], (_, Int, _)));
+        assert!(matches!(args[0][4], (_, Eq, _)));
+        assert_eq!(args[0][5].1, IntLiteral("0".to_owned()));
     } else {
         unreachable!()
     }
@@ -607,15 +619,15 @@ fn macros_call_success() {
     if let MacroCallArgs(args) = args.1 {
         assert_eq!(args.len(), 1);
         assert_eq!(args[0].len(), 15);
-        assert_eq!(args[0][0], IntLiteral("1".to_owned()));
-        assert!(matches!(args[0][1], Comma));
-        assert_eq!(args[0][2], IntLiteral("2".to_owned()));
-        assert!(matches!(args[0][3], Comma));
+        assert_eq!(args[0][0].1, IntLiteral("1".to_owned()));
+        assert!(matches!(args[0][1], (_, Comma, _)));
+        assert_eq!(args[0][2].1, IntLiteral("2".to_owned()));
+        assert!(matches!(args[0][3], (_, Comma, _)));
         // etc.
-        assert!(matches!(args[0][11], Comma));
-        assert_eq!(args[0][12], IntLiteral("7".to_owned()));
-        assert!(matches!(args[0][13], Comma));
-        assert_eq!(args[0][14], IntLiteral("8".to_owned()));
+        assert!(matches!(args[0][11], (_, Comma, _)));
+        assert_eq!(args[0][12].1, IntLiteral("7".to_owned()));
+        assert!(matches!(args[0][13], (_, Comma, _)));
+        assert_eq!(args[0][14].1, IntLiteral("8".to_owned()));
     } else {
         unreachable!()
     }

--- a/yurtc/src/macros.rs
+++ b/yurtc/src/macros.rs
@@ -1,35 +1,57 @@
-use crate::{expr::Ident, lexer::Token, types::Path};
+use crate::{
+    error::{CompileError, Error},
+    expr::Ident,
+    lexer::Token,
+    span::Span,
+    types::Path,
+};
 
-use std::fmt;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    fmt,
+    rc::Rc,
+};
 
 pub(crate) struct MacroDecl {
     pub(crate) name: Ident,
     pub(crate) params: Vec<Ident>,
-    pub(crate) body: Vec<Token>,
+    pub(crate) pack: Option<Ident>,
+    pub(crate) body: Vec<(usize, Token, usize)>,
+    pub(crate) sig_span: Span,
 }
 
 impl fmt::Display for MacroDecl {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "macro {}(", self.name)?;
         write!(
             f,
-            "macro {}({}) {}",
-            self.name,
+            "{}",
             self.params
                 .iter()
                 .map(|p| p.to_string())
                 .collect::<Vec<_>>()
-                .join(", "),
+                .join(", ")
+        )?;
+        if let Some(pack) = &self.pack {
+            write!(f, ", {pack}")?;
+        }
+        write!(
+            f,
+            ") {}",
             self.body
                 .iter()
-                .map(|t| t.to_string())
+                .map(|(_, t, _)| t.to_string())
                 .collect::<Vec<_>>()
                 .join(" ")
         )
     }
 }
+
 pub(crate) struct MacroCall {
     pub(crate) name: Path,
-    pub(crate) args: Vec<Vec<Token>>,
+    pub(crate) mod_path: Vec<String>,
+    pub(crate) args: Vec<Vec<(usize, Token, usize)>>,
+    pub(crate) span: Span,
 }
 
 impl fmt::Display for MacroCall {
@@ -42,11 +64,132 @@ impl fmt::Display for MacroCall {
                 .iter()
                 .map(|arg| arg
                     .iter()
-                    .map(|tok| tok.to_string())
+                    .map(|(_, tok, _)| tok.to_string())
                     .collect::<Vec<_>>()
                     .join(" "))
                 .collect::<Vec<_>>()
                 .join("; ")
         )
     }
+}
+
+pub(crate) fn verify_unique_set(macro_decls: &[MacroDecl]) -> Vec<Error> {
+    let mut errors = Vec::new();
+    let mut sigs_set = HashMap::<_, Span>::new();
+
+    for MacroDecl {
+        name,
+        params,
+        pack,
+        sig_span,
+        ..
+    } in macro_decls
+    {
+        // The key is name, number of params and whether it has a parameter pack.
+        let entry = sigs_set.entry((name.name.clone(), params.len(), pack.is_some()));
+        if let Entry::Occupied(prev_span) = entry {
+            errors.push(Error::Compile {
+                error: CompileError::MacroDeclClash {
+                    name: name.name.clone(),
+                    span: sig_span.clone(),
+                    prev_span: prev_span.get().clone(),
+                },
+            });
+        } else {
+            entry.or_insert(sig_span.clone());
+        }
+    }
+
+    errors
+}
+
+pub(crate) fn expand_call(
+    macro_decls: &[MacroDecl],
+    call: &MacroCall,
+) -> Result<Vec<(usize, Token, usize)>, Vec<Error>> {
+    let macro_decl: &MacroDecl = match_macro(macro_decls, call)?;
+    let mut body = Vec::with_capacity(macro_decl.body.len());
+    let mut errs = Vec::new();
+
+    let param_idcs = HashMap::<&String, usize>::from_iter(
+        macro_decl
+            .params
+            .iter()
+            .enumerate()
+            .map(|(idx, id)| (&id.name, idx)),
+    );
+
+    for tok in &macro_decl.body {
+        match &tok.1 {
+            Token::MacroParam(param) => {
+                if let Some(&idx) = param_idcs.get(param) {
+                    body.append(&mut call.args[idx].clone());
+                } else {
+                    errs.push(Error::Compile {
+                        error: CompileError::MacroUndefinedParam {
+                            name: param.clone(),
+                            span: Span {
+                                context: Rc::clone(&macro_decl.sig_span.context),
+                                range: tok.0..tok.2,
+                            },
+                        },
+                    });
+                }
+            }
+            Token::MacroParamPack(_) => {
+                // `match_macro()` guarantees that the param pack is not empty.  We need to append
+                // the arg tokens separated by `;` for each arg.
+                for arg in call.args.iter().skip(macro_decl.params.len()) {
+                    body.append(&mut arg.clone());
+                    body.push((0, Token::Semi, 0));
+                }
+            }
+            _ => body.push(tok.clone()),
+        }
+    }
+
+    if errs.is_empty() {
+        Ok(body)
+    } else {
+        Err(errs)
+    }
+}
+
+fn match_macro<'a>(
+    macro_decls: &'a [MacroDecl],
+    call: &MacroCall,
+) -> Result<&'a MacroDecl, Vec<Error>> {
+    // Firstly find the macros which have the correct name.
+    let named_macros = macro_decls
+        .iter()
+        .filter(|md| md.name.name == call.name)
+        .collect::<Vec<_>>();
+    if named_macros.is_empty() {
+        return Err(vec![Error::Compile {
+            error: CompileError::MacroNotFound {
+                name: call.name.clone(),
+                span: call.span.clone(),
+            },
+        }]);
+    }
+
+    // Then search for one with exactly the right number of parameters.
+    named_macros
+        .iter()
+        .find(|md| md.pack.is_none() && md.params.len() == call.args.len())
+        .or_else(|| {
+            // Or find one with too few parameters AND a parameter pack.
+            named_macros
+                .iter()
+                .find(|md| md.pack.is_some() && md.params.len() < call.args.len())
+        })
+        .copied()
+        .ok_or_else(|| {
+            vec![Error::Compile {
+                error: CompileError::MacroCallMismatch {
+                    name: call.name.clone(),
+                    span: call.span.clone(),
+                },
+            }]
+        })
 }

--- a/yurtc/src/main.rs
+++ b/yurtc/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     if !solve_flag {
-        eprintln!("{:?}", intent);
+        eprintln!("{intent}");
         return Ok(());
     }
 

--- a/yurtc/src/parser.rs
+++ b/yurtc/src/parser.rs
@@ -1,11 +1,12 @@
 use crate::{
     error::{CompileError, Error},
     expr::Ident,
-    intent::intermediate::{CallKey, IntermediateIntent},
+    intent::intermediate::{CallKey, ExprKey, IntermediateIntent},
     lexer,
-    macros::{MacroCall, MacroDecl},
+    macros::{self, MacroCall, MacroDecl},
     span::{self, Span},
 };
+
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -14,7 +15,7 @@ use std::{
 
 use lalrpop_util::lalrpop_mod;
 
-lalrpop_mod!(#[allow(clippy::ptr_arg)] pub yurt_parser);
+lalrpop_mod!(#[allow(clippy::ptr_arg, clippy::type_complexity)] pub yurt_parser);
 
 mod use_path;
 pub(crate) use use_path::{UsePath, UseTree};
@@ -28,7 +29,6 @@ mod tests;
 pub fn parse_project(root_src_path: &Path) -> Result<IntermediateIntent, Vec<Error>> {
     ProjectParser::new(PathBuf::from(root_src_path))
         .parse_project()
-        .expand_macros()
         .finalize()
 }
 
@@ -36,11 +36,13 @@ pub fn parse_project(root_src_path: &Path) -> Result<IntermediateIntent, Vec<Err
 struct ProjectParser {
     intent: IntermediateIntent,
     macros: Vec<MacroDecl>,
-    macro_calls: slotmap::SecondaryMap<CallKey, MacroCall>,
+    macro_calls: slotmap::SecondaryMap<CallKey, (ExprKey, MacroCall)>,
     proj_root_path: PathBuf,
     root_src_path: PathBuf,
     visited_paths: Vec<PathBuf>,
     errors: Vec<Error>,
+
+    unique_idx: u64,
 }
 
 #[derive(Clone)]
@@ -72,6 +74,241 @@ impl ProjectParser {
             root_src_path,
 
             ..Self::default()
+        }
+    }
+
+    /// Parse the project starting with the `root_src_path` and return an intermediate intent. Upon
+    /// failure, return a vector of all compile errors encountered.
+    fn parse_project(mut self) -> Self {
+        let mut call_replacements = Vec::<(ExprKey, ExprKey)>::new();
+        let mut pending_paths = vec![(self.root_src_path.clone(), Vec::new())];
+
+        // This is an unbound loop which breaks if there are errors or when there is no more work
+        // to do, as per the pending_paths queue.  It will also break after a gazillion iterations
+        // in case of an infinite loop bug.
+        for loop_count in 0.. {
+            while let Some((src_path, mod_path)) = pending_paths.pop() {
+                if self.visited_paths.contains(&src_path) {
+                    continue;
+                }
+
+                // Store this path as parsed to avoid re-parsing later.
+                self.visited_paths.push(src_path.to_path_buf());
+
+                // Parse this file module, returning any paths to other potential modules.
+                let (_, next_paths) = self.parse_module(&Rc::from(src_path), &mod_path);
+                self.analyse_and_add_paths(&mod_path, &next_paths, &mut pending_paths);
+            }
+
+            // Perform macro expansion for any new calls we have parsed. First, check for multiple
+            // macros with the same signature.
+            let mut errs = macros::verify_unique_set(&self.macros);
+            let some_non_unique = !errs.is_empty();
+            self.errors.append(&mut errs);
+
+            // Abort here if we have non-unique macro declarations since call expansion assumes
+            // that there will be a single match.
+            if some_non_unique {
+                return self;
+            }
+
+            // Expand the next call.  It may find new paths.
+            if let Some(call_key) = self.macro_calls.keys().nth(0) {
+                let (call_expr_key, call) = self
+                    .macro_calls
+                    .remove(call_key)
+                    .expect("Call key must be valid.");
+
+                match macros::expand_call(&self.macros, &call) {
+                    Ok(tokens) => {
+                        let (body_expr, next_paths) =
+                            self.parse_macro_body(tokens, &call.span.context, &call.mod_path);
+
+                        self.analyse_and_add_paths(&call.mod_path, &next_paths, &mut pending_paths);
+
+                        if let Some(expr_key) = body_expr {
+                            call_replacements.push((call_expr_key, expr_key));
+                        }
+                    }
+                    Err(mut errs) => self.errors.append(&mut errs),
+                }
+            }
+
+            // If there's no more work then there's no more work.
+            if pending_paths.is_empty() && self.macro_calls.is_empty() {
+                break;
+            }
+
+            // If the loop has gone for too long then there's an internal error. Arbitrary limit...
+            if loop_count > 10_000 {
+                self.errors.push(Error::Compile {
+                    error: CompileError::Internal {
+                        msg: "Infinite loop in project parser",
+                        span: span::empty_span(),
+                    },
+                });
+                return self;
+            }
+        }
+
+        // For each call we need to replace its user (there should be just one) with the macro body
+        // expression.
+        for (call_expr_key, body_expr_key) in call_replacements {
+            self.intent.replace_exprs(call_expr_key, body_expr_key);
+        }
+
+        self
+    }
+
+    fn finalize(self) -> Result<IntermediateIntent, Vec<Error>> {
+        if self.errors.is_empty() {
+            Ok(self.intent)
+        } else {
+            Err(self.errors)
+        }
+    }
+}
+
+// This is a macro for calling a LALRPOP parser with a full ParserContext.  It can't be a function
+// because the parser needs to be passed in, and the parsers can't be generic types since they're
+// different structs each time -- they don't implement a trait, they just all have identical
+// `.parse()` methods.
+//
+// Perhaps it's confusing to put this in a macro, but if it's not then all of the context creation
+// code here is duplicated.  *shrug*
+
+macro_rules! parse_with {
+    ($self: ident,
+     $tokens: expr,
+     $parser: expr,
+     $src_path: ident,
+     $mod_path: ident,
+     $local_scope: expr) => {{
+        let span_from = |start, end| Span {
+            context: Rc::clone($src_path),
+            range: start..end,
+        };
+
+        let mut mod_prefix = $mod_path
+            .iter()
+            .map(|el| format!("::{el}"))
+            .collect::<Vec<_>>()
+            .concat();
+        mod_prefix.push_str("::");
+
+        let mut next_paths = Vec::new();
+
+        let mut context = ParserContext {
+            $mod_path,
+            mod_prefix: &mod_prefix,
+            local_scope: $local_scope,
+            ii: &mut $self.intent,
+            macros: &mut $self.macros,
+            macro_calls: &mut $self.macro_calls,
+            span_from: &span_from,
+            use_paths: &mut Vec::new(),
+            next_paths: &mut next_paths,
+        };
+
+        let parsed_val = $parser
+            .parse(&mut context, &mut $self.errors, $tokens)
+            .map_err(|lalrpop_err| {
+                $self.errors.push(Error::Parse {
+                    error: (lalrpop_err, $src_path).into(),
+                });
+            })
+            .unwrap_or_default();
+
+        (parsed_val, next_paths)
+    }};
+}
+
+impl ProjectParser {
+    fn parse_module(&mut self, src_path: &Rc<Path>, mod_path: &[String]) -> ((), Vec<NextModPath>) {
+        let src_str = fs::read_to_string(src_path).unwrap_or_else(|io_err| {
+            self.errors.push(Error::Compile {
+                error: CompileError::FileIO {
+                    error: io_err,
+                    file: src_path.to_path_buf(),
+                    span: span::empty_span(),
+                },
+            });
+            String::new()
+        });
+
+        parse_with!(
+            self,
+            lexer::Lexer::new(&src_str, src_path),
+            yurt_parser::YurtParser::new(),
+            src_path,
+            mod_path,
+            None
+        )
+    }
+
+    fn parse_macro_body(
+        &mut self,
+        tokens: Vec<(usize, lexer::Token, usize)>,
+        src_path: &Rc<Path>,
+        mod_path: &[String],
+    ) -> (Option<ExprKey>, Vec<NextModPath>) {
+        let local_scope = format!("anon@{}", self.unique_idx);
+        self.unique_idx += 1;
+
+        parse_with!(
+            self,
+            lexer::Lexer::from_tokens(tokens, src_path),
+            yurt_parser::MacroBodyParser::new(),
+            src_path,
+            mod_path,
+            Some(&local_scope)
+        )
+    }
+
+    fn analyse_and_add_paths(
+        &mut self,
+        mod_path: &[String],
+        next_paths: &[NextModPath],
+        pending_paths: &mut Vec<(PathBuf, Vec<String>)>,
+    ) {
+        for NextModPath {
+            is_abs,
+            mod_path_strs,
+            suffix,
+            enum_path_strs,
+            span,
+        } in next_paths
+        {
+            // The idea here is to try to handle the next path assuming the suffix refers to a
+            // declaration. If that fails, then try to handle the next path assuming it's a path to
+            // an enum variant. If both options fail, then we emit an error.
+
+            if let Some(next_path) = self.find_next_path(*is_abs, mod_path_strs, mod_path, span) {
+                pending_paths.push(next_path);
+                continue;
+            }
+
+            if let Some(enum_path_strs) = enum_path_strs {
+                if let Some(next_path) =
+                    self.find_next_path(*is_abs, enum_path_strs, mod_path, span)
+                {
+                    pending_paths.push(next_path);
+                    continue;
+                }
+
+                let path_mod = mod_path_strs.join("::");
+                let path_enum = enum_path_strs.join("::");
+                let path_full = format!("{path_mod}::{suffix}");
+
+                self.errors.push(Error::Compile {
+                    error: CompileError::NoFileFoundForPath {
+                        path_full: path_full.clone(),
+                        path_mod,
+                        path_enum,
+                        span: span.clone(),
+                    },
+                });
+            }
         }
     }
 
@@ -124,135 +361,6 @@ impl ProjectParser {
                 });
                 None
             }
-        }
-    }
-
-    /// Parse the project starting with the `root_src_path` and return an intermediate intent. Upon
-    /// failure, return a vector of all compile errors encountered.
-    fn parse_project(mut self) -> Self {
-        let mut pending_paths = vec![(self.root_src_path.clone(), Vec::new())];
-        while let Some((src_path, mod_path)) = pending_paths.pop() {
-            if self.visited_paths.contains(&src_path) {
-                continue;
-            }
-
-            // Store this path as parsed to avoid re-parsing later.
-            self.visited_paths.push(src_path.clone());
-
-            // Parse this file module, returning any paths to other potential modules.
-            let mut mod_prefix = mod_path
-                .iter()
-                .map(|el| format!("::{el}"))
-                .collect::<Vec<_>>()
-                .concat();
-            mod_prefix.push_str("::");
-
-            let next_paths = self.parse_module(&Rc::from(src_path), &mod_path, &mod_prefix);
-
-            for NextModPath {
-                is_abs,
-                mod_path_strs,
-                suffix,
-                enum_path_strs,
-                span,
-            } in &next_paths
-            {
-                // The idea here is to try to handle the next path assuming the suffix refers to a
-                // declaration. If that fails, then try to handle the next path assuming it's a path to
-                // an enum variant. If both options fail, then we emit an error.
-
-                if let Some(next_path) =
-                    self.find_next_path(*is_abs, mod_path_strs, &mod_path, span)
-                {
-                    pending_paths.push(next_path);
-                    continue;
-                }
-
-                if let Some(enum_path_strs) = enum_path_strs {
-                    if let Some(next_path) =
-                        self.find_next_path(*is_abs, enum_path_strs, &mod_path, span)
-                    {
-                        pending_paths.push(next_path);
-                        continue;
-                    }
-
-                    let path_mod = mod_path_strs.join("::");
-                    let path_enum = enum_path_strs.join("::");
-                    let path_full = format!("{path_mod}::{suffix}");
-
-                    self.errors.push(Error::Compile {
-                        error: CompileError::NoFileFoundForPath {
-                            path_full: path_full.clone(),
-                            path_mod,
-                            path_enum,
-                            span: span.clone(),
-                        },
-                    });
-                }
-            }
-        }
-
-        self
-    }
-
-    fn parse_module(
-        &mut self,
-        src_path: &Rc<Path>,
-        mod_path: &[String],
-        mod_prefix: &String,
-    ) -> Vec<NextModPath> {
-        let src_str = fs::read_to_string(src_path).unwrap_or_else(|io_err| {
-            self.errors.push(Error::Compile {
-                error: CompileError::FileIO {
-                    error: io_err,
-                    file: src_path.to_path_buf(),
-                    span: span::empty_span(),
-                },
-            });
-            String::new()
-        });
-
-        let span_from = |start, end| Span {
-            context: Rc::clone(src_path),
-            range: start..end,
-        };
-
-        let mut next_paths = Vec::new();
-        let mut context = ParserContext {
-            mod_path,
-            mod_prefix,
-            ii: &mut self.intent,
-            macros: &mut self.macros,
-            macro_calls: &mut self.macro_calls,
-            span_from: &span_from,
-            use_paths: &mut Vec::new(),
-            next_paths: &mut next_paths,
-        };
-
-        let _ = yurt_parser::YurtParser::new()
-            .parse(
-                &mut context,
-                &mut self.errors,
-                lexer::Lexer::new(&src_str, src_path),
-            )
-            .map_err(|lalrpop_err| {
-                self.errors.push(Error::Parse {
-                    error: (lalrpop_err, src_path).into(),
-                });
-            });
-
-        next_paths
-    }
-
-    fn expand_macros(self) -> Self {
-        self
-    }
-
-    fn finalize(self) -> Result<IntermediateIntent, Vec<Error>> {
-        if self.errors.is_empty() {
-            Ok(self.intent)
-        } else {
-            Err(self.errors)
         }
     }
 }

--- a/yurtc/src/parser/context.rs
+++ b/yurtc/src/parser/context.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    intent::intermediate::CallKey,
+    intent::intermediate::{CallKey, ExprKey},
     macros::{MacroCall, MacroDecl},
     parser::Ident,
     parser::{IntermediateIntent, NextModPath, UsePath},
@@ -10,9 +10,10 @@ use crate::{
 pub struct ParserContext<'a> {
     pub(crate) mod_path: &'a [String],
     pub(crate) mod_prefix: &'a str,
+    pub(crate) local_scope: Option<&'a str>,
     pub(crate) ii: &'a mut IntermediateIntent,
     pub(crate) macros: &'a mut Vec<MacroDecl>,
-    pub(crate) macro_calls: &'a mut slotmap::SecondaryMap<CallKey, MacroCall>,
+    pub(crate) macro_calls: &'a mut slotmap::SecondaryMap<CallKey, (ExprKey, MacroCall)>,
     pub(crate) span_from: &'a dyn Fn(usize, usize) -> Span,
     pub(crate) use_paths: &'a mut Vec<UsePath>,
     pub(crate) next_paths: &'a mut Vec<NextModPath>,
@@ -27,7 +28,7 @@ impl<'a> ParserContext<'a> {
     ) -> Ident {
         match self
             .ii
-            .add_top_level_symbol(prefix, &ident, ident.span.clone())
+            .add_top_level_symbol(prefix, None, &ident, ident.span.clone())
         {
             Ok(name) => ident.name = name,
             Err(error) => errors.push(Error::Parse { error }),

--- a/yurtc/src/parser/use_path.rs
+++ b/yurtc/src/parser/use_path.rs
@@ -110,6 +110,7 @@ fn gather_use_paths() {
                 &mut crate::parser::ParserContext {
                     mod_path: &[],
                     mod_prefix: "",
+                    local_scope: None,
                     ii: &mut ii,
                     macros: &mut Vec::new(),
                     macro_calls: &mut slotmap::SecondaryMap::new(),

--- a/yurtc/src/yurt_parser.lalrpop
+++ b/yurtc/src/yurt_parser.lalrpop
@@ -5,8 +5,9 @@ use crate::{
     intent::intermediate::{ExprKey, SolveFunc},
     lexer,
     macros::{MacroCall, MacroDecl},
-    parser::{ParserContext, UseTree::{self, Path as UseTreePath}, NextModPath},
+    parser::{ParserContext, UsePath, UseTree::{self, Path as UseTreePath}, NextModPath},
     types::{EnumDecl, Path, FnSig, NewTypeDecl, PrimitiveKind, Type},
+    span,
 };
 
 grammar<'a>(
@@ -23,6 +24,11 @@ pub Yurt: () = {
 ////////////////////
 
 Decl: () = {
+    DeclBarringMacro,
+    MacroDecl,
+};
+
+DeclBarringMacro: () = {
     UseStatement ";",
     LetDecl ";",
     StateDecl ";",
@@ -30,7 +36,7 @@ Decl: () = {
     SolveDecl ";",
     EnumDecl ";",
     NewTypeDecl ";",
-    MacroDecl,
+    MacroCallDecl ";",
     InterfaceDecl,
     ContractDecl,
     ExternDecl,
@@ -112,6 +118,7 @@ UseStatement: () = {
                     .ii
                     .add_top_level_symbol(
                         context.mod_prefix,
+                        None,
                         &Ident {
                             name: use_path
                                 .alias
@@ -135,7 +142,7 @@ UseStatement: () = {
 };
 
 pub UsePathIdent: Ident = {
-    IdentFromToken<"ident">,
+    Ident,
     IdentFromToken<"self">,
 }
 
@@ -147,10 +154,15 @@ pub UseTree: UseTree = {
 };
 
 pub LetDecl: () = {
-    <l:@L> "let" <name:Ident> ":" <ty:Type> <init:LetInit?> <r:@R> => {
+    <l:@L> "let" <let_name:LetName> ":" <ty:Type> <init:LetInit?> <r:@R> => {
         context
             .ii
-            .insert_var(context.mod_prefix, &name, Some(ty))
+            .insert_var(
+                context.mod_prefix,
+                let_name.1,
+                &let_name.0,
+                Some(ty),
+            )
             .map(|var_key| {
                 if let Some(expr_key) = init {
                     context.ii.insert_eq_or_ineq_constraint(
@@ -164,10 +176,15 @@ pub LetDecl: () = {
                 errors.push(Error::Parse { error });
             });
     },
-    <l:@L> "let" <name:Ident> <init:LetInit> <r:@R> => {
+    <l:@L> "let" <let_name:LetName> <init:LetInit> <r:@R> => {
         context
             .ii
-            .insert_var(context.mod_prefix, &name, None)
+            .insert_var(
+                context.mod_prefix,
+                let_name.1,
+                &let_name.0,
+                None,
+            )
             .map(|var_key| {
                 context
                     .ii
@@ -184,6 +201,42 @@ pub LetDecl: () = {
                 span: (context.span_from)(l, r),
             },
         });
+    }
+};
+
+LetName: (Ident, Option<&'a str>) = {
+    <l:@L> <id:"ident"> <r:@R> => {
+        // We special case the let name here, as we're interested in the associated flag (and this
+        // is the only place where we care).  The flag indicates that this identifier was
+        // substituted as a part of a macro argument during macro expansion.
+        //
+        // This is to implement macro body hygiene.
+        //
+        // If we have an identifier which is NOT from a macro arg AND a local prefix set in the
+        // parser context indicating we're currently parsing a macro body, then we need to add a Use
+        // path to make sure this name is referred to using that local prefix.  We're adding hygiene
+        // using the prefix.
+
+        let local_scope = (!id.1).then_some(()).and(context.local_scope);
+
+        if let Some(prefix) = local_scope {
+            let mut path = context.mod_path.to_vec();
+            path.push(prefix.to_owned());
+            path.push(id.0.to_owned());
+            context.use_paths.push(UsePath {
+                path,
+                alias: None,
+                is_absolute: true,
+                span: span::empty_span(),
+            });
+        }
+
+        let name = Ident {
+            name: id.0.to_owned(),
+            span: (context.span_from)(l, r),
+        };
+
+        (name, local_scope)
     }
 };
 
@@ -255,12 +308,39 @@ pub NewTypeDecl: () = {
 }
 
 pub MacroDecl: () = {
-    "macro" <name:IdentFromToken<"macro_name">> "("
-        <params:SepList<IdentFromToken<"macro_param">, ",">>
-    ")"
+    "macro" <l:@L> <mut name:IdentFromToken<"macro_name">> "("
+        <params:MacroParamList>
+    ")" <r:@R>
     <body:"macro_body"> => {
-        context.macros.push(MacroDecl { name, params, body });
+        // Prefix the name with the module.  We can't use `add_top_level_symbol()` to do this as we
+        // must avoid the regular name clash error we'd get with variadic macros.
+        name.name = context.mod_prefix.to_string() + &name.name;
+        context.macros.push(MacroDecl {
+            name,
+            params: params.0,
+            pack: params.1,
+            body,
+            sig_span: (context.span_from)(l, r),
+        });
     }
+}
+
+MacroParamList: (Vec<Ident>, Option<Ident>) = {
+    <mut v: (<MacroParam> ",")*> <e:MacroParam>
+    <p:("," <IdentFromToken<"macro_param_pack">>)?> ","? => {
+        v.push(e);
+        (v, p)
+    }
+}
+
+MacroParam: Ident = IdentFromToken<"macro_param">;
+
+MacroCallDecl: () = {
+    MacroCallExpr => (),
+}
+
+pub MacroBody: Option<ExprKey> = {
+    "{" DeclBarringMacro* <Expr?> "}"
 }
 
 FnParam: (Ident, Type)  = {
@@ -682,6 +762,7 @@ UnaryOpOp: UnaryOp = {
 
 Term: ExprKey = {
     <e:TermInner> => context.ii.exprs.insert(e),
+    <MacroCallExpr>,
     <CondExpr>,
     "(" <Expr> ")",
     <BlockExpr>,
@@ -695,7 +776,6 @@ TermInner: Expr = {
         }
     },
     <IfExpr>,
-    <MacroCallExpr>,
     <FnCallExpr>,
     <ArrayExpr>,
     <TupleExpr>,
@@ -745,15 +825,24 @@ CondExpr: ExprKey = {
     }
 };
 
-MacroCallExpr: Expr = {
+MacroCallExpr: ExprKey = {
     <l:@L> <name:MacroPath> <args:"macro_call_args"> <r:@L> => {
         let call_key = context.ii.calls.insert(name.clone());
-        let call_data = MacroCall { name, args };
-        context.macro_calls.insert(call_key, call_data);
-        Expr::MacroCall {
+        let span = (context.span_from)(l, r);
+        let call_data = MacroCall {
+            name,
+            mod_path: context.mod_path.to_vec(),
+            args,
+            span: span.clone(),
+        };
+        let call_expr_key = context.ii.exprs.insert(Expr::MacroCall {
             call: call_key,
-            span: (context.span_from)(l, r),
-        }
+            span,
+        });
+        context
+            .macro_calls
+            .insert(call_key, (call_expr_key, call_data));
+        call_expr_key
     },
 };
 
@@ -963,7 +1052,12 @@ ImmediateInt: Immediate = {
 
 };
 
-pub Ident: Ident = IdentFromToken<"ident">;
+pub Ident: Ident = {
+    <l:@L> <id:"ident"> <r:@R> => Ident {
+        name: id.0.to_string(),
+        span: (context.span_from)(l, r),
+    }
+}
 
 IdentFromToken<Tok>: Ident = {
     <l:@L> <id:Tok> <r:@R> => Ident {
@@ -1088,12 +1182,13 @@ extern {
 
         "in" => lexer::Token::In,
 
-        "ident" => lexer::Token::Ident(<String>),
+        "ident" => lexer::Token::Ident(<(String, bool)>),
 
         "macro" => lexer::Token::Macro,
         "macro_name" => lexer::Token::MacroName(<String>),
         "macro_param" => lexer::Token::MacroParam(<String>),
-        "macro_body" => lexer::Token::MacroBody(<Vec<lexer::Token>>),
-        "macro_call_args" => lexer::Token::MacroCallArgs(<Vec<Vec<lexer::Token>>>),
+        "macro_param_pack" => lexer::Token::MacroParamPack(<String>),
+        "macro_body" => lexer::Token::MacroBody(<Vec<(usize, lexer::Token, usize)>>),
+        "macro_call_args" => lexer::Token::MacroCallArgs(<Vec<Vec<(usize, lexer::Token, usize)>>>),
     }
 }

--- a/yurtc/tests/basic_tests/arrays.yrt
+++ b/yurtc/tests/basic_tests/arrays.yrt
@@ -13,7 +13,7 @@ fn nums() -> int[4] {
 
 let one = nums()[1];
 
-// intermediate <<<<
+// intermediate <<<
 // let ::a: real[5];
 // let ::a1 = ::a[1];
 // enum ::Colour = Red | Green | Blue;

--- a/yurtc/tests/basic_tests/aust.yrt
+++ b/yurtc/tests/basic_tests/aust.yrt
@@ -24,7 +24,7 @@ constraint nsw != v;
 // We're just looking for a satisfying assignment of colours
 solve satisfy;
 
-// intermediate <<<<
+// intermediate <<<
 // var ::wa: ::Colour;
 // var ::nt: ::Colour;
 // var ::sa: ::Colour;

--- a/yurtc/tests/basic_tests/erc20.yrt
+++ b/yurtc/tests/basic_tests/erc20.yrt
@@ -18,7 +18,7 @@ contract MyToken(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48) implements IERC20, 
 
 solve satisfy;
 
-// intermediate <<<<
+// intermediate <<<
 // interface ::IERC20 { fn ::IERC20::totalSupply() -> int; fn ::IERC20::balanceOf(account: int) -> int; fn ::IERC20::allowance(owner: int, spender: int) -> int; }
 // interface ::Ownable { fn ::Ownable::owner() -> int; }
 // contract ::MyToken(917551056842671309452305380979543736893630245704) implements ::IERC20, ::Ownable { fn ::MyToken::custom_function() -> int; }

--- a/yurtc/tests/basic_tests/tiny.yrt
+++ b/yurtc/tests/basic_tests/tiny.yrt
@@ -1,7 +1,7 @@
 let a: int = 1;
 solve satisfy;
 
-// intermediate <<<<
+// intermediate <<<
 // var ::a: int;
 // constraint (::a == 1);
 // solve satisfy;

--- a/yurtc/tests/macros/macro_hygiene.yrt
+++ b/yurtc/tests/macros/macro_hygiene.yrt
@@ -1,0 +1,17 @@
+macro @foo($x) {
+    let a: int;
+    constraint a == $x;
+}
+
+@foo(11);
+@foo(22);
+
+solve satisfy;
+
+// intermediate <<<
+// var ::anon@0::a: int;
+// var ::anon@1::a: int;
+// constraint (::anon@0::a == 11);
+// constraint (::anon@1::a == 22);
+// solve satisfy;
+// >>>

--- a/yurtc/tests/macros/macro_recursion_error_mutual.yrt
+++ b/yurtc/tests/macros/macro_recursion_error_mutual.yrt
@@ -1,0 +1,14 @@
+// <disabled>
+macro @a($x) {
+    let z = @b($x);
+}
+
+macro @b($x) {
+    let z = @a($x);
+}
+
+solve satisfy;
+
+// parse_failure <<<
+// unbound recursion
+// >>>

--- a/yurtc/tests/macros/macro_recursion_error_self.yrt
+++ b/yurtc/tests/macros/macro_recursion_error_self.yrt
@@ -1,0 +1,12 @@
+// <disabled>
+macro @m($a) {
+    let x = @m(22);
+}
+
+@m(11);
+
+solve satisfy;
+
+// parse_failure <<<
+// unbound recursion
+// >>>

--- a/yurtc/tests/macros/macro_simple.yrt
+++ b/yurtc/tests/macros/macro_simple.yrt
@@ -1,0 +1,28 @@
+macro @a_macro($a, $0, $type) {
+    let $a: $type = $0;
+    let b: $type;
+    constraint b > $a;
+    b
+}
+
+constraint @a_macro(id; 1234; int) > 1;
+
+solve satisfy;
+
+// intermediate <<<
+// var ::id: int;
+// var ::anon@0::b: int;
+// constraint (::anon@0::b > 1);
+// constraint (::id == 1234);
+// constraint (::anon@0::b > ::id);
+// solve satisfy;
+// >>>
+
+// compiled_intent <<<
+// var ::id: int;
+// var ::anon@0::b: int;
+// constraint (::anon@0::b > 1);
+// constraint (::id == 1234);
+// constraint (::anon@0::b > ::id);
+// solve satisfy;
+// >>>

--- a/yurtc/tests/macros/macro_unknown_name.yrt
+++ b/yurtc/tests/macros/macro_unknown_name.yrt
@@ -1,0 +1,12 @@
+macro @useful($0) {
+    constraint a > $0;
+}
+
+@useless(11);
+
+solve satisfy;
+
+// parse_failure <<<
+// macro not found
+// @46..58: macro `::@useless` not found
+// >>>

--- a/yurtc/tests/macros/macro_unknown_param.yrt
+++ b/yurtc/tests/macros/macro_unknown_param.yrt
@@ -1,0 +1,12 @@
+macro @foo($a, $b) {
+    $a + $b + $c
+}
+
+@foo(11; 22);
+
+solve satisfy;
+
+// parse_failure <<<
+// undefined macro parameter
+// @35..37: undefined parameter `$c` in macro body
+// >>>

--- a/yurtc/tests/macros/macro_variadic_bad_num_args.yrt
+++ b/yurtc/tests/macros/macro_variadic_bad_num_args.yrt
@@ -1,0 +1,17 @@
+macro @m($a, $b) {
+    let z = $a + $b;
+}
+
+@m(1);
+@m(1; 2; 3);
+
+solve satisfy;
+
+// parse_failure <<<
+// unable to match macro call
+// @43..48: unable to match call to macro `::@m`
+// a macro named `::@m` is defined but not with the required signature to fulfill this call
+// unable to match macro call
+// @50..61: unable to match call to macro `::@m`
+// a macro named `::@m` is defined but not with the required signature to fulfill this call
+// >>>

--- a/yurtc/tests/macros/macro_variadic_chain.yrt
+++ b/yurtc/tests/macros/macro_variadic_chain.yrt
@@ -1,0 +1,40 @@
+// <no-solve>
+
+macro @chain($a, &rest) {
+    let $a: int;
+    @chain_next($a; &rest)
+}
+
+macro @chain_next($prev, $next, &rest) {
+    let $next: int;
+    constraint $next > $prev + 10;
+    @chain_next($next; &rest)
+}
+
+macro @chain_next($prev, $last) {
+    let $last: int;
+    constraint $last > $prev + 10;
+    $last
+}
+
+@chain(x; y; z);
+
+solve satisfy;
+
+// intermediate <<<
+// var ::x: int;
+// var ::y: int;
+// var ::z: int;
+// constraint (::y > (::x + 10));
+// constraint (::z > (::y + 10));
+// solve satisfy;
+// >>>
+
+// compiled_intent <<<
+// var ::x: int;
+// var ::y: int;
+// var ::z: int;
+// constraint (::y > (::x + 10));
+// constraint (::z > (::y + 10));
+// solve satisfy;
+// >>>

--- a/yurtc/tests/macros/macro_variadic_sig_clash.yrt
+++ b/yurtc/tests/macros/macro_variadic_sig_clash.yrt
@@ -1,0 +1,18 @@
+macro @m($a, $b) {
+    let z = $a + $b;
+}
+
+macro @m($x, $y) {
+    let a = $x + $y;
+}
+
+@m(1; 2);
+
+solve satisfy;
+
+// parse_failure <<<
+// macro ::@m is declared multiple times
+// @6..16: previous declaration of the macro `::@m` here
+// @49..59: `::@m` redeclared here with the same number of parameters
+// it is valid to have multiple macros named `::@m` but they must have differing parameter lists
+// >>>

--- a/yurtc/tests/macros/macro_variadic_sum.yrt
+++ b/yurtc/tests/macros/macro_variadic_sum.yrt
@@ -1,0 +1,29 @@
+macro @sum($x, &rest) {
+    @sum($x + &rest)
+}
+
+macro @sum($x) {
+    $x
+}
+
+
+let a: int = 4;
+let b: int = @sum(1; 2; 3; a);
+
+solve satisfy;
+
+// intermediate <<<
+// var ::a: int;
+// var ::b: int;
+// constraint (::a == 4);
+// constraint (::b == (((1 + 2) + 3) + ::a));
+// solve satisfy;
+// >>>
+
+// compiled_intent <<<
+// var ::a: int;
+// var ::b: int;
+// constraint (::a == 4);
+// constraint (::b == (((1 + 2) + 3) + ::a));
+// solve satisfy;
+// >>>

--- a/yurtc/tests/macros/macro_variadic_unaligned_pack.yrt
+++ b/yurtc/tests/macros/macro_variadic_unaligned_pack.yrt
@@ -1,0 +1,18 @@
+// <disabled>
+macro @m($a, $b, &rest) {
+    let a = $a + $b;
+    @m(&rest);
+}
+
+macro @m($a) {
+    $a
+}
+
+// @m() has no signature with only 2 params.  The param pack can never be empty.
+@m(1; 2; 3; 4);
+
+solve satisfy;
+
+// parse_failure <<<
+// pattern failure
+// >>>


### PR DESCRIPTION
This is still strictly a work in progress, but what I have has reached a size I'd like to merge before it starts getting unwieldy as a branch.

Simple macro expansion is working as is recursive variadic macro expansion, though it breaks if you push it too hard.  I've added some integration tests, two are still disabled and I have a list of functionality which still needs to go in, along with more tests.

In particular I'm pretty sure it's broken when used across different modules.  I.e., using a macro declared in a different module or even calling a macro from a non-root module will probably produce symbols with the wrong path.  This is what I'll focus on next.