### PR TITLE
Add a flag to the LALRPOP build script to make it less aggressive.

### DIFF
--- a/yurtc/build.rs
+++ b/yurtc/build.rs
@@ -1,4 +1,7 @@
 // Generate the LALRPOP parser.
 fn main() {
-    lalrpop::process_root().unwrap();
+    lalrpop::Configuration::new()
+        .emit_rerun_directives(true)
+        .process_current_dir()
+        .unwrap();
 }


### PR DESCRIPTION
Until now it would try to rebuild the parser when _any_ file was updated, including any source or even test file.  It usually meant nothing changed if the grammar file was unchanged, but it still took a few seconds, which is especially frustrating when iterating on tests.

I haven't tested this longer term -- I hope it doesn't make it harder to update the grammar.