### PR TITLE
Error handler + recovery in the middleend

### DIFF
--- a/tests/solver_tests.rs
+++ b/tests/solver_tests.rs
@@ -17,20 +17,35 @@ fn solver_e2e() {
             path.push("main.yrt");
         }
 
+        // Error handler
+        let handler = yurtc::error::Handler::default();
+
         // Produce the initial `IntermediateIntent`
         let parsed = unwrap_or_continue!(
-            yurtc::parser::parse_project(&path),
+            yurtc::parser::parse_project(&handler, &path),
             "parse yurt",
             failed_tests,
-            path
+            path,
+            handler
         );
 
         // Parsed II -> Type-checked II
-        let type_checked =
-            unwrap_or_continue!(parsed.type_check(), "type check", failed_tests, path);
+        let type_checked = unwrap_or_continue!(
+            parsed.type_check(&handler),
+            "type check",
+            failed_tests,
+            path,
+            handler
+        );
 
         // Type checked II -> Flattened II
-        let flattened = unwrap_or_continue!(type_checked.flatten(), "flatten", failed_tests, path);
+        let flattened = unwrap_or_continue!(
+            type_checked.flatten(&handler),
+            "flatten",
+            failed_tests,
+            path,
+            handler
+        );
 
         // Flattened II -> FlatYurt
         #[allow(unused)]

--- a/tests/validation_tests.rs
+++ b/tests/validation_tests.rs
@@ -35,23 +35,34 @@ fn deploy(server: &mut Server) -> anyhow::Result<()> {
             path.push("main.yrt");
         }
 
+        // Error handler
+        let handler = yurtc::error::Handler::default();
+
         // Produce the initial parsed program
         let parsed = unwrap_or_continue!(
-            yurtc::parser::parse_project(&path),
+            yurtc::parser::parse_project(&handler, &path),
             "parse yurt",
             failed_tests,
-            path
+            path,
+            handler
         );
 
         // Parsed program -> Flattened program
-        let flattened = unwrap_or_continue!(parsed.compile(), "compile", failed_tests, path);
+        let flattened = unwrap_or_continue!(
+            parsed.compile(&handler),
+            "compile",
+            failed_tests,
+            path,
+            handler
+        );
 
         // Flattened program -> Assembly (aka collection of Intents)
         let intents = unwrap_or_continue!(
-            yurtc::asm_gen::program_to_intents(&flattened),
+            yurtc::asm_gen::program_to_intents(&handler, &flattened),
             "asm gen",
             failed_tests,
-            path
+            path,
+            handler
         );
 
         // Get the addresses of all produced persistent intents
