### PR TITLE
Add support for macros calling other local macros in sub-modules.

### DIFF
--- a/yurtc/src/lexer/tests.rs
+++ b/yurtc/src/lexer/tests.rs
@@ -292,7 +292,7 @@ fn macros_success() {
     let path = Rc::from(Path::new("test"));
 
     // Simple success cases.
-    let mut toks = Lexer::new("macro @name()", &Rc::clone(&path));
+    let mut toks = Lexer::new("macro @name()", &Rc::clone(&path), &[]);
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Macro, _)));
     assert_eq!(
         toks.next().unwrap().unwrap().1,
@@ -302,7 +302,7 @@ fn macros_success() {
     assert!(matches!(toks.next().unwrap().unwrap(), (_, ParenClose, _)));
     assert!(toks.next().is_none());
 
-    let mut toks = Lexer::new("macro @name_x11($a)", &Rc::clone(&path));
+    let mut toks = Lexer::new("macro @name_x11($a)", &Rc::clone(&path), &[]);
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Macro, _)));
     assert_eq!(
         toks.next().unwrap().unwrap().1,
@@ -313,7 +313,7 @@ fn macros_success() {
     assert!(matches!(toks.next().unwrap().unwrap(), (_, ParenClose, _)));
     assert!(toks.next().is_none());
 
-    let mut toks = Lexer::new("macro @name($Z, $9)", &Rc::clone(&path));
+    let mut toks = Lexer::new("macro @name($Z, $9)", &Rc::clone(&path), &[]);
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Macro, _)));
     assert_eq!(
         toks.next().unwrap().unwrap().1,
@@ -326,7 +326,7 @@ fn macros_success() {
     assert!(matches!(toks.next().unwrap().unwrap(), (_, ParenClose, _)));
     assert!(toks.next().is_none());
 
-    let mut toks = Lexer::new("macro @name($Z, $9,)", &Rc::clone(&path));
+    let mut toks = Lexer::new("macro @name($Z, $9,)", &Rc::clone(&path), &[]);
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Macro, _)));
     assert_eq!(
         toks.next().unwrap().unwrap().1,
@@ -340,7 +340,7 @@ fn macros_success() {
     assert!(matches!(toks.next().unwrap().unwrap(), (_, ParenClose, _)));
     assert!(toks.next().is_none());
 
-    let mut toks = Lexer::new("macro @name() {} constraint", &Rc::clone(&path));
+    let mut toks = Lexer::new("macro @name() {} constraint", &Rc::clone(&path), &[]);
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Macro, _)));
     assert_eq!(
         toks.next().unwrap().unwrap().1,
@@ -355,7 +355,11 @@ fn macros_success() {
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Constraint, _)));
     assert!(toks.next().is_none());
 
-    let mut toks = Lexer::new(r#"macro @name() { let it "be" 88 ; }"#, &Rc::clone(&path));
+    let mut toks = Lexer::new(
+        r#"macro @name() { let it "be" 88 ; }"#,
+        &Rc::clone(&path),
+        &[],
+    );
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Macro, _)));
     assert_eq!(
         toks.next().unwrap().unwrap().1,
@@ -381,7 +385,11 @@ fn macros_success() {
     }
 
     // Nested braces.
-    let mut toks = Lexer::new("macro @name() { a { b}{{}c}{ d }} let", &Rc::clone(&path));
+    let mut toks = Lexer::new(
+        "macro @name() { a { b}{{}c}{ d }} let",
+        &Rc::clone(&path),
+        &[],
+    );
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Macro, _)));
     assert_eq!(
         toks.next().unwrap().unwrap().1,
@@ -422,7 +430,7 @@ fn macros_badly_formed() {
     let path = Rc::from(Path::new("test"));
 
     // Macro name has no `@`, should not parse the body.
-    let mut toks = Lexer::new("macro bad() { 11 }", &Rc::clone(&path));
+    let mut toks = Lexer::new("macro bad() { 11 }", &Rc::clone(&path), &[]);
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Macro, _)));
     assert_eq!(
         toks.next().unwrap().unwrap().1,
@@ -436,7 +444,7 @@ fn macros_badly_formed() {
     assert!(toks.next().is_none());
 
     // Macro params have no `$`, should not parse the body.
-    let mut toks = Lexer::new("macro @name(bad, param) { 22 }", &Rc::clone(&path));
+    let mut toks = Lexer::new("macro @name(bad, param) { 22 }", &Rc::clone(&path), &[]);
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Macro, _)));
     assert_eq!(
         toks.next().unwrap().unwrap().1,
@@ -458,7 +466,7 @@ fn macros_badly_formed() {
     assert!(matches!(toks.next().unwrap().unwrap(), (_, BraceClose, _)));
     assert!(toks.next().is_none());
 
-    let mut toks = Lexer::new("macro @name($good, bad) { 33 }", &Rc::clone(&path));
+    let mut toks = Lexer::new("macro @name($good, bad) { 33 }", &Rc::clone(&path), &[]);
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Macro, _)));
     assert_eq!(
         toks.next().unwrap().unwrap().1,
@@ -481,7 +489,7 @@ fn macros_badly_formed() {
     assert!(toks.next().is_none());
 
     // Badly nested braces, should backtrack.
-    let mut toks = Lexer::new("macro @name() { { } let", &Rc::clone(&path));
+    let mut toks = Lexer::new("macro @name() { { } let", &Rc::clone(&path), &[]);
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Macro, _)));
     assert_eq!(
         toks.next().unwrap().unwrap().1,
@@ -503,7 +511,7 @@ fn macros_call_success() {
 
     let path = Rc::from(Path::new("test"));
 
-    let mut toks = Lexer::new("@name()", &Rc::clone(&path));
+    let mut toks = Lexer::new("@name()", &Rc::clone(&path), &[]);
     assert_eq!(
         toks.next().unwrap().unwrap().1,
         MacroName("@name".to_owned()),
@@ -517,7 +525,7 @@ fn macros_call_success() {
         unreachable!()
     }
 
-    let mut toks = Lexer::new("11 + @name()", &Rc::clone(&path));
+    let mut toks = Lexer::new("11 + @name()", &Rc::clone(&path), &[]);
     assert_eq!(toks.next().unwrap().unwrap().1, IntLiteral("11".to_owned()),);
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Plus, _)));
     assert_eq!(
@@ -530,7 +538,7 @@ fn macros_call_success() {
     ));
     assert!(toks.next().is_none());
 
