### PR TITLE
Add detection of illegal recursive macros.

### DIFF
--- a/yurtc/src/intent/intermediate.rs
+++ b/yurtc/src/intent/intermediate.rs
@@ -156,13 +156,25 @@ impl IntermediateIntent {
     pub fn replace_exprs(&mut self, old_expr: ExprKey, new_expr: ExprKey) {
         self.exprs
             .iter_mut()
-            .for_each(|(_, expr)| expr.replace_one_to_one(old_expr, new_expr))
+            .for_each(|(_, expr)| expr.replace_one_to_one(old_expr, new_expr));
+
+        self.constraints.iter_mut().for_each(|(expr, _)| {
+            if *expr == old_expr {
+                *expr = new_expr
+            }
+        });
     }
 
     pub fn replace_exprs_by_map(&mut self, expr_map: &HashMap<ExprKey, ExprKey>) {
         self.exprs
             .iter_mut()
-            .for_each(|(_, expr)| expr.replace_ref_by_map(expr_map))
+            .for_each(|(_, expr)| expr.replace_ref_by_map(expr_map));
+
+        self.constraints.iter_mut().for_each(|(expr, _)| {
+            if let Some(new_expr) = expr_map.get(expr) {
+                *expr = *new_expr;
+            }
+        });
     }
 }
 

--- a/yurtc/src/parser.rs
+++ b/yurtc/src/parser.rs
@@ -3,7 +3,7 @@ use crate::{
     expr::Ident,
     intent::intermediate::{CallKey, ExprKey, IntermediateIntent},
     lexer,
-    macros::{self, MacroCall, MacroDecl},
+    macros::{self, MacroCall, MacroDecl, MacroExpander},
     span::{self, Span},
 };
 
@@ -81,6 +81,7 @@ impl ProjectParser {
     /// failure, return a vector of all compile errors encountered.
     fn parse_project(mut self) -> Self {
         let mut call_replacements = Vec::<(ExprKey, ExprKey)>::new();
+        let mut macro_expander = MacroExpander::default();
         let mut pending_paths = vec![(self.root_src_path.clone(), Vec::new())];
 
         // This is an unbound loop which breaks if there are errors or when there is no more work
@@ -119,7 +120,7 @@ impl ProjectParser {
                     .remove(call_key)
                     .expect("Call key must be valid.");
 
-                match macros::expand_call(&self.macros, &call) {
+                match macro_expander.expand_call(&self.macros, &call) {
                     Ok(tokens) => {
                         let (body_expr, next_paths) =
                             self.parse_macro_body(tokens, &call.span.context, &call.mod_path);

--- a/yurtc/src/yurt_parser.lalrpop
+++ b/yurtc/src/yurt_parser.lalrpop
@@ -826,7 +826,7 @@ CondExpr: ExprKey = {
 };
 
 MacroCallExpr: ExprKey = {
-    <l:@L> <name:MacroPath> <args:"macro_call_args"> <r:@L> => {
+    <l:@L> <name:MacroPath> <tag:"macro_tag"?> <args:"macro_call_args"> <r:@L> => {
         let call_key = context.ii.calls.insert(name.clone());
         let span = (context.span_from)(l, r);
         let call_data = MacroCall {
@@ -834,6 +834,7 @@ MacroCallExpr: ExprKey = {
             mod_path: context.mod_path.to_vec(),
             args,
             span: span.clone(),
+            tag: tag.flatten(),
         };
         let call_expr_key = context.ii.exprs.insert(Expr::MacroCall {
             call: call_key,
@@ -1190,5 +1191,6 @@ extern {
         "macro_param_pack" => lexer::Token::MacroParamPack(<String>),
         "macro_body" => lexer::Token::MacroBody(<Vec<(usize, lexer::Token, usize)>>),
         "macro_call_args" => lexer::Token::MacroCallArgs(<Vec<Vec<(usize, lexer::Token, usize)>>>),
+        "macro_tag" => lexer::Token::MacroTag(<Option<u64>>),
     }
 }

--- a/yurtc/tests/macros/macro_recursion_but_isnt.yrt
+++ b/yurtc/tests/macros/macro_recursion_but_isnt.yrt
@@ -1,0 +1,38 @@
+macro @a($x) {
+    @c($x)
+}
+
+macro @b($y) {
+    @c($y)
+}
+
+macro @c($z) {
+    $z == 0
+}
+
+let v: int;
+
+constraint @a(v);
+constraint @b(v);
+constraint @a(v);
+constraint @b(v);
+
+solve satisfy;
+
+// intermediate <<<
+// var ::v: int;
+// constraint (::v == 0);
+// constraint (::v == 0);
+// constraint (::v == 0);
+// constraint (::v == 0);
+// solve satisfy;
+// >>>
+
+// compiled_intent <<<
+// var ::v: int;
+// constraint (::v == 0);
+// constraint (::v == 0);
+// constraint (::v == 0);
+// constraint (::v == 0);
+// solve satisfy;
+// >>>

--- a/yurtc/tests/macros/macro_recursion_error_mutual.yrt
+++ b/yurtc/tests/macros/macro_recursion_error_mutual.yrt
@@ -1,14 +1,22 @@
-// <disabled>
 macro @a($x) {
     let z = @b($x);
 }
 
 macro @b($x) {
+    let z = @c($x);
+}
+
+macro @c($x) {
     let z = @a($x);
 }
+
+@a(11);
 
 solve satisfy;
 
 // parse_failure <<<
-// unbound recursion
+// macro call is recursive
+// @103..109: macro '::@a' is recursively called
+// @6..12: macro '::@a' declared here
+// a macro called recursively with the same number of arguments will cause a non-terminating loop during expansion
 // >>>

--- a/yurtc/tests/macros/macro_recursion_error_self.yrt
+++ b/yurtc/tests/macros/macro_recursion_error_self.yrt
@@ -1,4 +1,3 @@
-// <disabled>
 macro @m($a) {
     let x = @m(22);
 }
@@ -8,5 +7,8 @@ macro @m($a) {
 solve satisfy;
 
 // parse_failure <<<
-// unbound recursion
+// macro call is recursive
+// @27..33: macro '::@m' is recursively called
+// @6..12: macro '::@m' declared here
+// a macro called recursively with the same number of arguments will cause a non-terminating loop during expansion
 // >>>


### PR DESCRIPTION
Since macro expansion isn't strictly making calls it isn't as straight forward to detect illegal (i.e., non-terminating) recursion as it is for function calls.

I've added hidden unique tags to calls within macro bodies which can be tracked during expansion to see if a macro has been used with the exact same number of args within the same expansion.  Merely checking if a macro has been used identically multiple times isn't enough as they may originate from different root calls and not actually be recursive.