### PR TITLE
Spec and implement `forall`

### DIFF
--- a/docs/book/theme/yurt.js
+++ b/docs/book/theme/yurt.js
@@ -2,7 +2,7 @@ hljs.registerLanguage("yurt", (hljs) => ({
   name: "Yurt",
   keywords: {
     keyword:
-      "as bool cond constraint contract else enum extern fn if implements in interface int let macro maximize minimize real satisfy solve state string type use",
+      "as bool cond constraint contract else enum extern forall fn if implements in interface int let macro maximize minimize real satisfy solve state string type use where",
     literal: "false true",
   },
   contains: [

--- a/docs/specs/src/SUMMARY.md
+++ b/docs/specs/src/SUMMARY.md
@@ -38,6 +38,7 @@
       - [Arrays and Array Accesses](yurt/expressions/atoms/arrays.md)
       - [Ranges](yurt/expressions/atoms/ranges.md)
       - [Conditionals](yurt/expressions/atoms/conditionals.md)
+      - [Generators](yurt/expressions/atoms/generators.md)
       - [Casts](yurt/expressions/atoms/casts.md)
       - [Calls](yurt/expressions/atoms/calls.md)
       - ["In" Expressions](yurt/expressions/atoms/in.md)

--- a/docs/specs/src/yurt/expressions.md
+++ b/docs/specs/src/yurt/expressions.md
@@ -19,6 +19,7 @@ Expressions represent values and have the following syntax:
          | <range-expr>
          | <if-expr>
          | <cond-expr>
+         | <forall-expr>
          | <call-expr>
          | <cast-expr>
          | <in-expr>

--- a/docs/specs/src/yurt/expressions/atoms/generators.md
+++ b/docs/specs/src/yurt/expressions/atoms/generators.md
@@ -1,0 +1,34 @@
+#### Generator Expressions
+
+Generator expressions are used to reduce verbosity and improve readability of a Yurt program. The most common generator expression is `forall` which has the following syntax:
+
+```bnf
+<forall-expr> ::= "forall" <ident> "in" <range-expr> ( "," <ident> "in" <range-expr> )*
+                 [ "where" <expr> ( "," <expr> )* ]
+                 "{" <expr> "}"
+```
+
+The rule `<ident> "in" <range-expr>` effectively declares a new integer index named `<ident>` that belongs to the range `<range-expr>`. This index can only be used in the body of the `forall` expression.
+
+The `where` clause restricts the declared indices using the Boolean expressions that follow it.
+
+A `forall` expression is equivalent to the conjunction of all the possible instances of its body, given its ranges and conditions.
+
+For example, the following `forall` expression:
+
+```yurt
+forall i in 0..3, j in 0..3 where i <= j {
+    a[i] != b[j]
+}
+```
+
+is equivalent to the following:
+
+```yurt
+   a[0] != b[0]
+&& a[0] != b[1]
+&& a[0] != b[2]
+&& a[1] != b[1]
+&& a[1] != b[2]
+&& a[2] != b[2]
+```

--- a/docs/specs/theme/yurt.js
+++ b/docs/specs/theme/yurt.js
@@ -2,7 +2,7 @@ hljs.registerLanguage("yurt", (hljs) => ({
   name: "Yurt",
   keywords: {
     keyword:
-      "as bool cond constraint contract else enum extern fn if implements in interface int let macro maximize minimize real satisfy solve state string type use",
+      "as bool cond constraint contract else enum extern forall fn if implements in interface int let macro maximize minimize real satisfy solve state string type use where",
     literal: "false true",
   },
   contains: [

--- a/yurtc/src/expr/display.rs
+++ b/yurtc/src/expr/display.rs
@@ -116,6 +116,23 @@ impl DisplayWithII for &super::Expr {
             super::Expr::Range { lb, ub, .. } => {
                 write!(f, "{}..{}", ii.with_ii(lb), ii.with_ii(ub))
             }
+
+            super::Expr::ForAll {
+                gen_ranges,
+                body,
+                conditions,
+                ..
+            } => {
+                write!(f, "forall")?;
+                for (ident, range) in gen_ranges {
+                    write!(f, " {} in {},", ident, ii.with_ii(range))?;
+                }
+                if !conditions.is_empty() {
+                    write!(f, " where ")?;
+                    write_many_with_ii!(f, conditions, ", ", ii);
+                }
+                write!(f, " {{ {} }}", ii.with_ii(body))
+            }
         }
     }
 }

--- a/yurtc/src/expr/evaluate.rs
+++ b/yurtc/src/expr/evaluate.rs
@@ -1,0 +1,338 @@
+use crate::{
+    error::CompileError,
+    expr::{BinaryOp, Expr, Immediate, UnaryOp},
+    intent::intermediate::{ExprKey, IntermediateIntent},
+    span::empty_span,
+    types::Path,
+};
+use std::collections::HashMap;
+
+impl Expr {
+    /// Given an expression `self`, an `IntermediateIntent`, and a map between symbols and their
+    /// values as `Immediate`s, evaluate `self` into an `Immediate`
+    ///
+    /// This is pretty basic for now and will fail for anything other than `Immediate`,
+    /// `PathByName`, `UnaryOp`, `BinaryOp`.
+    pub(crate) fn evaluate(
+        &self,
+        ii: &IntermediateIntent,
+        values_map: &HashMap<Path, Immediate>,
+    ) -> Result<Immediate, CompileError> {
+        use BinaryOp::*;
+        use Immediate::*;
+        use UnaryOp::*;
+        match self {
+            Expr::Immediate { value: imm, .. } => Ok(imm.clone()),
+            Expr::PathByName(path, span) => {
+                values_map
+                    .get(path)
+                    .cloned()
+                    .ok_or_else(|| CompileError::SymbolNotFound {
+                        name: path.to_string(),
+                        span: span.clone(),
+                    })
+            }
+            Expr::UnaryOp { op, expr, .. } => {
+                let expr = ii
+                    .exprs
+                    .get(*expr)
+                    .expect("guaranteed by parser")
+                    .evaluate(ii, values_map)?;
+
+                match (expr, op) {
+                    (Real(expr), Neg) => Ok(Real(-expr)),
+                    (Int(expr), Neg) => Ok(Int(-expr)),
+                    (Bool(expr), Not) => Ok(Bool(!expr)),
+                    _ => Err(CompileError::Internal {
+                        msg: "type error: invalid unary op for expression",
+                        span: empty_span(),
+                    }),
+                }
+            }
+            Expr::BinaryOp { op, lhs, rhs, .. } => {
+                let lhs = ii
+                    .exprs
+                    .get(*lhs)
+                    .expect("guaranteed by parser")
+                    .evaluate(ii, values_map)?;
+
+                let rhs = ii
+                    .exprs
+                    .get(*rhs)
+                    .expect("guaranteed by parser")
+                    .evaluate(ii, values_map)?;
+
+                match (lhs, rhs) {
+                    (Real(lhs), Real(rhs)) => match op {
+                        // Arithmetic
+                        Add => Ok(Real(lhs + rhs)),
+                        Sub => Ok(Real(lhs - rhs)),
+                        Mul => Ok(Real(lhs * rhs)),
+                        Div => Ok(Real(lhs / rhs)),
+
+                        // Comparison
+                        Equal => Ok(Bool(lhs == rhs)),
+                        NotEqual => Ok(Bool(lhs != rhs)),
+                        LessThan => Ok(Bool(lhs < rhs)),
+                        LessThanOrEqual => Ok(Bool(lhs <= rhs)),
+                        GreaterThan => Ok(Bool(lhs > rhs)),
+                        GreaterThanOrEqual => Ok(Bool(lhs >= rhs)),
+
+                        _ => Err(CompileError::Internal {
+                            msg: "type error: invalid binary op for reals",
+                            span: empty_span(),
+                        }),
+                    },
+                    (Int(lhs), Int(rhs)) => match op {
+                        // Arithmetic
+                        Add => Ok(Int(lhs + rhs)),
+                        Sub => Ok(Int(lhs - rhs)),
+                        Mul => Ok(Int(lhs * rhs)),
+                        Div => Ok(Int(lhs / rhs)),
+                        Mod => Ok(Int(lhs % rhs)),
+
+                        // Comparison
+                        Equal => Ok(Bool(lhs == rhs)),
+                        NotEqual => Ok(Bool(lhs != rhs)),
+                        LessThan => Ok(Bool(lhs < rhs)),
+                        LessThanOrEqual => Ok(Bool(lhs <= rhs)),
+                        GreaterThan => Ok(Bool(lhs > rhs)),
+                        GreaterThanOrEqual => Ok(Bool(lhs >= rhs)),
+
+                        _ => Err(CompileError::Internal {
+                            msg: "type error: invalid binary op for ints",
+                            span: empty_span(),
+                        }),
+                    },
+                    (Bool(lhs), Bool(rhs)) => match op {
+                        // Comparison
+                        Equal => Ok(Bool(lhs == rhs)),
+                        NotEqual => Ok(Bool(lhs != rhs)),
+                        LessThan => Ok(Bool(!lhs && rhs)),
+                        LessThanOrEqual => Ok(Bool(lhs <= rhs)),
+                        GreaterThan => Ok(Bool(lhs && !rhs)),
+                        GreaterThanOrEqual => Ok(Bool(lhs >= rhs)),
+
+                        // Logical
+                        LogicalAnd => Ok(Bool(lhs && rhs)),
+                        LogicalOr => Ok(Bool(lhs || rhs)),
+
+                        _ => Err(CompileError::Internal {
+                            msg: "type error: invalid binary op for bools",
+                            span: empty_span(),
+                        }),
+                    },
+                    _ => Err(CompileError::Internal {
+                        msg: "compile-time evaluation for \"big ints\" and \"strings\" \
+                              not currently supported",
+                        span: empty_span(),
+                    }),
+                }
+            }
+            _ => Err(CompileError::Internal {
+                msg: "unexpected expression during compile-time evaluation",
+                span: empty_span(),
+            }),
+        }
+    }
+}
+
+impl ExprKey {
+    /// Given an `ExprKey` `self`, an `IntermediateIntent`, and a map between some symbols and
+    /// their values as `Immediate`s, create a deep clone of `self` (i.e. clone the `Expr` it
+    /// points to and all of its sub-expressions) while replacing each symbol by its immediate
+    /// value as per `values_map`.
+    ///
+    /// Note: not every symbol needs to be replaced.
+    ///
+    /// For example, if `self` points to the following expression:
+    ///
+    ///
+    /// ```yurt
+    /// i + j > k
+    /// ```
+    ///
+    /// and if `values_map` looks like: `i -> 5, j -> 9`, then `plug_in` creates the following new
+    /// expression:
+    ///
+    /// ```yurt
+    /// 5 + 9 > k
+    /// ```
+    ///
+    /// and inserts it (and its sub-expressions) into `ii.exprs`.
+    pub(crate) fn plug_in(
+        self,
+        ii: &mut IntermediateIntent,
+        values_map: &HashMap<Path, Immediate>,
+    ) -> ExprKey {
+        let expr = ii
+            .exprs
+            .get(self)
+            .expect("expr key must belong to ii.expr")
+            .clone();
+
+        match expr {
+            Expr::Immediate { .. } | Expr::MacroCall { .. } | Expr::Error(_) => self,
+            Expr::PathByName(path, span) => values_map.get(&path).map_or(self, |value| {
+                ii.exprs.insert(Expr::Immediate {
+                    value: value.clone(),
+                    span,
+                })
+            }),
+            Expr::PathByKey(key, span) => {
+                values_map.get(&ii.vars[key].name).map_or(self, |value| {
+                    ii.exprs.insert(Expr::Immediate {
+                        value: value.clone(),
+                        span,
+                    })
+                })
+            }
+            Expr::UnaryOp { op, expr, span } => {
+                let expr = expr.plug_in(ii, values_map);
+
+                ii.exprs.insert(Expr::UnaryOp {
+                    op,
+                    expr,
+                    span: span.clone(),
+                })
+            }
+            Expr::BinaryOp { op, lhs, rhs, span } => {
+                let lhs = lhs.plug_in(ii, values_map);
+                let rhs = rhs.plug_in(ii, values_map);
+
+                ii.exprs.insert(Expr::BinaryOp {
+                    op,
+                    lhs,
+                    rhs,
+                    span: span.clone(),
+                })
+            }
+            Expr::FnCall { name, args, span } => {
+                let args = args
+                    .iter()
+                    .map(|arg| arg.plug_in(ii, values_map))
+                    .collect::<Vec<_>>();
+
+                ii.exprs.insert(Expr::FnCall {
+                    name,
+                    args,
+                    span: span.clone(),
+                })
+            }
+            Expr::If {
+                condition,
+                then_block,
+                else_block,
+                span,
+            } => {
+                let condition = condition.plug_in(ii, values_map);
+                let then_block = then_block.plug_in(ii, values_map);
+                let else_block = else_block.plug_in(ii, values_map);
+
+                ii.exprs.insert(Expr::If {
+                    condition,
+                    then_block,
+                    else_block,
+                    span: span.clone(),
+                })
+            }
+            Expr::Array { elements, span } => {
+                let elements = elements
+                    .iter()
+                    .map(|element| element.plug_in(ii, values_map))
+                    .collect::<Vec<_>>();
+
+                ii.exprs.insert(Expr::Array {
+                    elements,
+                    span: span.clone(),
+                })
+            }
+            Expr::ArrayElementAccess { array, index, span } => {
+                let array = array.plug_in(ii, values_map);
+                let index = index.plug_in(ii, values_map);
+
+                ii.exprs.insert(Expr::ArrayElementAccess {
+                    array,
+                    index,
+                    span: span.clone(),
+                })
+            }
+            Expr::Tuple { fields, span } => {
+                let fields = fields
+                    .iter()
+                    .map(|(name, value)| (name.clone(), value.plug_in(ii, values_map)))
+                    .collect::<Vec<_>>();
+
+                ii.exprs.insert(Expr::Tuple {
+                    fields,
+                    span: span.clone(),
+                })
+            }
+            Expr::TupleFieldAccess { tuple, field, span } => {
+                let tuple = tuple.plug_in(ii, values_map);
+
+                ii.exprs.insert(Expr::TupleFieldAccess {
+                    tuple,
+                    field,
+                    span: span.clone(),
+                })
+            }
+            Expr::Cast { value, ty, span } => {
+                let value = value.plug_in(ii, values_map);
+
+                ii.exprs.insert(Expr::Cast {
+                    value,
+                    ty,
+                    span: span.clone(),
+                })
+            }
+            Expr::In {
+                value,
+                collection,
+                span,
+            } => {
+                let value = value.plug_in(ii, values_map);
+                let collection = collection.plug_in(ii, values_map);
+
+                ii.exprs.insert(Expr::In {
+                    value,
+                    collection,
+                    span: span.clone(),
+                })
+            }
+            Expr::Range { lb, ub, span } => {
+                let lb = lb.plug_in(ii, values_map);
+                let ub = ub.plug_in(ii, values_map);
+
+                ii.exprs.insert(Expr::Range {
+                    lb,
+                    ub,
+                    span: span.clone(),
+                })
+            }
+            Expr::ForAll {
+                gen_ranges,
+                conditions,
+                body,
+                span,
+            } => {
+                let gen_ranges = gen_ranges
+                    .iter()
+                    .map(|(index, range)| (index.clone(), range.plug_in(ii, values_map)))
+                    .collect::<Vec<_>>();
+                let conditions = conditions
+                    .iter()
+                    .map(|condition| condition.plug_in(ii, values_map))
+                    .collect::<Vec<_>>();
+                let body = body.plug_in(ii, values_map);
+
+                ii.exprs.insert(Expr::ForAll {
+                    gen_ranges,
+                    conditions,
+                    body,
+                    span: span.clone(),
+                })
+            }
+        }
+    }
+}

--- a/yurtc/src/intent/intermediate.rs
+++ b/yurtc/src/intent/intermediate.rs
@@ -13,6 +13,7 @@ use std::{
 
 mod compile;
 mod display;
+mod transform;
 
 type Result<T> = std::result::Result<T, CompileError>;
 
@@ -44,8 +45,12 @@ pub struct IntermediateIntent {
 }
 
 impl IntermediateIntent {
-    pub fn compile(self) -> Result<Intent> {
-        compile::compile(&self)
+    pub fn compile(&mut self) -> Result<Intent> {
+        compile::compile(self)
+    }
+
+    pub fn flatten(self) -> Result<IntermediateIntent> {
+        compile::flatten(self)
     }
 
     /// Helps out some `thing: T` by adding `self` as context.
@@ -160,7 +165,7 @@ impl IntermediateIntent {
 
         self.constraints.iter_mut().for_each(|(expr, _)| {
             if *expr == old_expr {
-                *expr = new_expr
+                *expr = new_expr;
             }
         });
     }
@@ -179,7 +184,7 @@ impl IntermediateIntent {
 }
 
 /// A state specification with an optional type.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct State {
     name: Path,
     ty: Option<Type>,

--- a/yurtc/src/intent/intermediate/transform.rs
+++ b/yurtc/src/intent/intermediate/transform.rs
@@ -1,0 +1,3 @@
+mod unroll;
+
+pub(crate) use unroll::unroll_foralls;

--- a/yurtc/src/intent/intermediate/transform/unroll.rs
+++ b/yurtc/src/intent/intermediate/transform/unroll.rs
@@ -1,0 +1,191 @@
+use crate::{
+    error::CompileError,
+    expr::{BinaryOp, Ident, Immediate},
+    intent::{
+        intermediate::{Expr, ExprKey},
+        IntermediateIntent,
+    },
+    span::{empty_span, Span, Spanned},
+};
+use itertools::Itertools;
+use std::collections::{HashMap, HashSet};
+
+/// Given an `IntermediateIntent`, a list of indices with their ranges `gen_ranges`, an optional list of
+/// `conditions`, and a `forall` body, return a new expression that is the AND of all the possible
+/// valid `forall` bodies.
+///
+/// For example,
+/// ```yurt
+/// forall i in 0..3, j in 0..3 where i <= j { a[i] != b[j] }
+/// ```
+///
+/// becomes
+///
+/// ```yurt
+///    a[0] != b[0]
+/// && a[0] != b[1]
+/// && a[0] != a[2]
+/// && a[1] != b[1]
+/// && a[1] != b[2]
+/// && a[2] != b[2]
+/// ```
+fn unroll_forall(
+    ii: &mut IntermediateIntent,
+    gen_ranges: &Vec<(Ident, ExprKey)>,
+    conditions: &Vec<ExprKey>,
+    body: ExprKey,
+    span: &Span,
+) -> Result<Expr, CompileError> {
+    // Sanity check
+    let mut indices = HashSet::new();
+    for range in gen_ranges {
+        if !indices.insert(&range.0.name) {
+            // The name is already in the HashSet, indicating a duplicate
+            // Find the first occurance of the index
+            let first_occurance = gen_ranges
+                .iter()
+                .find(|range_j| range.0.name == range_j.0.name)
+                .expect("Index guaranteed to be in gen_ranges");
+
+            // Error out
+            return Err(CompileError::DuplicateForAllIndex {
+                name: range.0.name.clone(),
+                span: range.0.span.clone(),
+                prev_span: first_occurance.0.span.clone(),
+            });
+        }
+    }
+
+    // Compute the Cartesian product of all the ranges
+    let product_of_ranges = (0..gen_ranges.len())
+        .map(|i| {
+            match ii.exprs.get(gen_ranges[i].1).expect("guaranteed by parser") {
+                Expr::Range { lb, ub, .. } => {
+                    let lb = ii.exprs.get(*lb).expect("guaranteed by parser");
+                    let ub = ii.exprs.get(*ub).expect("guaranteed by parser");
+                    match (lb, ub) {
+                        // Only support integer literals as bounds, for now
+                        (
+                            Expr::Immediate {
+                                value: Immediate::Int(lb),
+                                ..
+                            },
+                            Expr::Immediate {
+                                value: Immediate::Int(ub),
+                                ..
+                            },
+                        ) => Ok(*lb..=*ub),
+                        _ if !matches!(
+                            lb,
+                            Expr::Immediate {
+                                value: Immediate::Int(_),
+                                ..
+                            }
+                        ) =>
+                        {
+                            // Bad lower bound
+                            Err(CompileError::InvalidForAllIndexBound {
+                                name: gen_ranges[i].0.name.clone(),
+                                span: lb.span().clone(),
+                            })
+                        }
+                        _ => {
+                            // Bad upper bound
+                            Err(CompileError::InvalidForAllIndexBound {
+                                name: gen_ranges[i].0.name.clone(),
+                                span: ub.span().clone(),
+                            })
+                        }
+                    }
+                }
+                _ => panic!("guaranteed by the parser"),
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .multi_cartesian_product();
+
+    // Collect the names of all the indices
+    let indices = gen_ranges
+        .iter()
+        .map(|(index, _)| index.clone())
+        .collect::<Vec<_>>();
+
+    // Generate a new expression that is the AND of all the unrolled expressions. Consider the
+    // following:
+    // 1. All possible combinations of the indices given `gen_ranges`: this is tracked in
+    //    `product_of_ranges`.
+    // 2. All the conditions which restrict the possible index combinations.
+
+    // Base value = `true`
+    let mut unrolled = Expr::Immediate {
+        value: Immediate::Bool(true),
+        span: span.clone(),
+    };
+
+    for values in product_of_ranges {
+        // Build a map from indicies to their concrete values
+        let values_map = indices
+            .iter()
+            .zip(values.iter())
+            .map(|(index, int_index)| ("::".to_owned() + &index.name, Immediate::Int(*int_index)))
+            .collect::<HashMap<_, _>>();
+
+        // Check each condition, if available, against the values map above
+        let mut satisfied = true;
+        for condition in conditions {
+            match ii
+                .exprs
+                .get(*condition)
+                .expect("guaranteed by parser")
+                .evaluate(ii, &values_map)?
+            {
+                Immediate::Bool(false) => {
+                    satisfied = false;
+                    break;
+                }
+                Immediate::Bool(true) => {}
+                _ => {
+                    return Err(CompileError::Internal {
+                        msg: "type error: boolean expression expected",
+                        span: empty_span(),
+                    })
+                }
+            }
+        }
+
+        // If all conditions are satisifed (or if none are present), then update the resulting
+        // expression by ANDing it with the newly unrolled `forall` body.
+        if satisfied {
+            unrolled = Expr::BinaryOp {
+                op: BinaryOp::LogicalAnd,
+                lhs: ii.exprs.insert(unrolled.clone()),
+                rhs: body.plug_in(ii, &values_map),
+                span: span.clone(),
+            };
+        }
+    }
+
+    Ok(unrolled)
+}
+
+/// Given an `IntermediateIntent`, unroll all `forall` expressions and replace them in the
+/// expressions map with their unrolled version
+pub(crate) fn unroll_foralls(ii: &mut IntermediateIntent) -> Result<(), CompileError> {
+    for (key, expr) in ii.exprs.clone() {
+        if let Expr::ForAll {
+            gen_ranges,
+            conditions,
+            body,
+            span,
+        } = expr
+        {
+            let unrolled = unroll_forall(ii, &gen_ranges, &conditions, body, &span)?;
+            *ii.exprs
+                .get_mut(key)
+                .expect("key guaranteed to exist in the map!") = unrolled;
+        }
+    }
+
+    Ok(())
+}

--- a/yurtc/src/lexer.rs
+++ b/yurtc/src/lexer.rs
@@ -146,6 +146,12 @@ pub enum Token {
     #[token("in")]
     In,
 
+    // Generators
+    #[token("forall")]
+    ForAll,
+    #[token("where")]
+    Where,
+
     // Ident has a flag indicating whether it's in a macro argument.  Is generally false.
     #[regex(r"[A-Za-z_][A-Za-z_0-9]*", |lex| {(lex.slice().to_string(), false)})]
     Ident((String, bool)),
@@ -176,6 +182,7 @@ pub(super) static KEYWORDS: &[Token] = &[
     Token::True,
     Token::False,
     Token::String,
+    Token::ForAll,
     Token::Fn,
     Token::If,
     Token::Else,
@@ -183,6 +190,7 @@ pub(super) static KEYWORDS: &[Token] = &[
     Token::Let,
     Token::State,
     Token::Constraint,
+    Token::Macro,
     Token::Maximize,
     Token::Minimize,
     Token::Solve,
@@ -197,6 +205,7 @@ pub(super) static KEYWORDS: &[Token] = &[
     Token::Extern,
     Token::In,
     Token::Type,
+    Token::Where,
 ];
 
 impl fmt::Display for Token {
@@ -291,6 +300,8 @@ impl fmt::Display for Token {
             Token::Implements => write!(f, "implements"),
             Token::Extern => write!(f, "extern"),
             Token::In => write!(f, "in"),
+            Token::ForAll => write!(f, "forall"),
+            Token::Where => write!(f, "where"),
             Token::Ident((ident, _)) => write!(f, "{ident}"),
             Token::RealLiteral(ident) => write!(f, "{ident}"),
             Token::IntLiteral(ident) => write!(f, "{ident}"),

--- a/yurtc/src/lexer/tests.rs
+++ b/yurtc/src/lexer/tests.rs
@@ -234,6 +234,12 @@ fn blockchain_items() {
 }
 
 #[test]
+fn forall() {
+    assert_eq!(lex_one_success("forall"), Token::ForAll);
+    assert_eq!(lex_one_success("where"), Token::Where);
+}
+
+#[test]
 fn with_error() {
     let src = r#"
 let low_val: int = 5.0;

--- a/yurtc/src/main.rs
+++ b/yurtc/src/main.rs
@@ -22,10 +22,22 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // Compile the intermediate intent down to a final intent
-    let intent = match intermediate_intent.compile() {
+    // Flatten the intermediate intent
+    let mut flattened = match intermediate_intent.flatten() {
+        Ok(flattened) => flattened,
+        Err(error) => {
+            if !cfg!(test) {
+                error::print_errors(&vec![error::Error::Compile { error }]);
+            }
+            yurtc::yurtc_bail!(1, filepath)
+        }
+    };
+
+    // Compile the flattened intent down to a final intent
+    let intent = match flattened.compile() {
         Ok(intent) => intent,
         Err(error) => {
+            eprintln!("{flattened}");
             if !cfg!(test) {
                 error::print_errors(&vec![error::Error::Compile { error }]);
             }

--- a/yurtc/src/parser.rs
+++ b/yurtc/src/parser.rs
@@ -94,10 +94,10 @@ impl ProjectParser {
                 }
 
                 // Store this path as parsed to avoid re-parsing later.
-                self.visited_paths.push(src_path.to_path_buf());
+                self.visited_paths.push(src_path.clone());
 
                 // Parse this file module, returning any paths to other potential modules.
-                let (_, next_paths) = self.parse_module(&Rc::from(src_path), &mod_path);
+                let ((), next_paths) = self.parse_module(&Rc::from(src_path), &mod_path);
                 self.analyse_and_add_paths(&mod_path, &next_paths, &mut pending_paths);
             }
 

--- a/yurtc/src/parser/tests.rs
+++ b/yurtc/src/parser/tests.rs
@@ -715,8 +715,8 @@ fn parens_exprs() {
     check(
         &run_parser!(expr, "()"),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`, found `)`
-            @1..2: expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`, found `)`
+            @1..2: expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`
         "#]],
     );
 
@@ -836,8 +836,8 @@ fn ranges() {
     check(
         &run_parser!(range, "1...2"),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`, found `.`
-            @3..4: expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`, found `.`
+            @3..4: expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`
         "#]],
     );
 
@@ -1166,8 +1166,8 @@ fn code_blocks() {
     check(
         &run_parser!(expr, "{ constraint x == 0; }", mod_path),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `constraint`, `false`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`, found `}`
-            @21..22: expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `constraint`, `false`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `constraint`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`, found `}`
+            @21..22: expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `constraint`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`
         "#]],
     );
 
@@ -1175,8 +1175,8 @@ fn code_blocks() {
     check(
         &run_parser!(expr, "{ let x = 0; 5 }", mod_path),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `constraint`, `false`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, `{`, or `}`, found `let`
-            @2..5: expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `constraint`, `false`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, `{`, or `}`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `constraint`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, `{`, or `}`, found `let`
+            @2..5: expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `constraint`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, `{`, or `}`
         "#]],
     );
 
@@ -1566,8 +1566,8 @@ fn cond_exprs() {
     check(
         &run_parser!(expr, r#"cond { a => b, }"#),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `else`, `false`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`, found `}`
-            @15..16: expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `else`, `false`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `else`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`, found `}`
+            @15..16: expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `else`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`
         "#]],
     );
 
@@ -1643,8 +1643,59 @@ fn in_expr() {
     check(
         &run_parser!(yp::LetDeclParser::new(), r#"let x = 5 in"#),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`, found `end of file`
-            @12..12: expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`, found `end of file`
+            @12..12: expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`
+        "#]],
+    );
+}
+
+#[test]
+fn forall_expr() {
+    let expr = yp::ExprParser::new();
+    check(
+        &run_parser!(expr, r#"forall i in 0..3 { true }"#),
+        expect_test::expect!["forall i in 0..3, { true }"],
+    );
+
+    check(
+        &run_parser!(expr, r#"forall i in 0..3, j in i..k { true }"#),
+        expect_test::expect!["forall i in 0..3, j in ::i..::k, { true }"],
+    );
+
+    check(
+        &run_parser!(expr, r#"forall i in 0..3 where i > 4 { true }"#),
+        expect_test::expect!["forall i in 0..3, where (::i > 4) { true }"],
+    );
+
+    check(
+        &run_parser!(
+            expr,
+            r#"forall i in 0..3, j in 0..3 where i > 2, j < 3, i != j && true { A[i] > A[j] }"#
+        ),
+        expect_test::expect!["forall i in 0..3, j in 0..3, where (::i > 2), (::j < 3), ((::i != ::j) && true) { (::A[::i] > ::A[::j]) }"],
+    );
+
+    check(
+        &run_parser!(expr, r#"forall { true }"#),
+        expect_test::expect![[r#"
+            expected `ident`, found `{`
+            @7..8: expected `ident`
+        "#]],
+    );
+
+    check(
+        &run_parser!(expr, r#"forall range { true }"#),
+        expect_test::expect![[r#"
+            expected `in`, found `{`
+            @13..14: expected `in`
+        "#]],
+    );
+
+    check(
+        &run_parser!(expr, r#"forall i in 0..3 { constraint x; true }"#),
+        expect_test::expect![[r#"
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`, found `constraint`
+            @19..29: expected `!`, `(`, `+`, `-`, `::`, `[`, `cond`, `false`, `forall`, `ident`, `if`, `int_lit`, `macro_name`, `real_lit`, `str_lit`, `true`, or `{`
         "#]],
     );
 }

--- a/yurtc/src/yurt_parser.lalrpop
+++ b/yurtc/src/yurt_parser.lalrpop
@@ -776,6 +776,7 @@ TermInner: Expr = {
         }
     },
     <IfExpr>,
+    <ForAllExpr>,
     <FnCallExpr>,
     <ArrayExpr>,
     <TupleExpr>,
@@ -785,6 +786,23 @@ TermInner: Expr = {
 BlockExpr: ExprKey = {
     "{" (ConstraintDecl ";")* <Expr> "}"
 };
+
+GeneratorRange: (Ident, ExprKey) = {
+    <index:Ident> "in" <range:Range> => (index, range)
+}
+
+ForAllExpr: Expr = {
+    <l:@L> "forall" <gen_ranges:Sep1ListNoTrail<GeneratorRange, ",">>
+            <conditions: ("where" <Sep1ListNoTrail<Expr, ",">>)?>
+            "{" <body:Expr> "}" <r:@R> => {
+        Expr::ForAll {
+            gen_ranges,
+            conditions: conditions.unwrap_or_default(),
+            body,
+            span: (context.span_from)(l, r),
+        }
+    }
+}
 
 IfExpr: Expr = {
     <l:@L> "if" <condition:Expr> <then_block:BlockExpr> "else" <else_block:BlockExpr> <r:@R> => {
@@ -1182,6 +1200,9 @@ extern {
         "maximize" => lexer::Token::Maximize,
 
         "in" => lexer::Token::In,
+
+        "forall" => lexer::Token::ForAll,
+        "where" => lexer::Token::Where,
 
         "ident" => lexer::Token::Ident(<(String, bool)>),
 

--- a/yurtc/tests/basic_tests/magic_modulo.yrt
+++ b/yurtc/tests/basic_tests/magic_modulo.yrt
@@ -14,29 +14,15 @@
  
 let x: int;
 
-constraint x % 2 == 1;
-constraint x % 3 == 2;
-constraint x % 4 == 3;
-constraint x % 5 == 4;
-constraint x % 6 == 5;
-constraint x % 7 == 6;
-constraint x % 8 == 7;
-constraint x % 9 == 8;
-constraint x % 10 == 9;
+constraint forall i in 2..10 { 
+    x % i == i - 1 
+};
 
 solve satisfy;
 
 // intermediate <<<<
 // var ::x: int;
-// constraint ((::x % 2) == 1);
-// constraint ((::x % 3) == 2);
-// constraint ((::x % 4) == 3);
-// constraint ((::x % 5) == 4);
-// constraint ((::x % 6) == 5);
-// constraint ((::x % 7) == 6);
-// constraint ((::x % 8) == 7);
-// constraint ((::x % 9) == 8);
-// constraint ((::x % 10) == 9);
+// constraint forall i in 2..10, { ((::x % ::i) == (::i - 1)) };
 // solve satisfy;
 // >>>
 

--- a/yurtc/tests/forall/duplicate_indices.yrt
+++ b/yurtc/tests/forall/duplicate_indices.yrt
@@ -1,0 +1,10 @@
+constraint forall i in 1..2, i in 3..4 { true };
+
+solve satisfy;
+
+// flattening_failure <<<
+// `forall` index `i` has already been declared
+// @18..19: previous declaration of the index `i` here
+// @29..30: `i` redeclared here
+// `forall` index `i` must be declared only once in this scope
+// >>>

--- a/yurtc/tests/forall/forall.yrt
+++ b/yurtc/tests/forall/forall.yrt
@@ -1,0 +1,41 @@
+constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { k > i + j || j > k };
+constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { !(i - j < k) };
+constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { k == foo(i) + foo(j) };
+constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { if i > 0 { j > 0 } else { k > 1 } };
+constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { k in [i, j, l] };
+constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { A[i] != A[j] + k };
+constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { k in {i, j, l} };
+constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { {i, j, k}.0 != {i, j, k}.1 };
+constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { {i, j, k}.0 != {i, j, k}.1 };
+constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { i as real / j as real >= k };
+constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { i in j..k };
+constraint forall i in 0..3 { 
+    forall j in 0..3 {
+        A[i] < B[j] 
+    }
+};
+constraint   forall i in 0..3 { A[i] != 0 } 
+          && forall j in 0..3 { A[j] != 0 };
+
+solve satisfy;
+
+// flattened <<<
+// constraint (((true && ((::k > (1 + 2)) || (2 > ::k))) && ((::k > (1 + 3)) || (3 > ::k))) && ((::k > (2 + 3)) || (3 > ::k)));
+// constraint (((true && !((1 - 2) < ::k)) && !((1 - 3) < ::k)) && !((2 - 3) < ::k));
+// constraint (((true && (::k == (::foo(1) + ::foo(2)))) && (::k == (::foo(1) + ::foo(3)))) && (::k == (::foo(2) + ::foo(3))));
+// constraint (((true && if (1 > 0) { (2 > 0) } else { (::k > 1) }) && if (1 > 0) { (3 > 0) } else { (::k > 1) }) && if (2 > 0) { (3 > 0) } else { (::k > 1) });
+// constraint (((true && ::k in [1, 2, ::l]) && ::k in [1, 3, ::l]) && ::k in [2, 3, ::l]);
+// constraint (((true && (::A[1] != (::A[2] + ::k))) && (::A[1] != (::A[3] + ::k))) && (::A[2] != (::A[3] + ::k)));
+// constraint (((true && ::k in {1, 2, ::l}) && ::k in {1, 3, ::l}) && ::k in {2, 3, ::l});
+// constraint (((true && ({1, 2, ::k}.0 != {1, 2, ::k}.1)) && ({1, 3, ::k}.0 != {1, 3, ::k}.1)) && ({2, 3, ::k}.0 != {2, 3, ::k}.1));
+// constraint (((true && ({1, 2, ::k}.0 != {1, 2, ::k}.1)) && ({1, 3, ::k}.0 != {1, 3, ::k}.1)) && ({2, 3, ::k}.0 != {2, 3, ::k}.1));
+// constraint (((true && ((1 as real / 2 as real) >= ::k)) && ((1 as real / 3 as real) >= ::k)) && ((2 as real / 3 as real) >= ::k));
+// constraint (((true && 1 in 2..::k) && 1 in 3..::k) && 2 in 3..::k);
+// constraint ((((true && ((((true && (::A[0] < ::B[0])) && (::A[0] < ::B[1])) && (::A[0] < ::B[2])) && (::A[0] < ::B[3]))) && ((((true && (::A[1] < ::B[0])) && (::A[1] < ::B[1])) && (::A[1] < ::B[2])) && (::A[1] < ::B[3]))) && ((((true && (::A[2] < ::B[0])) && (::A[2] < ::B[1])) && (::A[2] < ::B[2])) && (::A[2] < ::B[3]))) && ((((true && (::A[3] < ::B[0])) && (::A[3] < ::B[1])) && (::A[3] < ::B[2])) && (::A[3] < ::B[3])));
+// constraint (((((true && (::A[0] != 0)) && (::A[1] != 0)) && (::A[2] != 0)) && (::A[3] != 0)) && ((((true && (::A[0] != 0)) && (::A[1] != 0)) && (::A[2] != 0)) && (::A[3] != 0)));
+// solve satisfy;
+// >>>
+
+// compile_failure <<<
+// compiler internal error: Found unsupported expressions in final Intent.
+// >>>

--- a/yurtc/tests/forall/invalid_bounds.yrt
+++ b/yurtc/tests/forall/invalid_bounds.yrt
@@ -1,0 +1,9 @@
+constraint forall i in j..k { true };
+
+solve satisfy;
+
+// flattening_failure <<<
+// invalid bound for `forall` index `i`
+// @23..24: invalid bound for `forall` index `i`
+// `forall` index bound must be an integer literal
+// >>>

--- a/yurtc/tests/forall/symbol_not_found.yrt
+++ b/yurtc/tests/forall/symbol_not_found.yrt
@@ -1,0 +1,8 @@
+constraint forall i in 0..5 where j != 3 { true };
+
+solve satisfy;
+
+// flattening_failure <<<
+// cannot find value `::j` in this scope
+// @34..35: not found in this scope
+// >>>

--- a/yurtc/tests/forall/type_error.yrt
+++ b/yurtc/tests/forall/type_error.yrt
@@ -1,0 +1,9 @@
+constraint forall i in 0..3 where i { true };
+
+solve satisfy;
+
+// Eventually, this should become proper type error instead of a internal error,  once the type
+// checker is implemented.
+// flattening_failure <<<
+// compiler internal error: type error: boolean expression expected
+// >>>


### PR DESCRIPTION
This PR specs and implements `forall`.

The following `forall` expression:

```yurt
forall i in 0..3, j in 0..3 where i <= j {
    a[i] != b[j]
}
```

is equivalent to the following:

```yurt
   a[0] != b[0]
&& a[0] != b[1]
&& a[0] != b[2]
&& a[1] != b[1]
&& a[1] != b[2]
&& a[2] != b[2]
```

One corner case that does not work yet is the following:
```yurt
constraint forall i in 0..3 { 
    forall j in 0..3 where i != j { // Using `i` in the `where` clause of the second `forall` does not work yet
        A[i] < B[j] 
    }
};
```

There are a few other things that don't work as well such as:
- [ ] Named ranges as in `forall i in my_range { true }`.
- [ ] Bounds on indices that are not literals as in `forall i in k..j { true }`

Created an issue to track any other issues [here](https://github.com/essential-contributions/yurt/issues/434) and will add any other issues that come up.

Tasks:
- [x] specs
- [x] `forall` in the lexer/parser
- [x] lexer and parser tests
- [x] convert `forall` to a sequence of ANDs
- [x] e2e functional tests
- [x] e2e error messages tests