@@ -127,23 +138,34 @@ fn submit_and_check_solution(server: &mut Server) -> anyhow::Result<()> {
 
         println!("Submitting {}.", entry.path().display());
 
+        // Error handler
+        let handler = yurtc::error::Handler::default();
+
         // Produce the initial parsed program
         let parsed = unwrap_or_continue!(
-            yurtc::parser::parse_project(&path),
+            yurtc::parser::parse_project(&handler, &path),
             "parse yurt",
             failed_tests,
-            path
+            path,
+            handler
         );
 
         // Parsed program -> Flattened program
-        let flattened = unwrap_or_continue!(parsed.compile(), "compile", failed_tests, path);
+        let flattened = unwrap_or_continue!(
+            parsed.compile(&handler),
+            "compile",
+            failed_tests,
+            path,
+            handler
+        );
 
         // Flattened program -> Assembly (aka collection of Intents)
         let intents = unwrap_or_continue!(
-            yurtc::asm_gen::program_to_intents(&flattened),
+            yurtc::asm_gen::program_to_intents(&handler, &flattened),
             "asm gen",
             failed_tests,
-            path
+            path,
+            handler
         );
 
         // Extract the transient intent. There should be a single intent in `intents`.

--- a/yurtc/src/asm_gen/tests.rs
+++ b/yurtc/src/asm_gen/tests.rs
@@ -1,5 +1,6 @@
 use crate::{
     asm_gen::{program_to_intents, Intents},
+    error::Handler,
     parser::parse_project,
 };
 use essential_types::slots::*;
@@ -15,8 +16,12 @@ fn check(actual: &str, expect: expect_test::Expect) {
 fn compile(code: &str) -> Intents {
     let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
     write!(tmpfile.as_file_mut(), "{}", code).unwrap();
-    let program = parse_project(tmpfile.path()).unwrap().compile().unwrap();
-    program_to_intents(&program).unwrap()
+    let handler = Handler::default();
+    let program = parse_project(&handler, tmpfile.path())
+        .unwrap()
+        .compile(&handler)
+        .unwrap();
+    program_to_intents(&handler, &program).unwrap()
 }
 
 #[test]

--- a/yurtc/src/error.rs
+++ b/yurtc/src/error.rs
@@ -1,4 +1,5 @@
 mod compile_error;
+mod handler;
 mod lex_error;
 mod parse_error;
 
@@ -10,6 +11,7 @@ use yansi::{Color, Style};
 
 pub(super) use compile_error::CompileError;
 pub(super) use compile_error::LargeTypeError;
+pub use handler::{ErrorEmitted, Handler};
 pub(super) use lex_error::LexError;
 pub(super) use parse_error::ParseError;
 

--- a/yurtc/src/error/handler.rs
+++ b/yurtc/src/error/handler.rs
@@ -1,0 +1,72 @@
+use crate::error::Error;
+use core::cell::RefCell;
+
+/// A handler with which you can emit diagnostics.
+#[derive(Default, Debug)]
+pub struct Handler {
+    /// The inner handler.
+    /// This construction is used to avoid `&mut` all over the compiler.
+    inner: RefCell<HandlerInner>,
+}
+
+/// Contains the actual data for `Handler`.
+/// Modelled this way to afford an API using interior mutability.
+#[derive(Default, Debug)]
+struct HandlerInner {
+    /// The sink through which errors will be emitted.
+    errors: Vec<Error>,
+    // TODO: add warnings here
+}
+
+impl Handler {
+    /// Emit the error `err`.
+    pub fn emit_err(&self, err: Error) -> ErrorEmitted {
+        self.inner.borrow_mut().errors.push(err);
+        ErrorEmitted { _priv: () }
+    }
+
+    /// Compilation should be cancelled.
+    pub fn cancel(&self) -> ErrorEmitted {
+        ErrorEmitted { _priv: () }
+    }
+
+    pub fn has_errors(&self) -> bool {
+        !self.inner.borrow().errors.is_empty()
+    }
+
+    pub fn scope<T>(
+        &self,
+        f: impl FnOnce(&Handler) -> Result<T, ErrorEmitted>,
+    ) -> Result<T, ErrorEmitted> {
+        let scoped_handler = Handler::default();
+        let closure_res = f(&scoped_handler);
+        let had_errors = scoped_handler.has_errors();
+
+        self.append(scoped_handler);
+
+        if had_errors {
+            Err(ErrorEmitted { _priv: () })
+        } else {
+            closure_res
+        }
+    }
+
+    /// Extract all the warnings and errors from this handler.
+    pub fn consume(self) -> Vec<Error> {
+        let inner = self.inner.into_inner();
+        inner.errors
+    }
+
+    pub fn append(&self, other: Handler) {
+        let errors = other.consume();
+        for err in errors {
+            self.emit_err(err);
+        }
+    }
+}
+
+/// Proof that an error was emitted through a `Handler`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ErrorEmitted {
+    pub _priv: (),
+}

--- a/yurtc/src/intermediate/check_program_kind.rs
+++ b/yurtc/src/intermediate/check_program_kind.rs
@@ -1,7 +1,7 @@
 use super::{Program, ProgramKind};
 
 use crate::{
-    error::{CompileError, Error, Errors},
+    error::{CompileError, Error, ErrorEmitted, Handler},
     span::empty_span,
 };
 
@@ -11,31 +11,28 @@ impl Program {
     /// `Program::ROOT_II_NAME`.
     /// * Stateful programs must have at least a two IIs, one of them being the root II. The root
     /// II cannot have variables, states, constraints, nor solve directives.
-    pub fn check_program_kind(self) -> Result<Self, Errors> {
-        let errors = match self.kind {
+    pub fn check_program_kind(self, handler: &Handler) -> Result<Self, ErrorEmitted> {
+        match self.kind {
             ProgramKind::Stateless => {
-                let mut errors = Vec::new();
                 if self.iis.len() != 1 {
-                    errors.push(Error::Compile {
+                    handler.emit_err(Error::Compile {
                         error: CompileError::Internal {
                             msg: "stateless intents cannot have multiple intent decls",
                             span: empty_span(),
                         },
                     });
                 } else if self.iis.iter().next().unwrap().0 != Program::ROOT_II_NAME {
-                    errors.push(Error::Compile {
+                    handler.emit_err(Error::Compile {
                         error: CompileError::Internal {
                             msg: "stateless intent must have an empty name",
                             span: empty_span(),
                         },
                     });
                 }
-                errors
             }
             ProgramKind::Stateful => {
-                let mut errors = Vec::new();
                 if self.iis.len() <= 1 {
-                    errors.push(Error::Compile {
+                    handler.emit_err(Error::Compile {
                         error: CompileError::Internal {
                             msg: "stateful intents must have at least one intent decl \
                               in addition to the root intent",
@@ -44,38 +41,46 @@ impl Program {
                     });
                 } else {
                     let root_ii = self.root_ii();
-                    errors.extend(root_ii.vars.iter().map(|(_, var)| Error::Compile {
-                        error: CompileError::InvalidDeclOutsideIntentDecl {
-                            kind: "variable".to_string(),
-                            span: var.span.clone(),
-                        },
-                    }));
-                    errors.extend(root_ii.states.iter().map(|(_, state)| Error::Compile {
-                        error: CompileError::InvalidDeclOutsideIntentDecl {
-                            kind: "state".to_string(),
-                            span: state.span.clone(),
-                        },
-                    }));
-                    errors.extend(root_ii.constraints.iter().map(|(_, span)| Error::Compile {
-                        error: CompileError::InvalidDeclOutsideIntentDecl {
-                            kind: "constraint".to_string(),
-                            span: span.clone(),
-                        },
-                    }));
-                    errors.extend(root_ii.directives.iter().map(|(_, span)| Error::Compile {
-                        error: CompileError::InvalidDeclOutsideIntentDecl {
-                            kind: "solve directive".to_string(),
-                            span: span.clone(),
-                        },
-                    }));
+                    for var in root_ii.vars.values() {
+                        handler.emit_err(Error::Compile {
+                            error: CompileError::InvalidDeclOutsideIntentDecl {
+                                kind: "variable".to_string(),
+                                span: var.span.clone(),
+                            },
+                        });
+                    }
+                    for state in root_ii.states.values() {
+                        handler.emit_err(Error::Compile {
+                            error: CompileError::InvalidDeclOutsideIntentDecl {
+                                kind: "state".to_string(),
+                                span: state.span.clone(),
+                            },
+                        });
+                    }
+                    for (_, span) in &root_ii.constraints {
+                        handler.emit_err(Error::Compile {
+                            error: CompileError::InvalidDeclOutsideIntentDecl {
+                                kind: "constraint".to_string(),
+                                span: span.clone(),
+                            },
+                        });
+                    }
+                    for (_, span) in &root_ii.directives {
+                        handler.emit_err(Error::Compile {
+                            error: CompileError::InvalidDeclOutsideIntentDecl {
+                                kind: "solve directive".to_string(),
+                                span: span.clone(),
+                            },
+                        });
+                    }
                 }
-                errors
             }
         };
 
-        errors
-            .is_empty()
-            .then(|| Ok(self))
-            .unwrap_or_else(|| Err(Errors(errors)))
+        if handler.has_errors() {
+            return Err(handler.cancel());
+        }
+
+        Ok(self)
     }
 }

--- a/yurtc/src/parser/context.rs
+++ b/yurtc/src/parser/context.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::Error,
+    error::Handler,
     intermediate::{CallKey, ExprKey, IntermediateIntent, Program},
     macros::{MacroCall, MacroDecl},
     parser::{Ident, NextModPath, UsePath},
@@ -24,16 +24,18 @@ pub struct ParserContext<'a> {
 impl<'a> ParserContext<'a> {
     pub fn add_top_level_symbol(
         &mut self,
+        handler: &Handler,
         mut ident: Ident,
         prefix: &str,
-        errors: &mut Vec<Error>,
     ) -> Ident {
-        match self
-            .current_ii()
-            .add_top_level_symbol(prefix, None, &ident, ident.span.clone())
-        {
-            Ok(name) => ident.name = name,
-            Err(error) => errors.push(Error::Parse { error }),
+        if let Ok(name) = self.current_ii().add_top_level_symbol(
+            handler,
+            prefix,
+            None,
+            &ident,
+            ident.span.clone(),
+        ) {
+            ident.name = name
         }
         ident
     }

--- a/yurtc/src/parser/use_path.rs
+++ b/yurtc/src/parser/use_path.rs
@@ -100,7 +100,10 @@ lalrpop_mod!(#[allow(unused)] pub yurt_parser);
 
 #[test]
 fn gather_use_paths() {
-    use crate::intermediate::{IntermediateIntent, Program, ProgramKind};
+    use crate::{
+        error::Handler,
+        intermediate::{IntermediateIntent, Program, ProgramKind},
+    };
     use std::collections::BTreeMap;
     let parser = yurt_parser::UseTreeParser::new();
     let mut current_ii = Program::ROOT_II_NAME.to_string();
@@ -130,7 +133,7 @@ fn gather_use_paths() {
                     use_paths: &mut Vec::new(),
                     next_paths: &mut Vec::new(),
                 },
-                &mut Vec::new(),
+                &Handler::default(),
                 crate::lexer::Lexer::new(src, &filepath, &[]),
             )
             .expect("Failed to parse test case.")

--- a/yurtc/src/yurt_parser.lalrpop
+++ b/yurtc/src/yurt_parser.lalrpop
@@ -1,5 +1,5 @@
 use crate::{
-    error::{Error, ParseError},
+    error::{Error, ParseError, Handler},
     expr::*,
     intermediate::{ExprKey, SolveFunc, IntermediateIntent, ProgramKind, Program},
     lexer,
@@ -11,7 +11,7 @@ use crate::{
 
 grammar<'a>(
     context: &mut ParserContext<'a>,
-    errors: &mut Vec<Error>,
+    handler: &Handler,
 );
 
 pub Yurt: () = {
@@ -43,12 +43,12 @@ pub IntentOpen: () = {
     <l:@L> "intent" <name:Ident> "{" <r:@R> => {
         // To detect name clashes
         let name = context.add_top_level_symbol(
+            handler,
             Ident {
                 name: name.to_string(),
                 span: (context.span_from)(l, r),
             },
             context.mod_prefix,
-            errors,
         );
 
         // Brand new II in the program
@@ -88,7 +88,7 @@ UseStatement: () = {
         // use tree is not absolute, and append to the current list of use paths in our context.
         let mod_prefix = context.mod_prefix;
         let mod_path = context.mod_path;
-        let mut local_errors = Vec::new();
+        let local_handler = Handler::default();
         let mut new_use_paths = ut
             .gather_paths()
             .into_iter()
@@ -105,7 +105,7 @@ UseStatement: () = {
                     .take(use_path.path.len() - 1)
                     .any(|elem| elem == "self")
                 {
-                    local_errors.push(Error::Parse {
+                    local_handler.emit_err(Error::Parse {
                         error: ParseError::SelfNotAtTheEnd {
                             // We can use a better span here but that's okay for now. Ideally, we
                             // would use the span of the `self` ident itself, but we don't have that
@@ -127,7 +127,7 @@ UseStatement: () = {
                     // Check that the prefix `use_path.path` matches the current `mod_path` because
                     // we may in a module other than the root module
                     if use_path.path == mod_path {
-                        local_errors.push(Error::Parse {
+                        local_handler.emit_err(Error::Parse {
                             error: ParseError::SelfWithEmptyPrefix {
                                 span: use_path.span.clone(),
                             },
@@ -159,6 +159,7 @@ UseStatement: () = {
                 context
                     .current_ii()
                     .add_top_level_symbol(
+                        &local_handler,
                         mod_prefix,
                         None,
                         &Ident {
@@ -171,14 +172,11 @@ UseStatement: () = {
                         use_path.span.clone(),
                     )
                     .map(|_| use_path.clone())
-                    .unwrap_or_else(|error| {
-                        errors.push(Error::Parse { error });
-                        use_path
-                    })
+                    .unwrap_or_else(|error| use_path)
             })
             .collect::<Vec<_>>();
 
-        errors.extend(local_errors);
+        handler.append(local_handler);
         context.use_paths.append(&mut new_use_paths);
     }
 };
@@ -199,9 +197,9 @@ pub UseTree: UseTree = {
 pub LetDecl: () = {
     <l:@L> "let" <let_name:LetName> ":" <ty:Type> <init:LetInit?> <r:@R> => {
         let mod_prefix = context.mod_prefix;
-        context
+        let _ = context
             .current_ii()
-            .insert_var(mod_prefix, let_name.1, &let_name.0, Some(ty))
+            .insert_var(handler, mod_prefix, let_name.1, &let_name.0, Some(ty))
             .map(|var_key| {
                 if let Some(expr_key) = init {
                     context.current_ii().var_inits.insert(var_key, expr_key);
@@ -210,29 +208,23 @@ pub LetDecl: () = {
                         .current_ii()
                         .insert_eq_or_ineq_constraint(var_key, expr_key, span);
                 }
-            })
-            .unwrap_or_else(|error| {
-                errors.push(Error::Parse { error });
             });
     },
     <l:@L> "let" <let_name:LetName> <init:LetInit> <r:@R> => {
         let mod_prefix = context.mod_prefix;
-        context
+        let _ = context
             .current_ii()
-            .insert_var(mod_prefix, let_name.1, &let_name.0, None)
+            .insert_var(handler, mod_prefix, let_name.1, &let_name.0, None)
             .map(|var_key| {
                 context.current_ii().var_inits.insert(var_key, init);
                 let span = (context.span_from)(l, r);
                 context
                     .current_ii()
                     .insert_eq_or_ineq_constraint(var_key, init, span);
-            })
-            .unwrap_or_else(|error| {
-                errors.push(Error::Parse { error });
             });
     },
     <l:@L> "let" <name:Ident> <r:@R> => {
-        errors.push(Error::Parse {
+        handler.emit_err(Error::Parse {
             error: ParseError::UntypedVariable {
                 name: name.name,
                 span: (context.span_from)(l, r),
@@ -288,13 +280,10 @@ pub StateDecl: () = {
         let init_key = context.current_ii().exprs.insert(init);
         let span = (context.span_from)(l, r);
         let mod_prefix = context.mod_prefix;
-        context
+        let _ = context
             .current_ii()
-            .insert_state(mod_prefix, &name, ty, init_key, span)
-            .map(|_| ())
-            .unwrap_or_else(|error| {
-                errors.push(Error::Parse { error });
-            });
+            .insert_state(handler, mod_prefix, &name, ty, init_key, span)
+            .map(|_| ());
     }
 };
 
@@ -310,7 +299,7 @@ pub SolveDecl: () = {
         let span = (context.span_from)(l, r);
         if let Some((_, prev_span)) = context.current_ii().directives.first() {
             // Multiple `solve` directives are not allowed
-            errors.push(Error::Parse {
+            handler.emit_err(Error::Parse {
                 error: ParseError::TooManySolveDirectives {
                     span,
                     prev_span: prev_span.clone(),
@@ -318,14 +307,14 @@ pub SolveDecl: () = {
             });
         } else if !context.mod_path.is_empty() {
             // `solve` directives in sub-modules are not allowed
-            errors.push(Error::Parse {
+            handler.emit_err(Error::Parse {
                 error: ParseError::SolveDirectiveMustBeTopLevel { span },
             });
         } else if context.current_ii != Program::ROOT_II_NAME {
             // `solve` directives inside an `intent` declaration are not allowed
-            errors.push(Error::Parse {
+            handler.emit_err(Error::Parse {
                 error: ParseError::SolveDirectiveMustBeOutsideIntent { span },
-            })
+            });
         } else {
             context.current_ii().directives.push((sd.clone(), span));
         }
@@ -342,7 +331,7 @@ pub EnumDecl: () = {
     <l:@L> "enum" <name:Ident> "=" <variants:Sep1ListNoTrail<Ident, "|">> <r:@R> => {
         let current_ii = context.current_ii.clone();
         let enum_decl = EnumDecl {
-            name: context.add_top_level_symbol(name, context.mod_prefix, errors),
+            name: context.add_top_level_symbol(handler, name, context.mod_prefix),
             variants,
             span: (context.span_from)(l, r),
         };
@@ -354,7 +343,7 @@ pub NewTypeDecl: () = {
     <l:@L> "type" <name:Ident> "=" <ty:Type> <r:@R> => {
         let current_ii = context.current_ii.clone();
         let new_type_decl = NewTypeDecl {
-            name: context.add_top_level_symbol(name, context.mod_prefix, errors),
+            name: context.add_top_level_symbol(handler, name, context.mod_prefix),
             ty,
             span: (context.span_from)(l, r),
         };
@@ -437,7 +426,7 @@ TypeAtom: Type = {
     },
     <l:@L> "{" "}" <r:@R> => {
         let span = (context.span_from)(l, r);
-        errors.push(Error::Parse {
+        handler.emit_err(Error::Parse {
             error: ParseError::EmptyTupleType { span: span.clone() },
         });
 
@@ -465,7 +454,7 @@ ArrayType: Type = {
     },
     <l:@L> <ty:TypeAtom> "[" "]" <r:@R> => {
         let span = (context.span_from)(l, r);
-        errors.push(Error::Parse {
+        handler.emit_err(Error::Parse {
             error: ParseError::EmptyArrayType { span: span.clone() },
         });
 
@@ -629,7 +618,7 @@ TupleFieldOp: ExprKey = {
                 .map(TupleAccess::Index)
                 .unwrap_or_else(|_| {
                     // Recover with a malformed field access
-                    errors.push(Error::Parse {
+                    handler.emit_err(Error::Parse {
                         error: ParseError::InvalidIntegerTupleIndex {
                             span: index_span,
                             index: num_str.to_string(),
@@ -647,7 +636,7 @@ TupleFieldOp: ExprKey = {
                     .parse::<usize>()
                     .map(TupleAccess::Index)
                     .unwrap_or_else(|_| {
-                        errors.push(Error::Parse {
+                        handler.emit_err(Error::Parse {
                             error: ParseError::InvalidIntegerTupleIndex {
                                 span: (context.span_from)(m, m + dot_index),
                                 index: num_str[0..dot_index].to_string(),
@@ -662,7 +651,7 @@ TupleFieldOp: ExprKey = {
                     .parse::<usize>()
                     .map(TupleAccess::Index)
                     .unwrap_or_else(|_| {
-                        errors.push(Error::Parse {
+                        handler.emit_err(Error::Parse {
                             error: ParseError::InvalidIntegerTupleIndex {
                                 span: (context.span_from)(m + dot_index + 1, r),
                                 index: num_str[(dot_index + 1)..].to_string(),
@@ -688,7 +677,7 @@ TupleFieldOp: ExprKey = {
                 })
             }
             None => {
-                errors.push(Error::Parse {
+                handler.emit_err(Error::Parse {
                     error: ParseError::InvalidTupleIndex {
                         span: (context.span_from)(m, r),
                         index: num_str.to_string(),
@@ -718,7 +707,7 @@ ArrayElOp: ExprKey = {
     },
     <l:@L> <array:ArrayElOp> "[" "]" <r:@R> => {
         let span = (context.span_from)(l, r);
-        errors.push(Error::Parse {
+        handler.emit_err(Error::Parse {
             error: ParseError::EmptyArrayAccess { span: span.clone() },
         });
 
@@ -753,7 +742,7 @@ UnaryOp: ExprKey = {
 
 UnaryOpOp: UnaryOp = {
     <l:@L> "+" <r:@R> => {
-        errors.push(Error::Parse {
+        handler.emit_err(Error::Parse {
             error: ParseError::UnsupportedLeadingPlus {
                 span: (context.span_from)(l, r),
             },
@@ -795,19 +784,15 @@ GeneratorRange: (Ident, ExprKey) = {
     <index:Ident> "in" <range:Range> => {
         // Generators for `forall` are always `int`s and need to be saved in the ephemeral list.
         let mod_prefix = context.mod_prefix;
-        context
-            .current_ii()
-            .insert_ephemeral(
-                mod_prefix,
-                &index,
-                Type::Primitive {
-                    kind: PrimitiveKind::Int,
-                    span: index.span.clone(),
-                },
-            )
-            .unwrap_or_else(|error| {
-                errors.push(Error::Parse { error });
-            });
+        let _ = context.current_ii().insert_ephemeral(
+            handler,
+            mod_prefix,
+            &index,
+            Type::Primitive {
+                kind: PrimitiveKind::Int,
+                span: index.span.clone(),
+            },
+        );
         (index, range)
     }
 }
@@ -923,7 +908,7 @@ TupleExpr: Expr = {
     },
     <l:@L> "{" "}" <r:@R> => {
         let span = (context.span_from)(l, r);
-        errors.push(Error::Parse {
+        handler.emit_err(Error::Parse {
             error: ParseError::EmptyTupleExpr { span: span.clone() },
         });
 
@@ -1107,7 +1092,7 @@ ImmediateInt: Immediate = {
                         ])
                     }
                     _ => {
-                        errors.push(Error::Parse {
+                        handler.emit_err(Error::Parse {
                             error: ParseError::BinaryLiteralLength {
                                 digits,
                                 span: span.clone(),
@@ -1144,7 +1129,7 @@ ImmediateInt: Immediate = {
                         ])
                     }
                     _ => {
-                        errors.push(Error::Parse {
+                        handler.emit_err(Error::Parse {
                             error: ParseError::HexLiteralLength {
                                 digits,
                                 span: span.clone(),
@@ -1157,7 +1142,7 @@ ImmediateInt: Immediate = {
             _ => match s.parse::<i64>() {
                 Ok(val) => Immediate::Int(val),
                 Err(_) => {
-                    errors.push(Error::Parse {
+                    handler.emit_err(Error::Parse {
                         error: ParseError::IntLiteralTooLarge { span: span.clone() },
                     });
                     Immediate::Error

--- a/yurtc/tests/arrays/non_const_index.yrt
+++ b/yurtc/tests/arrays/non_const_index.yrt
@@ -13,6 +13,8 @@ solve satisfy;
 // >>>
 
 // flattening_failure <<<
+// cannot find value `::n` in this scope
+// @42..43: not found in this scope
 // attempt to use a non-constant value as an array index
 // @42..43: this must be a constant
 // >>>

--- a/yurtc/tests/types/new_type_unknown.yrt
+++ b/yurtc/tests/types/new_type_unknown.yrt
@@ -12,6 +12,8 @@ solve satisfy;
 // >>>
 
 // typecheck_failure <<<
+// cannot find value `::NonExistentEnum::MissingVariant` in this scope
+// @17..32: not found in this scope
 // cannot find value `::Ambiguous::MissingVariant` in this scope
 // @43..68: not found in this scope
 // >>>


### PR DESCRIPTION
Introduce a `Handler` all over the compiler and use it to accumulate errors where needed. Eventually, we'll add warnings to it. 

This PR does not purposefully add any new error recovery. It just enables the capability to do so.

Closes #443 