### PR TITLE
Implement a type checker for the intermediate intent.

### DIFF
--- a/yurtc/src/error.rs
+++ b/yurtc/src/error.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 use yansi::{Color, Style};
 
 pub(super) use compile_error::CompileError;
+pub(super) use compile_error::LargeTypeError;
 pub(super) use lex_error::LexError;
 pub(super) use parse_error::ParseError;
 pub(super) use solve_error::SolveError;

--- a/yurtc/src/expr.rs
+++ b/yurtc/src/expr.rs
@@ -46,6 +46,7 @@ pub enum Expr {
     },
     Array {
         elements: Vec<ExprKey>,
+        range_expr: ExprKey,
         span: Span,
     },
     ArrayElementAccess {
@@ -135,6 +136,26 @@ pub enum BinaryOp {
     // Logical
     LogicalAnd,
     LogicalOr,
+}
+
+impl BinaryOp {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            BinaryOp::Add => "+",
+            BinaryOp::Sub => "-",
+            BinaryOp::Mul => "*",
+            BinaryOp::Div => "/",
+            BinaryOp::Mod => "%",
+            BinaryOp::Equal => "==",
+            BinaryOp::NotEqual => "!=",
+            BinaryOp::LessThanOrEqual => "<=",
+            BinaryOp::LessThan => "<",
+            BinaryOp::GreaterThanOrEqual => ">=",
+            BinaryOp::GreaterThan => ">",
+            BinaryOp::LogicalAnd => "&&",
+            BinaryOp::LogicalOr => "||",
+        }
+    }
 }
 
 impl Spanned for Expr {

--- a/yurtc/src/expr/evaluate.rs
+++ b/yurtc/src/expr/evaluate.rs
@@ -30,6 +30,7 @@ impl Expr {
                     .ok_or_else(|| CompileError::SymbolNotFound {
                         name: path.to_string(),
                         span: span.clone(),
+                        enum_names: Vec::new(),
                     })
             }
             Expr::UnaryOp { op, expr, .. } => {
@@ -225,13 +226,22 @@ impl ExprKey {
                     span,
                 }
             }
-            Expr::Array { elements, span } => {
+            Expr::Array {
+                elements,
+                range_expr,
+                span,
+            } => {
                 let elements = elements
                     .iter()
                     .map(|element| element.plug_in(ii, values_map))
                     .collect::<Vec<_>>();
+                let range_expr = range_expr.plug_in(ii, values_map);
 
-                Expr::Array { elements, span }
+                Expr::Array {
+                    elements,
+                    range_expr,
+                    span,
+                }
             }
             Expr::ArrayElementAccess { array, index, span } => {
                 let array = array.plug_in(ii, values_map);

--- a/yurtc/src/intent/intermediate/analyse.rs
+++ b/yurtc/src/intent/intermediate/analyse.rs
@@ -1,0 +1,700 @@
+use super::{Expr, ExprKey, Ident, IntermediateIntent, VarKey};
+
+use crate::{
+    error::{CompileError, LargeTypeError},
+    expr::{BinaryOp, Immediate, TupleAccess, UnaryOp},
+    span::{empty_span, Span, Spanned},
+    types::{EnumDecl, EphemeralDecl, NewTypeDecl, Path, PrimitiveKind, Type},
+};
+
+enum Inference {
+    Ignored,
+    Type(Type),
+    Dependant(ExprKey),
+    Dependencies(Vec<ExprKey>),
+}
+
+impl IntermediateIntent {
+    pub fn type_check(mut self) -> super::Result<Self> {
+        // Attempt to infer all the types of each expr.
+        let mut queue = Vec::new();
+
+        // Utility to check for recursion in the queue.  A macro to avoid borrowing self.
+        macro_rules! push_to_queue {
+            ($dependant_key: ident, $dependency_key: ident) => {
+                if queue.contains(&$dependency_key) {
+                    Err(CompileError::ExprRecursion {
+                        dependant_span: self.expr_key_to_span($dependant_key),
+                        dependency_span: self.expr_key_to_span($dependency_key),
+                    })
+                } else {
+                    queue.push($dependency_key);
+                    Ok(())
+                }
+            };
+        }
+
+        for expr_key in self.exprs.keys() {
+            // Start with this key.
+            queue.push(expr_key);
+
+            // Infer each expr type, or their dependencies.
+            while let Some(next_key) = queue.last().cloned() {
+                // We may already know this expr type, in which case we can pop it from the queue,
+                // or we can infer it.
+                if self.expr_types.contains_key(next_key) {
+                    queue.pop();
+                } else {
+                    match self.infer_expr_key_type(next_key)? {
+                        // Successfully inferred its type.  Save it and pop it from the queue.
+                        Inference::Type(ty) => {
+                            self.expr_types.insert(next_key, ty);
+                            queue.pop();
+                        }
+
+                        // Some dependencies need to be inferred before we can get back to this
+                        // expr.  When pushing dependencies we need to check if they're already
+                        // queued, in which case we have a recursive dependency and an error.
+                        Inference::Dependant(dep_expr_key) => {
+                            push_to_queue!(next_key, dep_expr_key)?
+                        }
+                        Inference::Dependencies(mut dep_expr_keys) => dep_expr_keys
+                            .drain(..)
+                            .try_for_each(|dep_expr_key| push_to_queue!(next_key, dep_expr_key))?,
+
+                        // Some expressions (e.g., macro calls) just aren't valid any longer and
+                        // are best ignored.
+                        Inference::Ignored => {
+                            queue.pop();
+                        }
+                    }
+                }
+            }
+        }
+
+        // Confirm now that all the variables are typed.
+        for (var_key, var) in &self.vars {
+            if self.var_types.get(var_key).is_none() {
+                if let Some(init_expr_key) = self.var_inits.get(var_key) {
+                    match self.expr_types.get(*init_expr_key) {
+                        Some(ty) => {
+                            self.var_types.insert(var_key, ty.clone());
+                        }
+                        None => {
+                            return Err(CompileError::UnknownType {
+                                span: var.span.clone(),
+                            });
+                        }
+                    }
+                } else {
+                    return Err(CompileError::Internal {
+                        msg: "untyped variable has no initialiser",
+                        span: var.span.clone(),
+                    });
+                }
+            }
+        }
+
+        Ok(self)
+    }
+
+    fn infer_expr_key_type(&self, expr_key: ExprKey) -> super::Result<Inference> {
+        let expr: &Expr = self
+            .exprs
+            .get(expr_key)
+            .ok_or_else(|| CompileError::Internal {
+                msg: "orphaned expr key when type checking",
+                span: empty_span(),
+            })?;
+
+        match expr {
+            Expr::Error(span) => Err(CompileError::Internal {
+                msg: "unable to type check from error expression",
+                span: span.clone(),
+            }),
+
+            Expr::Immediate { value, span } => Ok(Inference::Type(Self::get_immediate_type(
+                value,
+                span.clone(),
+            ))),
+
+            Expr::PathByKey(var_key, span) => self.infer_expr_key_path_by_key(*var_key, span),
+
+            Expr::PathByName(path, span) => self.infer_expr_key_path_by_name(path, span),
+
+            Expr::UnaryOp {
+                op,
+                expr: op_expr_key,
+                span,
+            } => self.infer_unary_op(*op, *op_expr_key, span),
+
+            Expr::BinaryOp { op, lhs, rhs, span } => self.infer_binary_op(*op, *lhs, *rhs, span),
+
+            Expr::MacroCall { .. } => Ok(Inference::Ignored),
+
+            Expr::FnCall { name, span, .. } => {
+                // For now, this very special case is all we support.
+                if name.as_str() == "::storage::get" {
+                    Ok(Inference::Type(Type::Primitive {
+                        kind: PrimitiveKind::Int,
+                        span: span.clone(),
+                    }))
+                } else {
+                    Err(CompileError::Internal {
+                        msg: "unable to check type of FnCall",
+                        span: span.clone(),
+                    })
+                }
+            }
+
+            Expr::If {
+                condition,
+                then_block,
+                else_block,
+                span,
+            } => self.infer_if_expr(*condition, *then_block, *else_block, span),
+
+            Expr::Array {
+                elements,
+                range_expr,
+                span,
+            } => self.infer_array_expr(*range_expr, elements, span),
+
+            Expr::ArrayElementAccess { array, index, span } => {
+                self.infer_array_access_expr(*array, *index, span)
+            }
+
+            Expr::Tuple { fields, span } => self.infer_tuple_expr(fields, span),
+
+            Expr::TupleFieldAccess { tuple, field, span } => {
+                self.infer_tuple_access_expr(*tuple, field, span)
+            }
+
+            Expr::Cast { ty, .. } => Ok(Inference::Type(*ty.clone())),
+
+            Expr::In { span, .. } => Ok(Inference::Type(Type::Primitive {
+                kind: PrimitiveKind::Bool,
+                span: span.clone(),
+            })),
+
+            Expr::Range { span, .. } => Ok(Inference::Type(Type::Primitive {
+                kind: PrimitiveKind::Int,
+                span: span.clone(),
+            })),
+
+            Expr::ForAll { span, .. } => Ok(Inference::Type(Type::Primitive {
+                kind: PrimitiveKind::Bool,
+                span: span.clone(),
+            })),
+        }
+    }
+
+    fn get_immediate_type(imm: &Immediate, span: Span) -> Type {
+        match imm {
+            Immediate::Real(_) => Type::Primitive {
+                kind: PrimitiveKind::Real,
+                span: span.clone(),
+            },
+            Immediate::Int(_) | Immediate::BigInt(_) => Type::Primitive {
+                kind: PrimitiveKind::Int,
+                span: span.clone(),
+            },
+            Immediate::Bool(_) => Type::Primitive {
+                kind: PrimitiveKind::Bool,
+                span: span.clone(),
+            },
+            Immediate::String(_) => Type::Primitive {
+                kind: PrimitiveKind::String,
+                span: span.clone(),
+            },
+        }
+    }
+
+    fn infer_expr_key_path_by_key(&self, var_key: VarKey, span: &Span) -> super::Result<Inference> {
+        if let Some(ty) = self.var_types.get(var_key) {
+            Ok(Inference::Type(ty.clone()))
+        } else if let Some(init_expr_key) = self.var_inits.get(var_key) {
+            if let Some(init_expr_ty) = self.expr_types.get(*init_expr_key) {
+                Ok(Inference::Type(init_expr_ty.clone()))
+            } else {
+                // We have a variable with an initialiser but don't know the initialiser type
+                // yet.
+                Ok(Inference::Dependant(*init_expr_key))
+            }
+        } else {
+            Err(CompileError::Internal {
+                msg: "untyped variable doesn't have initialiser",
+                span: span.clone(),
+            })
+        }
+    }
+
+    fn infer_expr_key_path_by_name(&self, path: &Path, span: &Span) -> super::Result<Inference> {
+        if let Some(var_key) = self
+            .vars
+            .iter()
+            .find_map(|(var_key, var)| (&var.name == path).then_some(var_key))
+        {
+            // It's a var.
+            self.infer_expr_key_path_by_key(var_key, span)
+        } else if let Some((state_key, state)) =
+            self.states.iter().find(|(_, state)| (&state.name == path))
+        {
+            // It's state.
+            Ok(if let Some(ty) = self.state_types.get(state_key) {
+                Inference::Type(ty.clone())
+            } else if let Some(init_expr_ty) = self.expr_types.get(state.expr) {
+                Inference::Type(init_expr_ty.clone())
+            } else {
+                Inference::Dependant(state.expr)
+            })
+        } else if let Some(EphemeralDecl { ty, .. }) = self
+            .ephemerals
+            .iter()
+            .find(|eph_decl| &eph_decl.name == path)
+        {
+            // It's an ephemeral value.
+            Ok(Inference::Type(ty.clone()))
+        } else {
+            // None of the above.  If we're searching for an enum variant and it appears to be
+            // unqualified then we can report some hints.
+            let mut err_potential_enums = Vec::new();
+
+            // Otherwise, is it in the map of self.new_types, or does it match an enum variant?
+            if let Some(ty) = self
+                .new_types
+                .iter()
+                .find_map(|NewTypeDecl { name, ty, .. }| (&name.name == path).then(|| ty.clone()))
+                .or(self.enums.iter().find_map(
+                    |EnumDecl {
+                         name: enum_name,
+                         variants,
+                         span,
+                     }| {
+                        variants
+                            .iter()
+                            .any(|variant| {
+                                if path[2..] == variant.name {
+                                    err_potential_enums.push(enum_name.name.clone());
+                                }
+
+                                let mut full_variant = enum_name.name.clone();
+                                full_variant.push_str("::");
+                                full_variant.push_str(&variant.name);
+
+                                &full_variant == path
+                            })
+                            .then(|| Type::Custom {
+                                path: enum_name.name.clone(),
+                                span: span.clone(),
+                            })
+                    },
+                ))
+            {
+                Ok(Inference::Type(ty.clone()))
+            } else {
+                Err(CompileError::SymbolNotFound {
+                    name: path.clone(),
+                    span: span.clone(),
+                    enum_names: err_potential_enums,
+                })
+            }
+        }
+    }
+
+    fn infer_unary_op(
+        &self,
+        op: UnaryOp,
+        rhs_expr_key: ExprKey,
+        span: &Span,
+    ) -> super::Result<Inference> {
+        match op {
+            UnaryOp::Error => Err(CompileError::Internal {
+                msg: "unable to type check unary op error",
+                span: span.clone(),
+            }),
+
+            UnaryOp::Neg => {
+                // RHS must be an int or real.
+                if let Some(ty) = self.expr_types.get(rhs_expr_key) {
+                    if ty.is_num() {
+                        Ok(Inference::Type(ty.clone()))
+                    } else {
+                        Err(CompileError::OperatorTypeError {
+                            arity: "unary",
+                            large_err: Box::new(LargeTypeError::OperatorTypeError {
+                                op: "-",
+                                expected_ty: "numeric".to_string(),
+                                found_ty: self.with_ii(ty).to_string(),
+                                span: span.clone(),
+                                expected_span: None,
+                            }),
+                        })
+                    }
+                } else {
+                    Ok(Inference::Dependant(rhs_expr_key))
+                }
+            }
+
+            UnaryOp::Not => {
+                // RHS must be a bool.
+                if let Some(ty) = self.expr_types.get(rhs_expr_key) {
+                    if ty.is_bool() {
+                        Ok(Inference::Type(ty.clone()))
+                    } else {
+                        Err(CompileError::OperatorTypeError {
+                            arity: "unary",
+                            large_err: Box::new(LargeTypeError::OperatorTypeError {
+                                op: "!",
+                                expected_ty: "bool".to_string(),
+                                found_ty: self.with_ii(ty).to_string(),
+                                span: span.clone(),
+                                expected_span: None,
+                            }),
+                        })
+                    }
+                } else {
+                    Ok(Inference::Dependant(rhs_expr_key))
+                }
+            }
+
+            UnaryOp::NextState => Ok(if let Some(ty) = self.expr_types.get(rhs_expr_key) {
+                Inference::Type(ty.clone())
+            } else {
+                Inference::Dependant(rhs_expr_key)
+            }),
+        }
+    }
+
+    fn infer_binary_op(
+        &self,
+        op: BinaryOp,
+        lhs_expr_key: ExprKey,
+        rhs_expr_key: ExprKey,
+        span: &Span,
+    ) -> super::Result<Inference> {
+        let check_numeric_args = |lhs_ty: &Type, rhs_ty: &Type, ty_str: &str| {
+            if !lhs_ty.is_num() {
+                Err(CompileError::OperatorTypeError {
+                    arity: "binary",
+                    large_err: Box::new(LargeTypeError::OperatorTypeError {
+                        op: op.as_str(),
+                        expected_ty: ty_str.to_string(),
+                        found_ty: self.with_ii(lhs_ty).to_string(),
+                        span: self.expr_key_to_span(lhs_expr_key),
+                        expected_span: None,
+                    }),
+                })
+            } else if !rhs_ty.is_num() {
+                Err(CompileError::OperatorTypeError {
+                    arity: "binary",
+                    large_err: Box::new(LargeTypeError::OperatorTypeError {
+                        op: op.as_str(),
+                        expected_ty: ty_str.to_string(),
+                        found_ty: self.with_ii(rhs_ty).to_string(),
+                        span: self.expr_key_to_span(rhs_expr_key),
+                        expected_span: None,
+                    }),
+                })
+            } else if lhs_ty != rhs_ty {
+                // Here we assume the LHS is the 'correct' type.
+                Err(CompileError::OperatorTypeError {
+                    arity: "binary",
+                    large_err: Box::new(LargeTypeError::OperatorTypeError {
+                        op: op.as_str(),
+                        expected_ty: self.with_ii(lhs_ty).to_string(),
+                        found_ty: self.with_ii(rhs_ty).to_string(),
+                        span: self.expr_key_to_span(rhs_expr_key),
+                        expected_span: Some(self.expr_key_to_span(lhs_expr_key)),
+                    }),
+                })
+            } else {
+                Ok(())
+            }
+        };
+
+        if let Some(lhs_ty) = self.expr_types.get(lhs_expr_key).cloned() {
+            if let Some(rhs_ty) = self.expr_types.get(rhs_expr_key) {
+                match op {
+                    BinaryOp::Add
+                    | BinaryOp::Sub
+                    | BinaryOp::Mul
+                    | BinaryOp::Div
+                    | BinaryOp::Mod => {
+                        // Both args must be numeric, i.e., ints or reals; binary op type is same
+                        // as arg types.
+                        check_numeric_args(&lhs_ty, rhs_ty, "numeric")
+                            .map(|_| Inference::Type(lhs_ty))
+                    }
+
+                    BinaryOp::Equal | BinaryOp::NotEqual => {
+                        // Both args must be equatable, which at this stage is any type; binary op
+                        // type is bool.
+                        if &lhs_ty != rhs_ty {
+                            Err(CompileError::OperatorTypeError {
+                                arity: "binary",
+                                large_err: Box::new(LargeTypeError::OperatorTypeError {
+                                    op: op.as_str(),
+                                    expected_ty: self.with_ii(lhs_ty).to_string(),
+                                    found_ty: self.with_ii(rhs_ty).to_string(),
+                                    span: self.expr_key_to_span(rhs_expr_key),
+                                    expected_span: Some(self.expr_key_to_span(lhs_expr_key)),
+                                }),
+                            })
+                        } else {
+                            Ok(Inference::Type(Type::Primitive {
+                                kind: PrimitiveKind::Bool,
+                                span: span.clone(),
+                            }))
+                        }
+                    }
+
+                    BinaryOp::LessThanOrEqual
+                    | BinaryOp::LessThan
+                    | BinaryOp::GreaterThanOrEqual
+                    | BinaryOp::GreaterThan => {
+                        // Both args must be ordinal, i.e., ints, reals; binary op type is bool.
+                        check_numeric_args(&lhs_ty, rhs_ty, "numeric").map(|_| {
+                            Inference::Type(Type::Primitive {
+                                kind: PrimitiveKind::Bool,
+                                span: span.clone(),
+                            })
+                        })
+                    }
+
+                    BinaryOp::LogicalAnd | BinaryOp::LogicalOr => {
+                        // Both arg types and binary op type are all bool.
+                        if !lhs_ty.is_bool() {
+                            Err(CompileError::OperatorTypeError {
+                                arity: "binary",
+                                large_err: Box::new(LargeTypeError::OperatorTypeError {
+                                    op: op.as_str(),
+                                    expected_ty: "bool".to_string(),
+                                    found_ty: self.with_ii(lhs_ty).to_string(),
+                                    span: self.expr_key_to_span(lhs_expr_key),
+                                    expected_span: Some(span.clone()),
+                                }),
+                            })
+                        } else if !rhs_ty.is_bool() {
+                            Err(CompileError::OperatorTypeError {
+                                arity: "binary",
+                                large_err: Box::new(LargeTypeError::OperatorTypeError {
+                                    op: op.as_str(),
+                                    expected_ty: "bool".to_string(),
+                                    found_ty: self.with_ii(rhs_ty).to_string(),
+                                    span: self.expr_key_to_span(rhs_expr_key),
+                                    expected_span: Some(span.clone()),
+                                }),
+                            })
+                        } else {
+                            Ok(Inference::Type(lhs_ty.clone()))
+                        }
+                    }
+                }
+            } else {
+                Ok(Inference::Dependant(rhs_expr_key))
+            }
+        } else {
+            Ok(Inference::Dependant(lhs_expr_key))
+        }
+    }
+
+    fn infer_if_expr(
+        &self,
+        cond_expr_key: ExprKey,
+        then_expr_key: ExprKey,
+        else_expr_key: ExprKey,
+        span: &Span,
+    ) -> super::Result<Inference> {
+        if let Some(cond_ty) = self.expr_types.get(cond_expr_key) {
+            if !cond_ty.is_bool() {
+                Err(CompileError::IfCondTypeNotBool(
+                    self.expr_key_to_span(cond_expr_key),
+                ))
+            } else if let Some(then_ty) = self.expr_types.get(then_expr_key) {
+                if let Some(else_ty) = self.expr_types.get(else_expr_key) {
+                    if then_ty == else_ty {
+                        Ok(Inference::Type(then_ty.clone()))
+                    } else {
+                        Err(CompileError::IfBranchesTypeMismatch {
+                            large_err: Box::new(LargeTypeError::IfBranchesTypeMismatch {
+                                then_type: self.with_ii(then_ty).to_string(),
+                                then_span: self.expr_key_to_span(then_expr_key),
+                                else_type: self.with_ii(else_ty).to_string(),
+                                else_span: self.expr_key_to_span(else_expr_key),
+                                span: span.clone(),
+                            }),
+                        })
+                    }
+                } else {
+                    Ok(Inference::Dependant(else_expr_key))
+                }
+            } else {
+                Ok(Inference::Dependant(then_expr_key))
+            }
+        } else {
+            Ok(Inference::Dependant(cond_expr_key))
+        }
+    }
+
+    fn infer_array_expr(
+        &self,
+        range_expr_key: ExprKey,
+        element_exprs: &[ExprKey],
+        span: &Span,
+    ) -> super::Result<Inference> {
+        if element_exprs.is_empty() {
+            return Err(CompileError::EmptyArrayExpression { span: span.clone() });
+        }
+
+        let mut elements = element_exprs.iter();
+
+        let el0 = elements
+            .next()
+            .expect("already check for elements.is_empty()");
+
+        let mut deps = Vec::new();
+        if let Some(el0_ty) = self.expr_types.get(*el0) {
+            for el_key in elements {
+                if let Some(el_ty) = self.expr_types.get(*el_key) {
+                    if el_ty != el0_ty {
+                        return Err(CompileError::NonHomogeneousArrayElement {
+                            expected_ty: self.with_ii(&el0_ty).to_string(),
+                            ty: self.with_ii(el_ty).to_string(),
+                            span: self.expr_key_to_span(*el_key),
+                        });
+                    }
+                } else {
+                    deps.push(*el_key);
+                }
+            }
+
+            Ok(if deps.is_empty() {
+                Inference::Type(Type::Array {
+                    ty: Box::new(el0_ty.clone()),
+                    range: range_expr_key,
+                    span: span.clone(),
+                })
+            } else {
+                Inference::Dependencies(deps)
+            })
+        } else {
+            Ok(Inference::Dependant(*el0))
+        }
+    }
+
+    fn infer_array_access_expr(
+        &self,
+        array_expr_key: ExprKey,
+        index_expr_key: ExprKey,
+        span: &Span,
+    ) -> super::Result<Inference> {
+        if let Some(index_ty) = self.expr_types.get(index_expr_key) {
+            if !index_ty.is_int() {
+                Err(CompileError::ArrayAccessWithNonInt {
+                    found_ty: self.with_ii(index_ty).to_string(),
+                    span: self.expr_key_to_span(index_expr_key),
+                })
+            } else if let Some(ary_ty) = self.expr_types.get(array_expr_key) {
+                if let Type::Array { ty, .. } = ary_ty {
+                    Ok(Inference::Type(*ty.clone()))
+                } else {
+                    Err(CompileError::ArrayAccessNonArray {
+                        non_array_type: self.with_ii(ary_ty).to_string(),
+                        span: span.clone(),
+                    })
+                }
+            } else {
+                Ok(Inference::Dependant(array_expr_key))
+            }
+        } else {
+            Ok(Inference::Dependant(index_expr_key))
+        }
+    }
+
+    fn infer_tuple_expr(
+        &self,
+        fields: &[(Option<Ident>, ExprKey)],
+        span: &Span,
+    ) -> super::Result<Inference> {
+        let mut field_tys = Vec::with_capacity(fields.len());
+
+        let mut deps = Vec::new();
+        for (name, field_expr_key) in fields {
+            if let Some(field_ty) = self.expr_types.get(*field_expr_key) {
+                field_tys.push((name.clone(), field_ty.clone()));
+            } else {
+                deps.push(*field_expr_key);
+            }
+        }
+
+        Ok(if deps.is_empty() {
+            Inference::Type(Type::Tuple {
+                fields: field_tys,
+                span: span.clone(),
+            })
+        } else {
+            Inference::Dependencies(deps)
+        })
+    }
+
+    fn infer_tuple_access_expr(
+        &self,
+        tuple_expr_key: ExprKey,
+        field: &TupleAccess,
+        span: &Span,
+    ) -> super::Result<Inference> {
+        if let Some(tuple_ty) = self.expr_types.get(tuple_expr_key) {
+            if let Type::Tuple { fields, .. } = tuple_ty {
+                match field {
+                    TupleAccess::Error => Err(CompileError::Internal {
+                        msg: "unable to type check tuple field access error",
+                        span: span.clone(),
+                    }),
+
+                    TupleAccess::Index(idx) => {
+                        if let Some(field_ty) = fields.get(*idx).map(|(_, ty)| ty.clone()) {
+                            Ok(Inference::Type(field_ty))
+                        } else {
+                            Err(CompileError::InvalidTupleAccessor {
+                                accessor: idx.to_string(),
+                                tuple_type: self.with_ii(tuple_ty).to_string(),
+                                span: span.clone(),
+                            })
+                        }
+                    }
+
+                    TupleAccess::Name(name) => {
+                        if let Some(field_ty) = fields.iter().find_map(|(field_name, ty)| {
+                            field_name.as_ref().and_then(|field_name| {
+                                (field_name.name == name.name).then(|| ty.clone())
+                            })
+                        }) {
+                            Ok(Inference::Type(field_ty))
+                        } else {
+                            Err(CompileError::InvalidTupleAccessor {
+                                accessor: name.name.clone(),
+                                tuple_type: self.with_ii(&tuple_ty).to_string(),
+                                span: span.clone(),
+                            })
+                        }
+                    }
+                }
+            } else {
+                Err(CompileError::TupleAccessNonTuple {
+                    non_tuple_type: self.with_ii(tuple_ty).to_string(),
+                    span: span.clone(),
+                })
+            }
+        } else {
+            Ok(Inference::Dependant(tuple_expr_key))
+        }
+    }
+
+    fn expr_key_to_span(&self, expr_key: ExprKey) -> Span {
+        self.exprs
+            .get(expr_key)
+            .map(|expr| expr.span().clone())
+            .unwrap_or_else(empty_span)
+    }
+}

--- a/yurtc/src/intent/intermediate/display.rs
+++ b/yurtc/src/intent/intermediate/display.rs
@@ -6,7 +6,7 @@ impl Display for super::IntermediateIntent {
             writeln!(f, "{};", self.with_ii(var.0))?;
         }
         for state in &self.states {
-            writeln!(f, "{};", self.with_ii(state))?;
+            writeln!(f, "{};", self.with_ii(state.0))?;
         }
         for r#enum in &self.enums {
             writeln!(f, "{};", self.with_ii(r#enum))?;

--- a/yurtc/src/intent/intermediate/transform/scalarize.rs
+++ b/yurtc/src/intent/intermediate/transform/scalarize.rs
@@ -54,10 +54,10 @@ fn scalarize_array(
                     for i in 0..val {
                         let new_var = Var {
                             name: format!("{name}[{i}]"),
-                            ty: Some(ty.clone()),
                             span: span.clone(),
                         };
                         let new_var_key = ii.vars.insert(new_var.clone());
+                        ii.var_types.insert(new_var_key, ty.clone());
 
                         // Recurse for arrays of arrays
                         if let Type::Array {
@@ -205,7 +205,7 @@ pub(crate) fn scalarize(ii: &mut IntermediateIntent) -> Result<(), CompileError>
         .iter()
         .filter_map(|(key, var)| {
             // Only collect arrays
-            if let Some(Type::Array { ty, range, span }) = &var.ty {
+            if let Some(Type::Array { ty, range, span }) = &ii.var_types.get(key) {
                 Some((key, var.name.clone(), ty.clone(), *range, span.clone()))
             } else {
                 None

--- a/yurtc/src/main.rs
+++ b/yurtc/src/main.rs
@@ -20,19 +20,8 @@ fn main() -> anyhow::Result<()> {
         }
     };
 
-    // Flatten the intermediate intent
-    let mut flattened = match intermediate_intent.flatten() {
-        Ok(flattened) => flattened,
-        Err(error) => {
-            if !cfg!(test) {
-                error::print_errors(&vec![error::Error::Compile { error }]);
-            }
-            yurtc::yurtc_bail!(1, filepath)
-        }
-    };
-
     // Compile the flattened intent down to a final intent
-    let intent = match flattened.compile() {
+    let intent = match intermediate_intent.compile() {
         Ok(intent) => intent,
         Err(error) => {
             if !cfg!(test) {

--- a/yurtc/src/parser.rs
+++ b/yurtc/src/parser.rs
@@ -160,6 +160,7 @@ impl ProjectParser {
         // expression.
         for (call_expr_key, body_expr_key) in call_replacements {
             self.intent.replace_exprs(call_expr_key, body_expr_key);
+            self.intent.exprs.remove(call_expr_key);
         }
 
         self

--- a/yurtc/src/types.rs
+++ b/yurtc/src/types.rs
@@ -16,7 +16,7 @@ pub enum PrimitiveKind {
     String,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum Type {
     Error(Span),
     Primitive {
@@ -36,6 +36,112 @@ pub enum Type {
         path: Path,
         span: Span,
     },
+}
+
+macro_rules! is_primitive {
+    ($self: ident, $kind: pat) => {
+        matches!($self, Type::Primitive { kind: $kind, .. })
+    };
+}
+
+impl Type {
+    pub fn is_bool(&self) -> bool {
+        is_primitive!(self, PrimitiveKind::Bool)
+    }
+
+    pub fn is_int(&self) -> bool {
+        is_primitive!(self, PrimitiveKind::Int)
+    }
+
+    pub fn is_real(&self) -> bool {
+        is_primitive!(self, PrimitiveKind::Real)
+    }
+
+    pub fn is_string(&self) -> bool {
+        is_primitive!(self, PrimitiveKind::String)
+    }
+
+    pub fn is_num(&self) -> bool {
+        self.is_int() || self.is_real()
+    }
+
+    pub fn is_any_primitive(&self) -> bool {
+        matches!(self, Type::Primitive { .. })
+    }
+
+    pub fn is_enum(&self) -> bool {
+        matches!(self, Type::Custom { .. })
+    }
+}
+
+impl PartialEq for Type {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Error(_), Self::Error(_)) => true,
+
+            (Self::Primitive { kind: lhs, .. }, Self::Primitive { kind: rhs, .. }) => lhs == rhs,
+
+            // This is sub-optimal; we're saying two arrays of the same element type are
+            // equivalent, regardless of their size.
+            (Self::Array { ty: lhs_ty, .. }, Self::Array { ty: rhs_ty, .. }) => lhs_ty == rhs_ty,
+
+            (
+                Self::Tuple {
+                    fields: lhs_fields, ..
+                },
+                Self::Tuple {
+                    fields: rhs_fields, ..
+                },
+            ) => {
+                if lhs_fields.len() != rhs_fields.len() {
+                    false
+                } else {
+                    // If all the fields are named for both tuples then we can compare them
+                    // name-wise.
+                    if lhs_fields.iter().all(|(name, _)| name.is_some())
+                        && rhs_fields.iter().all(|(name, _)| name.is_some())
+                    {
+                        let lhs_types: std::collections::HashMap<String, &Type> =
+                            std::collections::HashMap::from_iter(lhs_fields.iter().map(
+                                |(opt_name_id, ty)| {
+                                    (
+                                        opt_name_id
+                                            .as_ref()
+                                            .expect("have already checked is Some")
+                                            .name
+                                            .clone(),
+                                        ty,
+                                    )
+                                },
+                            ));
+                        rhs_fields.iter().all(|(rhs_name, rhs_ty)| {
+                            lhs_types
+                                .get(
+                                    &rhs_name
+                                        .as_ref()
+                                        .expect("have already checked is Some")
+                                        .name,
+                                )
+                                .map(|lhs_ty| lhs_ty == &rhs_ty)
+                                .unwrap_or(false)
+                        })
+                    } else {
+                        // Otherwise we compare them in declared order.
+                        lhs_fields
+                            .iter()
+                            .zip(rhs_fields.iter())
+                            .all(|((_, lhs_ty), (_, rhs_ty))| lhs_ty == rhs_ty)
+                    }
+                }
+            }
+
+            (Self::Custom { path: lhs_path, .. }, Self::Custom { path: rhs_path, .. }) => {
+                lhs_path == rhs_path
+            }
+
+            _ => false,
+        }
+    }
 }
 
 impl Spanned for Type {
@@ -72,6 +178,19 @@ pub struct NewTypeDecl {
 }
 
 impl Spanned for NewTypeDecl {
+    fn span(&self) -> &Span {
+        &self.span
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct EphemeralDecl {
+    pub(super) name: String,
+    pub(super) ty: Type,
+    pub(super) span: Span,
+}
+
+impl Spanned for EphemeralDecl {
     fn span(&self) -> &Span {
         &self.span
     }

--- a/yurtc/src/yurt_parser.lalrpop
+++ b/yurtc/src/yurt_parser.lalrpop
@@ -158,14 +158,10 @@ pub LetDecl: () = {
     <l:@L> "let" <let_name:LetName> ":" <ty:Type> <init:LetInit?> <r:@R> => {
         context
             .ii
-            .insert_var(
-                context.mod_prefix,
-                let_name.1,
-                &let_name.0,
-                Some(ty),
-            )
+            .insert_var(context.mod_prefix, let_name.1, &let_name.0, Some(ty))
             .map(|var_key| {
                 if let Some(expr_key) = init {
+                    context.ii.var_inits.insert(var_key, expr_key);
                     context.ii.insert_eq_or_ineq_constraint(
                         var_key,
                         expr_key,
@@ -180,13 +176,9 @@ pub LetDecl: () = {
     <l:@L> "let" <let_name:LetName> <init:LetInit> <r:@R> => {
         context
             .ii
-            .insert_var(
-                context.mod_prefix,
-                let_name.1,
-                &let_name.0,
-                None,
-            )
+            .insert_var(context.mod_prefix, let_name.1, &let_name.0, None)
             .map(|var_key| {
+                context.ii.var_inits.insert(var_key, init);
                 context
                     .ii
                     .insert_eq_or_ineq_constraint(var_key, init, (context.span_from)(l, r));
@@ -259,6 +251,7 @@ pub StateDecl: () = {
                 init_key,
                 (context.span_from)(l, r),
             )
+            .map(|_| ())
             .unwrap_or_else(|error| {
                 errors.push(Error::Parse { error });
             });
@@ -791,7 +784,23 @@ BlockExpr: ExprKey = {
 };
 
 GeneratorRange: (Ident, ExprKey) = {
-    <index:Ident> "in" <range:Range> => (index, range)
+    <index:Ident> "in" <range:Range> => {
+        // Generators for `forall` are always `int`s and need to be saved in the ephemeral list.
+        context
+            .ii
+            .insert_ephemeral(
+                context.mod_prefix,
+                &index,
+                Type::Primitive {
+                    kind: PrimitiveKind::Int,
+                    span: index.span.clone(),
+                },
+            )
+            .unwrap_or_else(|error| {
+                errors.push(Error::Parse { error });
+            });
+        (index, range)
+    }
 }
 
 ForAllExpr: Expr = {
@@ -879,9 +888,14 @@ FnCallExpr: Expr = {
 };
 
 ArrayExpr: Expr = {
-    <l:@L> "[" <elements:SepList<Expr, ",">> "]" <r:@R> => {
+    <l:@L> "[" <il:@L> <elements:SepList<Expr, ",">> <ir:@R> "]" <r:@R> => {
+        let range_expr = context.ii.exprs.insert(Expr::Immediate {
+            value: Immediate::Int(elements.len() as i64),
+            span: (context.span_from)(il, ir),
+        });
         Expr::Array {
             elements,
+            range_expr,
             span: (context.span_from)(l, r),
         }
     },

--- a/yurtc/tests/arrays/bad_const_index.yrt
+++ b/yurtc/tests/arrays/bad_const_index.yrt
@@ -5,7 +5,8 @@ constraint a[-1.2] == 3;
 
 solve satisfy;
 
-// flattening_failure <<<
-// attempt to use an invalid constant as an array index
-// @42..46: this must be a non-negative integer value
+// typecheck_failure <<<
+// attempt to index an array with a non-integer
+// @42..46: array access must be an int value
+// found access using type `real`
 // >>>

--- a/yurtc/tests/arrays/bad_indexed_value.yrt
+++ b/yurtc/tests/arrays/bad_indexed_value.yrt
@@ -4,8 +4,9 @@ constraint foo()[0] == 3;
 
 solve satisfy;
 
-// flattening_failure <<<
-// cannot index into value
-// @24..29: this must be an array
-// @30..31: invalid indexing here
+// This is pending whatever we decide for functions in the future.  For now we can't type-check an
+// unknown function like this.
+
+// typecheck_failure <<<
+// compiler internal error: unable to check type of FnCall
 // >>>

--- a/yurtc/tests/arrays/portfolio_optimization.yrt
+++ b/yurtc/tests/arrays/portfolio_optimization.yrt
@@ -42,7 +42,7 @@ constraint coeff[0][0] ==  0.08  &&
 // Amount invested in each asset 
 let x: real[4]; 
 constraint forall i in 0..3 {
-    x[i] >= 0 && x[i] <= 10000.0 * 10000.0
+    x[i] >= 0.0 && x[i] <= 10000.0 * 10000.0
 };
 
 // Invest no more than a total of B (Use a `fold` or `sum` here when available)

--- a/yurtc/tests/basic_tests/mismatch_enums.yrt
+++ b/yurtc/tests/basic_tests/mismatch_enums.yrt
@@ -4,7 +4,7 @@ enum Chord = FFlatDiminished | EMinorOverG;
 let saddest_sound: Chord;
 
 // Saddest key is D-minor.  Should produce type error since `saddest_sound` is a `Chord`.
-constraint saddest_sound == DMinor;
+constraint saddest_sound == Key::DMinor;
 
 solve satisfy;
 
@@ -12,12 +12,12 @@ solve satisfy;
 // var ::saddest_sound: ::Chord;
 // enum ::Key = CMajor | DMinor;
 // enum ::Chord = FFlatDiminished | EMinorOverG;
-// constraint (::saddest_sound == ::DMinor);
+// constraint (::saddest_sound == ::Key::DMinor);
 // solve satisfy;
 // >>>
 
-// We'll get this error until we implement enum desugaring.  But then we should get a `Chord` isn't
-// a `Key` type error.
-// compile_failure <<<
-// compiler internal error: Found unsupported types in final Intent.
+// typecheck_failure <<<
+// binary operator type error
+// @218..229: operator `==` argument has unexpected type `::Key`
+// @201..214: expecting type `::Chord`
 // >>>

--- a/yurtc/tests/basic_tests/reals.yrt
+++ b/yurtc/tests/basic_tests/reals.yrt
@@ -1,5 +1,5 @@
-let x: real = 1..4;
-let y: real = 1..4;
+let x: real = 1.0..4.0;
+let y: real = 1.0..4.0;
 
 constraint x + y == 3.3;
 
@@ -8,10 +8,10 @@ solve satisfy;
 // intermediate <<<
 // var ::x: real;
 // var ::y: real;
-// constraint (::x >= 1);
-// constraint (::x <= 4);
-// constraint (::y >= 1);
-// constraint (::y <= 4);
+// constraint (::x >= 1e0);
+// constraint (::x <= 4e0);
+// constraint (::y >= 1e0);
+// constraint (::y <= 4e0);
 // constraint ((::x + ::y) == 3.3e0);
 // solve satisfy;
 // >>>

--- a/yurtc/tests/basic_tests/tuples.yrt
+++ b/yurtc/tests/basic_tests/tuples.yrt
@@ -5,7 +5,7 @@ let t3: { x: int } = { 0, }; let t3_0 = t3.0; let t3_x = t3.x;
 let t4: { x: int } = { x: 0, }; let t4_0 = t4.0; let t4_x = t4.x;
 let t5: { x: int, } = { x: 0 }; let t5_0 = t5.0; let t5_x = t5.x;
 
-let t5a = { 0, 5.0 }; let t5a_0 = t5.0; let t5a_1 = t5.1;
+let t5a = { 0, 5.0 }; let t5a_0 = t5.0; let t5a_1 = t5a.1;
 let t6 = { x: 0, 5.0 }; let t6_0 = t6.0; let t6_x = t6.x; let t6_1 = t6.1;
 let t7: { x: int, real } = { 0, 5.0 }; let t7_0 = t7.0; let t7_x = t7.x; let t7_1 = t7.1;
 let t8: { x: int, real } = { x: 0, 5.0 }; let t8_0 = t8.0; let t8_x = t8.x; let t8_1 = t8.1;
@@ -109,7 +109,7 @@ let t14_z_w = t14.z.w;
 // constraint (::t5_x == ::t5.x);
 // constraint (::t5a == {0, 5e0});
 // constraint (::t5a_0 == ::t5.0);
-// constraint (::t5a_1 == ::t5.1);
+// constraint (::t5a_1 == ::t5a.1);
 // constraint (::t6 == {x: 0, 5e0});
 // constraint (::t6_0 == ::t6.0);
 // constraint (::t6_x == ::t6.x);
@@ -159,5 +159,5 @@ let t14_z_w = t14.z.w;
 
 // We'll get this error until we implement type inference.
 // compile_failure <<<
-// compiler internal error: Found untyped variable.
+// compiler internal error: Found unsupported types in final Intent.
 // >>>

--- a/yurtc/tests/cli.rs
+++ b/yurtc/tests/cli.rs
@@ -147,6 +147,7 @@ fn explicit_output() {
     check(&output.stdout, expect_test::expect![""]);
 }
 
+#[cfg(feature = "solver-scip")]
 #[test]
 fn solve() {
     let mut input_file = tempfile::NamedTempFile::new().unwrap();

--- a/yurtc/tests/forall/forall.yrt
+++ b/yurtc/tests/forall/forall.yrt
@@ -1,35 +1,51 @@
+let k: int;
+let l: int;
+let r: real;
+let A: int[4];
+let B: int[4];
+
 constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { k > i + j || j > k };
 constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { !(i - j < k) };
-constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { k == foo(i) + foo(j) };
+//constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { k == foo(i) + foo(j) };
 constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { if i > 0 { j > 0 } else { k > 1 } };
 constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { k in [i, j, l] };
 constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { A[i] != A[j] + k };
 constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { k in {i, j, l} };
 constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { {i, j, k}.0 != {i, j, k}.1 };
 constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { {i, j, k}.0 != {i, j, k}.1 };
-constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { i as real / j as real >= k };
+constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { i as real / j as real >= r };
 constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { i in j..k };
-constraint forall i in 0..3 { 
+constraint forall i in 0..3 {
     forall j in 0..3 {
-        A[i] < B[j] 
+        A[i] < B[j]
     }
 };
-constraint   forall i in 0..3 { A[i] != 0 } 
+constraint   forall i in 0..3 { A[i] != 0 }
           && forall j in 0..3 { A[j] != 0 };
 
 solve satisfy;
 
 // flattened <<<
+// var ::k: int;
+// var ::l: int;
+// var ::r: real;
+// var ::B[0]: int;
+// var ::A[0]: int;
+// var ::A[1]: int;
+// var ::A[2]: int;
+// var ::A[3]: int;
+// var ::B[1]: int;
+// var ::B[2]: int;
+// var ::B[3]: int;
 // constraint (((true && ((::k > (1 + 2)) || (2 > ::k))) && ((::k > (1 + 3)) || (3 > ::k))) && ((::k > (2 + 3)) || (3 > ::k)));
 // constraint (((true && !((1 - 2) < ::k)) && !((1 - 3) < ::k)) && !((2 - 3) < ::k));
-// constraint (((true && (::k == (::foo(1) + ::foo(2)))) && (::k == (::foo(1) + ::foo(3)))) && (::k == (::foo(2) + ::foo(3))));
 // constraint (((true && if (1 > 0) { (2 > 0) } else { (::k > 1) }) && if (1 > 0) { (3 > 0) } else { (::k > 1) }) && if (2 > 0) { (3 > 0) } else { (::k > 1) });
 // constraint (((true && ::k in [1, 2, ::l]) && ::k in [1, 3, ::l]) && ::k in [2, 3, ::l]);
 // constraint (((true && (::A[1] != (::A[2] + ::k))) && (::A[1] != (::A[3] + ::k))) && (::A[2] != (::A[3] + ::k)));
 // constraint (((true && ::k in {1, 2, ::l}) && ::k in {1, 3, ::l}) && ::k in {2, 3, ::l});
 // constraint (((true && ({1, 2, ::k}.0 != {1, 2, ::k}.1)) && ({1, 3, ::k}.0 != {1, 3, ::k}.1)) && ({2, 3, ::k}.0 != {2, 3, ::k}.1));
 // constraint (((true && ({1, 2, ::k}.0 != {1, 2, ::k}.1)) && ({1, 3, ::k}.0 != {1, 3, ::k}.1)) && ({2, 3, ::k}.0 != {2, 3, ::k}.1));
-// constraint (((true && ((1 as real / 2 as real) >= ::k)) && ((1 as real / 3 as real) >= ::k)) && ((2 as real / 3 as real) >= ::k));
+// constraint (((true && ((1 as real / 2 as real) >= ::r)) && ((1 as real / 3 as real) >= ::r)) && ((2 as real / 3 as real) >= ::r));
 // constraint (((true && 1 in 2..::k) && 1 in 3..::k) && 2 in 3..::k);
 // constraint ((((true && ((((true && (::A[0] < ::B[0])) && (::A[0] < ::B[1])) && (::A[0] < ::B[2])) && (::A[0] < ::B[3]))) && ((((true && (::A[1] < ::B[0])) && (::A[1] < ::B[1])) && (::A[1] < ::B[2])) && (::A[1] < ::B[3]))) && ((((true && (::A[2] < ::B[0])) && (::A[2] < ::B[1])) && (::A[2] < ::B[2])) && (::A[2] < ::B[3]))) && ((((true && (::A[3] < ::B[0])) && (::A[3] < ::B[1])) && (::A[3] < ::B[2])) && (::A[3] < ::B[3])));
 // constraint (((((true && (::A[0] != 0)) && (::A[1] != 0)) && (::A[2] != 0)) && (::A[3] != 0)) && ((((true && (::A[0] != 0)) && (::A[1] != 0)) && (::A[2] != 0)) && (::A[3] != 0)));

--- a/yurtc/tests/forall/invalid_bounds.yrt
+++ b/yurtc/tests/forall/invalid_bounds.yrt
@@ -1,9 +1,12 @@
+let j: int;
+let k: int;
+
 constraint forall i in j..k { true };
 
 solve satisfy;
 
 // flattening_failure <<<
 // invalid bound for `forall` index `i`
-// @23..24: invalid bound for `forall` index `i`
+// @48..49: invalid bound for `forall` index `i`
 // `forall` index bound must be an integer literal
 // >>>

--- a/yurtc/tests/forall/symbol_not_found.yrt
+++ b/yurtc/tests/forall/symbol_not_found.yrt
@@ -2,7 +2,7 @@ constraint forall i in 0..5 where j != 3 { true };
 
 solve satisfy;
 
-// flattening_failure <<<
+// typecheck_failure <<<
 // cannot find value `::j` in this scope
 // @34..35: not found in this scope
 // >>>

--- a/yurtc/tests/macros/macro_recursion_error_modules/main.yrt
+++ b/yurtc/tests/macros/macro_recursion_error_modules/main.yrt
@@ -6,7 +6,7 @@ solve satisfy;
 
 // parse_failure <<<
 // macro call is recursive
-// @26..42: macro '::b::@b_macro' is recursively called
-// @6..19: macro '::b::@b_macro' declared here
+// @26..42: macro `::b::@b_macro` is recursively called
+// @6..19: macro `::b::@b_macro` declared here
 // a macro called recursively with the same number of arguments will cause a non-terminating loop during expansion
 // >>>

--- a/yurtc/tests/macros/macro_recursion_error_mutual.yrt
+++ b/yurtc/tests/macros/macro_recursion_error_mutual.yrt
@@ -16,7 +16,7 @@ solve satisfy;
 
 // parse_failure <<<
 // macro call is recursive
-// @103..109: macro '::@a' is recursively called
-// @6..12: macro '::@a' declared here
+// @103..109: macro `::@a` is recursively called
+// @6..12: macro `::@a` declared here
 // a macro called recursively with the same number of arguments will cause a non-terminating loop during expansion
 // >>>

--- a/yurtc/tests/macros/macro_recursion_error_self.yrt
+++ b/yurtc/tests/macros/macro_recursion_error_self.yrt
@@ -8,7 +8,7 @@ solve satisfy;
 
 // parse_failure <<<
 // macro call is recursive
-// @27..33: macro '::@m' is recursively called
-// @6..12: macro '::@m' declared here
+// @27..33: macro `::@m` is recursively called
+// @6..12: macro `::@m` declared here
 // a macro called recursively with the same number of arguments will cause a non-terminating loop during expansion
 // >>>

--- a/yurtc/tests/modules/00/main.yrt
+++ b/yurtc/tests/modules/00/main.yrt
@@ -12,7 +12,10 @@ solve satisfy;
 // solve satisfy;
 // >>>
 
-// We'll get this error until we implement type inference.
-// compile_failure <<<
-// compiler internal error: Found untyped variable.
+// compiled_intent <<<
+// var ::a: int;
+// var ::b::b: int;
+// constraint (::a == ::b::b);
+// constraint (::b::b == 1);
+// solve satisfy;
 // >>>

--- a/yurtc/tests/modules/02/main.yrt
+++ b/yurtc/tests/modules/02/main.yrt
@@ -1,3 +1,8 @@
+// <disabled>
+//
+// I'm disabling this for now due to type checking and functions.  This one _could_ be type checked,
+// since `hello_world()` is well defined, but external functions are currently getting redesigned.
+
 use a::b;
 
 extern {

--- a/yurtc/tests/modules/04/debbie.yrt
+++ b/yurtc/tests/modules/04/debbie.yrt
@@ -1,3 +1,3 @@
 enum Skill = GlamourShots | Handicrafts;
 
-let debbie_skill = Skill::GlamourShots || Skill::Handicrafts;
+let debbie_skill = Skill::GlamourShots;

--- a/yurtc/tests/modules/04/main.yrt
+++ b/yurtc/tests/modules/04/main.yrt
@@ -3,7 +3,7 @@
 enum Skill = Nunchuck | BowHunting | ComputerHacking;
 
 let pedro_skill: Skill;
-constraint pedro_skill == Skill::Nunchuck || Skill::BowHunting;
+constraint pedro_skill == Skill::Nunchuck || pedro_skill == Skill::BowHunting;
 
 let kip_skill: kip::Skill;
 
@@ -19,10 +19,10 @@ solve satisfy;
 // enum ::Skill = Nunchuck | BowHunting | ComputerHacking;
 // enum ::kip::Skill = ChattingOnlineWithBabes | CageFighting;
 // enum ::debbie::Skill = GlamourShots | Handicrafts;
-// constraint ((::pedro_skill == ::Skill::Nunchuck) || ::Skill::BowHunting);
+// constraint ((::pedro_skill == ::Skill::Nunchuck) || (::pedro_skill == ::Skill::BowHunting));
 // constraint ((::debbie::debbie_skill == ::debbie::Skill::Handicrafts) && (::kip_skill == ::kip::Skill::CageFighting));
 // constraint (::kip::kip_skill == ::kip::Skill::ChattingOnlineWithBabes);
-// constraint (::debbie::debbie_skill == (::debbie::Skill::GlamourShots || ::debbie::Skill::Handicrafts));
+// constraint (::debbie::debbie_skill == ::debbie::Skill::GlamourShots);
 // solve satisfy;
 // >>>
 

--- a/yurtc/tests/modules/05/main.yrt
+++ b/yurtc/tests/modules/05/main.yrt
@@ -1,20 +1,31 @@
-
 use ::a_mod::a;
 
-constraint a > c;
+constraint a > b_mod::c_mod::c;
+
+solve satisfy;
 
 // intermediate <<<
-// var ::a_mod::a;
-// var ::b_mod::k;
 // var ::b_mod::c_mod::c;
 // var ::b_mod::e_mod::f_mod::f;
-// constraint (::a_mod::a > ::c);
-// constraint (::a_mod::a == (::b_mod::c_mod::c + ::b_mod::k));
-// constraint (::b_mod::k == ::b_mod::c_mod::c);
+// var ::a_mod::a;
+// var ::b_mod::k;
+// constraint (::a_mod::a > ::b_mod::c_mod::c);
 // constraint (::b_mod::c_mod::c == ::b_mod::e_mod::f_mod::f);
 // constraint (::b_mod::e_mod::f_mod::f == 5);
+// constraint (::a_mod::a == (::b_mod::c_mod::c + ::b_mod::k));
+// constraint (::b_mod::k == ::b_mod::c_mod::c);
+// solve satisfy;
 // >>>
 
-// compile_failure <<<
-// compiler internal error: Found untyped variable.
+// compiled_intent <<<
+// var ::b_mod::c_mod::c: int;
+// var ::b_mod::e_mod::f_mod::f: int;
+// var ::a_mod::a: int;
+// var ::b_mod::k: int;
+// constraint (::a_mod::a > ::b_mod::c_mod::c);
+// constraint (::b_mod::c_mod::c == ::b_mod::e_mod::f_mod::f);
+// constraint (::b_mod::e_mod::f_mod::f == 5);
+// constraint (::a_mod::a == (::b_mod::c_mod::c + ::b_mod::k));
+// constraint (::b_mod::k == ::b_mod::c_mod::c);
+// solve satisfy;
 // >>>

--- a/yurtc/tests/modules/06/main.yrt
+++ b/yurtc/tests/modules/06/main.yrt
@@ -35,5 +35,5 @@ enum U = V | W;
 // >>>
 
 // compile_failure <<<
-// compiler internal error: Found untyped variable.
+// compiler internal error: Found unsupported types in final Intent.
 // >>>

--- a/yurtc/tests/modules/08/main.yrt
+++ b/yurtc/tests/modules/08/main.yrt
@@ -29,5 +29,5 @@ let b_variant = d::MyEnum::B;
 // >>>
 
 // compile_failure <<<
-// compiler internal error: Found untyped variable.
+// compiler internal error: Found unsupported types in final Intent.
 // >>>

--- a/yurtc/tests/modules/foralls_abound/b.yrt
+++ b/yurtc/tests/modules/foralls_abound/b.yrt
@@ -1,0 +1,6 @@
+let bry: int[4];
+
+constraint forall i in 1..3 {
+    bry[i] < bry[i - 1]
+};
+

--- a/yurtc/tests/modules/foralls_abound/main.yrt
+++ b/yurtc/tests/modules/foralls_abound/main.yrt
@@ -1,0 +1,22 @@
+// <disabled>
+//
+// Due to bug? in forall unrolling in the `b` module.
+
+let ary: int[4];
+
+constraint forall i in 0..2 {
+    ary[i] > ary[i + 1]
+};
+
+constraint ary[0] == b::bry[0];
+
+solve satisfy;
+
+// intermediate <<<
+// var ::ary: int[4];
+// var ::b::bry: int[4];
+// constraint forall i in 0..2, { (::ary[::i] > ::ary[(::i + 1)]) };
+// constraint (::ary[0] == ::b::bry[0]);
+// constraint forall i in 1..3, { (::b::bry[::b::i] < ::b::bry[(::b::i - 1)]) };
+// solve satisfy;
+// >>>

--- a/yurtc/tests/types/bad_tuple_name_index.yrt
+++ b/yurtc/tests/types/bad_tuple_name_index.yrt
@@ -1,0 +1,11 @@
+let a = { x: 11, y: 22.2 };
+
+constraint a.z > 33;
+
+solve satisfy;
+
+// typecheck_failure <<<
+// invalid tuple accessor
+// @40..43: unable to get field from tuple using `z`
+// tuple has type `{x: int, y: real}`
+// >>>

--- a/yurtc/tests/types/bad_tuple_num_index.yrt
+++ b/yurtc/tests/types/bad_tuple_num_index.yrt
@@ -1,0 +1,11 @@
+let a = { 11, 22, 33 };
+
+constraint a.4 == 44;
+
+solve satisfy;
+
+// typecheck_failure <<<
+// invalid tuple accessor
+// @36..39: unable to get field from tuple using `4`
+// tuple has type `{int, int, int}`
+// >>>

--- a/yurtc/tests/types/binary_ops.yrt
+++ b/yurtc/tests/types/binary_ops.yrt
@@ -1,0 +1,36 @@
+// We don't have error recovery in the middle end yet so it'll bail on the first one.
+// When we do, these should all be errors.
+
+let a = 11 + false;
+let b = 22 - true;
+let c = [1,2] * 33;
+let d = "four" / 44;
+
+enum T = FortyTwo | FleventyFive;
+let e = 55 % T::FortyTwo;
+
+// Numerics are allowed, but they must match.
+let f = 66 + 77.7;
+let g = 88 - 99.9;
+let h = 10.10 * 11;
+let i = 12 / 13.13;
+let j = 14.14 % 15;
+
+// `==` and `!=` take any type but they must be equivalent.
+let k = 16 == T::FleventyFive;
+let l = 17 != true;
+
+let m = true > false;
+let n = 18 >= 19.19;
+let o = 20 < "21";
+let p = 22 <= [23, 23];
+
+let q = true && 24;
+let r = 25.25 || false;
+
+solve satisfy;
+
+// typecheck_failure <<<
+// binary operator type error
+// @143..148: operator `+` argument has unexpected type `bool`
+// >>>

--- a/yurtc/tests/types/clashing_array_indices.yrt
+++ b/yurtc/tests/types/clashing_array_indices.yrt
@@ -1,0 +1,34 @@
+let a: int[4];
+let b: int[4];
+
+// The inner `i` is shadowing the outer `i` which is probably not what we want to allow, considering
+// we disallow shadowing everywhere else in Yurt.
+
+constraint forall i in 0..3 {
+    b[i] == i &&
+    forall i in 0..3 {
+        a[i] > b[i]
+    }
+};
+
+solve satisfy;
+
+// intermediate <<<
+// var ::a: int[4];
+// var ::b: int[4];
+// constraint forall i in 0..3, { ((::b[::i] == ::i) && forall i in 0..3, { (::a[::i] > ::b[::i]) }) };
+// solve satisfy;
+// >>>
+
+// flattened <<<
+// var ::b[0]: int;
+// var ::a[0]: int;
+// var ::a[1]: int;
+// var ::a[2]: int;
+// var ::a[3]: int;
+// var ::b[1]: int;
+// var ::b[2]: int;
+// var ::b[3]: int;
+// constraint ((((true && ((::b[0] == 0) && ((((true && (::a[0] > ::b[0])) && (::a[1] > ::b[1])) && (::a[2] > ::b[2])) && (::a[3] > ::b[3])))) && ((::b[1] == 1) && ((((true && (::a[0] > ::b[0])) && (::a[1] > ::b[1])) && (::a[2] > ::b[2])) && (::a[3] > ::b[3])))) && ((::b[2] == 2) && ((((true && (::a[0] > ::b[0])) && (::a[1] > ::b[1])) && (::a[2] > ::b[2])) && (::a[3] > ::b[3])))) && ((::b[3] == 3) && ((((true && (::a[0] > ::b[0])) && (::a[1] > ::b[1])) && (::a[2] > ::b[2])) && (::a[3] > ::b[3]))));
+// solve satisfy;
+// >>>

--- a/yurtc/tests/types/clashing_enums.yrt
+++ b/yurtc/tests/types/clashing_enums.yrt
@@ -1,0 +1,28 @@
+enum AttackingBird = Goose | Duck | Chicken;
+enum AppropriateDefence = Kick | Runaway | Duck | StareDown;
+
+macro @panicked_response($bird) {
+    if $bird != ::AttackingBird::Goose {
+        Duck
+    } else {
+        Kick
+    }
+}
+
+let unfortunate_action = @panicked_response(AttackingBird::Goose);
+
+solve satisfy;
+
+// intermediate <<<
+// var ::unfortunate_action;
+// enum ::AttackingBird = Goose | Duck | Chicken;
+// enum ::AppropriateDefence = Kick | Runaway | Duck | StareDown;
+// constraint (::unfortunate_action == if (::AttackingBird::Goose != ::AttackingBird::Goose) { ::Duck } else { ::Kick });
+// solve satisfy;
+// >>>
+
+// typecheck_failure <<<
+// cannot find value `::Duck` in this scope
+// @190..194: not found in this scope
+// this symbol is a variant of enums `::AttackingBird` and `::AppropriateDefence` and may need a fully qualified path
+// >>>

--- a/yurtc/tests/types/empty_array.yrt
+++ b/yurtc/tests/types/empty_array.yrt
@@ -1,0 +1,10 @@
+let ary: int[10];
+
+constraint ary != [];
+
+solve satisfy;
+
+// typecheck_failure <<<
+// illegal empty array value
+// @37..39: empty array values are illegal
+// >>>

--- a/yurtc/tests/types/enum_variant_unqualified.yrt
+++ b/yurtc/tests/types/enum_variant_unqualified.yrt
@@ -1,0 +1,12 @@
+enum Foo = Bar | Baz;
+enum Bar = Baz | Xyzzy;
+
+let a = Baz;
+
+solve satisfy;
+
+// typecheck_failure <<<
+// cannot find value `::Baz` in this scope
+// @55..58: not found in this scope
+// this symbol is a variant of enums `::Foo` and `::Bar` and may need a fully qualified path
+// >>>

--- a/yurtc/tests/types/heterogeneous_array.yrt
+++ b/yurtc/tests/types/heterogeneous_array.yrt
@@ -1,0 +1,11 @@
+let ary: int[4];
+
+constraint ary == [1, true, 22.2, "foo"];
+
+solve satisfy;
+
+// typecheck_failure <<<
+// array element type mismatch
+// @40..44: array element has type `bool`
+// expecting array element type `int`
+// >>>

--- a/yurtc/tests/types/if_branches.yrt
+++ b/yurtc/tests/types/if_branches.yrt
@@ -1,0 +1,9 @@
+let a: int = if true { 11 } else { 22.2 };
+
+solve satisfy;
+
+// typecheck_failure <<<
+// branches in if-expression must have the same type
+// @23..25: 'then' branch has the type `int`
+// @35..39: 'else' branch has the type `real`
+// >>>

--- a/yurtc/tests/types/if_cond.yrt
+++ b/yurtc/tests/types/if_cond.yrt
@@ -1,0 +1,13 @@
+let a = 11;
+let b: int;
+let c = false;
+
+constraint b < if c { 22 } else { 33 };
+constraint b > if a { 44 } else { 55 };
+
+solve satisfy;
+
+// typecheck_failure <<<
+// condition in if-expression must be a boolean
+// @98..99: condition must be a boolean
+// >>>

--- a/yurtc/tests/types/non_array_access.yrt
+++ b/yurtc/tests/types/non_array_access.yrt
@@ -1,0 +1,10 @@
+let a: real;
+
+constraint a[0] == a[1];
+
+solve satisfy;
+
+// typecheck_failure <<<
+// attempt to access array element from a non-array value
+// @25..29: value must be an array; found `real`
+// >>>

--- a/yurtc/tests/types/non_int_array_access.yrt
+++ b/yurtc/tests/types/non_int_array_access.yrt
@@ -1,0 +1,11 @@
+let ary: int[2];
+
+constraint ary[false] == ary[11.1];
+
+solve satisfy;
+
+// typecheck_failure <<<
+// attempt to index an array with a non-integer
+// @33..38: array access must be an int value
+// found access using type `bool`
+// >>>

--- a/yurtc/tests/types/non_tuple_access.yrt
+++ b/yurtc/tests/types/non_tuple_access.yrt
@@ -1,0 +1,10 @@
+let a: bool;
+
+constraint a.0 == a.bar;
+
+solve satisfy;
+
+// typecheck_failure <<<
+// attempt to access tuple field from a non-tuple value
+// @25..28: value must be a tuple; found `bool`
+// >>>

--- a/yurtc/tests/types/recursive_array_vars.yrt
+++ b/yurtc/tests/types/recursive_array_vars.yrt
@@ -1,0 +1,11 @@
+let a = [c[1], b];
+let b = c[1];
+let c = [[b][0], a[1]];
+
+solve satisfy;
+
+// typecheck_failure <<<
+// expression has a recursive dependency
+// @27..28: cannot determine type of expression due to dependency
+// @41..55: dependency on expression is recursive
+// >>>

--- a/yurtc/tests/types/recursive_scalar_vars.yrt
+++ b/yurtc/tests/types/recursive_scalar_vars.yrt
@@ -1,0 +1,11 @@
+let a = b + c;
+let b = c + a;
+let c = a - b;
+
+solve satisfy;
+
+// typecheck_failure <<<
+// expression has a recursive dependency
+// @8..13: cannot determine type of expression due to dependency
+// @8..9: dependency on expression is recursive
+// >>>

--- a/yurtc/tests/types/unary_ops.yrt
+++ b/yurtc/tests/types/unary_ops.yrt
@@ -1,0 +1,15 @@
+// We don't have error recovery in the middle end yet so it'll bail on the first one.
+// When we do, these should all be errors.
+
+let a = -true;
+let b = -{1,2};
+
+let c = !11;
+let d = !"sure";
+
+solve satisfy;
+
+// typecheck_failure <<<
+// unary operator type error
+// @138..143: operator `-` argument has unexpected type `bool`
+// >>>


### PR DESCRIPTION
This change performs a type check of all the expressions in the intermediate intent, after parsing and before flattening.

All the expression types, decision var types and state types are saved in there for use afterwards.

There is a new `modules/foralls_abound` test which should pass but is disabled.  I think there's aproblem with unrolling `forall`s in sub-modules, I'm not sure, and I'll make a new issue to investigate.