-    let mut toks = Lexer::new("@name(int)", &Rc::clone(&path));
+    let mut toks = Lexer::new("@name(int)", &Rc::clone(&path), &[]);
     assert_eq!(
         toks.next().unwrap().unwrap().1,
         MacroName("@name".to_owned()),
@@ -546,7 +554,7 @@ fn macros_call_success() {
         unreachable!()
     }
 
-    let mut toks = Lexer::new("@name(int; foo) || true", &Rc::clone(&path));
+    let mut toks = Lexer::new("@name(int; foo) || true", &Rc::clone(&path), &[]);
     assert_eq!(
         toks.next().unwrap().unwrap().1,
         MacroName("@name".to_owned()),
@@ -566,7 +574,7 @@ fn macros_call_success() {
         unreachable!()
     }
 
-    let mut toks = Lexer::new("@name(1 + 2; [1, 2];)", &Rc::clone(&path));
+    let mut toks = Lexer::new("@name(1 + 2; [1, 2];)", &Rc::clone(&path), &[]);
     assert_eq!(
         toks.next().unwrap().unwrap().1,
         MacroName("@name".to_owned()),
@@ -590,7 +598,7 @@ fn macros_call_success() {
         unreachable!()
     }
 
-    let mut toks = Lexer::new("@name(let i: int = 0;)", &Rc::clone(&path));
+    let mut toks = Lexer::new("@name(let i: int = 0;)", &Rc::clone(&path), &[]);
     assert_eq!(
         toks.next().unwrap().unwrap().1,
         MacroName("@name".to_owned()),
@@ -611,7 +619,7 @@ fn macros_call_success() {
         unreachable!()
     }
 
-    let mut toks = Lexer::new("@name(1,2,3,4,5,6,7,8)", &Rc::clone(&path));
+    let mut toks = Lexer::new("@name(1,2,3,4,5,6,7,8)", &Rc::clone(&path), &[]);
     assert_eq!(
         toks.next().unwrap().unwrap().1,
         MacroName("@name".to_owned()),
@@ -643,7 +651,7 @@ fn macros_call_badly_formed() {
     let path = Rc::from(Path::new("test"));
 
     // Macro name has no `@`.
-    let mut toks = Lexer::new("1 + name() + 2", &Rc::clone(&path));
+    let mut toks = Lexer::new("1 + name() + 2", &Rc::clone(&path), &[]);
     assert_eq!(toks.next().unwrap().unwrap().1, IntLiteral("1".to_owned()),);
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Plus, _)));
     assert!(matches!(toks.next().unwrap().unwrap(), (_, Ident(_), _)));
@@ -654,7 +662,7 @@ fn macros_call_badly_formed() {
     assert!(toks.next().is_none());
 
     // No closing paren, should backtrack.
-    let mut toks = Lexer::new("@name(one; two", &Rc::clone(&path));
+    let mut toks = Lexer::new("@name(one; two", &Rc::clone(&path), &[]);
     assert_eq!(
         toks.next().unwrap().unwrap().1,
         MacroName("@name".to_owned()),

--- a/yurtc/src/main.rs
+++ b/yurtc/src/main.rs
@@ -43,13 +43,13 @@ fn main() -> anyhow::Result<()> {
     // numbers, etc.) and so, we can solve more intents than we can generate assembly for. When
     // this changes, we will always generate assembly and only solve when requested via `--solve`.
     if args.solve {
-        let flattened = &flattened.iis.get(&"".to_string()).unwrap();
         if args.solve && !cfg!(feature = "solver-scip") {
             eprintln!("Solving is disabled in this build.");
         }
 
         #[cfg(feature = "solver-scip")]
         if args.solve {
+            let flattened = &flattened.iis.get(&"".to_string()).unwrap();
             let flatyurt = match yurt_solve::parse_flatyurt(&format!("{flattened}")[..]) {
                 Ok(flatyurt) => flatyurt,
                 Err(err) => {

--- a/yurtc/src/parser.rs
+++ b/yurtc/src/parser.rs
@@ -127,8 +127,8 @@ impl ProjectParser {
             }
 
             let keys = self.macro_calls.keys().cloned().collect::<Vec<_>>();
-            for current_ii in keys.clone() {
-                let macro_calls = self.macro_calls.get_mut(&current_ii).unwrap();
+            for current_ii in &keys {
+                let macro_calls = self.macro_calls.get_mut(current_ii).unwrap();
 
                 // Expand the next call. It may find new paths.
                 if let Some(call_key) = macro_calls.keys().nth(0) {
@@ -346,7 +346,7 @@ impl ProjectParser {
 
         parse_with!(
             self,
-            lexer::Lexer::new(&src_str, src_path),
+            lexer::Lexer::new(&src_str, src_path, mod_path),
             yurt_parser::YurtParser::new(),
             src_path,
             mod_path,
@@ -368,7 +368,7 @@ impl ProjectParser {
         self.unique_idx += 1;
         parse_with!(
             self,
-            lexer::Lexer::from_tokens(tokens, src_path),
+            lexer::Lexer::from_tokens(tokens, src_path, mod_path),
             yurt_parser::MacroBodyParser::new(),
             src_path,
             mod_path,

--- a/yurtc/src/parser/tests.rs
+++ b/yurtc/src/parser/tests.rs
@@ -27,7 +27,7 @@ macro_rules! parse_and_collect_errors {
         match $parser.parse(
             &mut $context,
             &mut errors,
-            lexer::Lexer::new($source, &filepath),
+            lexer::Lexer::new($source, &filepath, &[]),
         ) {
             Ok(result) => {
                 if errors.is_empty() {

--- a/yurtc/src/parser/use_path.rs
+++ b/yurtc/src/parser/use_path.rs
@@ -131,7 +131,7 @@ fn gather_use_paths() {
                     next_paths: &mut Vec::new(),
                 },
                 &mut Vec::new(),
-                crate::lexer::Lexer::new(src, &filepath),
+                crate::lexer::Lexer::new(src, &filepath, &[]),
             )
             .expect("Failed to parse test case.")
             .gather_paths()

--- a/yurtc/src/yurt_parser.lalrpop
+++ b/yurtc/src/yurt_parser.lalrpop
@@ -874,7 +874,7 @@ MacroCallExpr: ExprKey = {
             mod_path: context.mod_path.to_vec(),
             args,
             span: span.clone(),
-            tag: tag.flatten(),
+            parent_tag: tag.flatten(),
         };
         let call_expr_key = context.current_ii().exprs.insert(Expr::MacroCall {
             call: call_key,
@@ -1306,6 +1306,6 @@ extern {
         "macro_param_pack" => lexer::Token::MacroParamPack(<String>),
         "macro_body" => lexer::Token::MacroBody(<Vec<(usize, lexer::Token, usize)>>),
         "macro_call_args" => lexer::Token::MacroCallArgs(<Vec<Vec<(usize, lexer::Token, usize)>>>),
-        "macro_tag" => lexer::Token::MacroTag(<Option<u64>>),
+        "macro_tag" => lexer::Token::MacroTag(<Option<usize>>),
     }
 }

--- a/yurtc/tests/macros/macros_in_modules/g.yrt
+++ b/yurtc/tests/macros/macros_in_modules/g.yrt
@@ -1,0 +1,8 @@
+macro @g_macro($a, $b, $c) {
+    @g_local($a; $b);
+    @g_local($b; $c);
+}
+
+macro @g_local($x, $y) {
+    constraint $x != $y;
+}

--- a/yurtc/tests/macros/macros_in_modules/main.yrt
+++ b/yurtc/tests/macros/macros_in_modules/main.yrt
@@ -21,6 +21,10 @@ constraint a != d;
 
 constraint @e_macro(a);
 
+// A macro in ::g which in turn calls another macro in ::g -- local expansion still needs to resolve
+// the other ::g macro properly (i.e., not locally).
+g::@g_macro(55; 66; 77);
+
 solve satisfy;
 
 // intermediate <<<
@@ -31,6 +35,8 @@ solve satisfy;
 // constraint (::a != ::d::d);
 // constraint ((::a % 3) == 0);
 // constraint (::d::d == 44);
+// constraint (55 != 66);
+// constraint (66 != 77);
 // solve satisfy;
 // >>>
 
@@ -42,5 +48,7 @@ solve satisfy;
 // constraint (::a != ::d::d);
 // constraint ((::a % 3) == 0);
 // constraint (::d::d == 44);
+// constraint (55 != 66);
+// constraint (66 != 77);
 // solve satisfy;
 // >>>


### PR DESCRIPTION
Closes #504.  Adds a hack for the edge case where a macro in a module calls a local macro.  Prior to this change the local macro was resolved in the caller scope which is wrong.  Now it is detected during expansion and converted to use an absolute path so the resolution is correct.

This change uncovered a bug in the recursion detection which I had to tweak.