### PR TITLE
Add conditional compilation features to allow disabling solvers.

### DIFF
--- a/yurtc/Cargo.toml
+++ b/yurtc/Cargo.toml
@@ -27,13 +27,18 @@ gcollections = "1.4.0"
 intervallum = "1.2.0"
 itertools = { workspace = true }
 lalrpop-util = "0.20"
-libpcp = "0.7.0"
+libpcp = { version = "0.7.0", optional = true }
 logos = { workspace = true }
 num-bigint = "0.4"
 num-traits = "0.2"
 regex = "1.9"
-russcip = { git = "https://github.com/mohammadfawaz/russcip", branch = "mohammadfawaz/indicator_constraints" }
+russcip = { git = "https://github.com/mohammadfawaz/russcip", branch = "mohammadfawaz/indicator_constraints", optional = true }
 similar-asserts = { version = "1.5", default-features = false }
 slotmap = "1.0"
 thiserror = { workspace = true }
 yansi = { workspace = true }
+
+[features]
+default = ["solver-scip", "solver-pcp"]
+solver-scip = ["dep:russcip"]
+solver-pcp = ["dep:libpcp"]

--- a/yurtc/src/solvers.rs
+++ b/yurtc/src/solvers.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "solver-pcp")]
 pub mod pcp;
+#[cfg(feature = "solver-scip")]
 pub mod scip;

--- a/yurtc/tests/tests.rs
+++ b/yurtc/tests/tests.rs
@@ -1,4 +1,3 @@
-use russcip::ProblemCreated;
 use std::{
     fs::{read_dir, File},
     io::{BufRead, BufReader},
@@ -8,7 +7,6 @@ use yansi::Color::{Cyan, Red, Yellow};
 use yurtc::{
     error::ReportableError,
     intent::{Intent, IntermediateIntent},
-    solvers::scip::Solver,
 };
 
 #[cfg(test)]
@@ -394,12 +392,19 @@ fn compile_to_final_intent_and_check(
     })
 }
 
+#[cfg(not(feature = "solver-scip"))]
+fn solve_and_check(_: Option<Intent>, _: &Expectations, _: &mut Vec<String>, _: &Path) {}
+
+#[cfg(feature = "solver-scip")]
 fn solve_and_check(
     ii: Option<Intent>,
     expectations: &Expectations,
     failed_tests: &mut Vec<String>,
     path: &Path,
 ) {
+    use russcip::ProblemCreated;
+    use yurtc::solvers::scip::Solver;
+
     ii.and_then(|ii| {
         Solver::<ProblemCreated>::new(&ii)
             .solve()


### PR DESCRIPTION
The "solver-russcip" and "solver-pcp" features are both on by default, but when disabled via `cargo build --no-default-features` or `cargo build --features ...` builtin solving is disabled.