### PR TITLE
Fix some issues with macro hygiene.

### DIFF
--- a/pintc/src/expr.rs
+++ b/pintc/src/expr.rs
@@ -90,6 +90,7 @@ pub enum Expr {
 #[derive(Clone, Debug, PartialEq)]
 pub struct Ident {
     pub(super) name: String,
+    pub(super) hygienic: bool,
     pub(super) span: Span,
 }
 

--- a/pintc/src/lexer.rs
+++ b/pintc/src/lexer.rs
@@ -494,16 +494,6 @@ impl<'sc> Lexer<'sc> {
                     ));
                 }
 
-                Some(Ok(Token::Ident((s, _)))) => {
-                    // When identifiers are in macro args we set the flag to true. Then while
-                    // parsing expanded macro bodies, the `let` decls can implement hygiene.
-                    let tok_span = args_token_stream.span();
-                    all_args
-                        .last_mut()
-                        .expect("Args vec is always valid.")
-                        .push((tok_span.start, Token::Ident((s, true)), tok_span.end))
-                }
-
                 // A regular parameter token.
                 Some(Ok(tok)) => {
                     let tok_span = args_token_stream.span();

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -1,12 +1,15 @@
 use crate::{
-    error::{Error, ParseError, Handler},
+    error::{Error, Handler, ParseError},
     expr::*,
-    intermediate::{ExprKey, SolveFunc, IntermediateIntent, ProgramKind, Program},
+    intermediate::{ExprKey, IntermediateIntent, Program, ProgramKind, SolveFunc},
     lexer,
     macros::{MacroCall, MacroDecl},
-    parser::{ParserContext, UsePath, UseTree::{self, Path as UseTreePath}, NextModPath},
-    types::{EnumDecl, Path, FnSig, NewTypeDecl, PrimitiveKind, Type},
+    parser::{
+        NextModPath, ParserContext, UsePath,
+        UseTree::{self, Path as UseTreePath},
+    },
     span,
+    types::{EnumDecl, FnSig, NewTypeDecl, Path, PrimitiveKind, Type},
 };
 
 grammar<'a>(
@@ -39,13 +42,18 @@ DeclBarringMacro: () = {
     MacroCallDecl ";",
 };
 
+pub IntentDecl: () = {
+    IntentOpen DeclBarringMacro* IntentClose,
+}
+
 pub IntentOpen: () = {
-    <l:@L> "intent" <name:Ident> "{" <r:@R> => {
+    <l:@L> "intent" <name:Ident> <r:@R> "{" => {
         // To detect name clashes
         let name = context.add_top_level_symbol(
             handler,
             Ident {
                 name: name.to_string(),
+                hygienic: false,
                 span: (context.span_from)(l, r),
             },
             context.mod_prefix,
@@ -71,12 +79,8 @@ pub IntentOpen: () = {
     }
 }
 
-pub IntentDecl: () = {
-    <l:@L> IntentOpen DeclBarringMacro* IntentClose <r:@R> => { },
-}
-
 pub IntentClose: () = {
-    <l:@L> "}" <r:@R> => {
+    "}" => {
         // At the end of the intent declaration, return back to the root II
         *context.current_ii = Program::ROOT_II_NAME.to_string();
     }
@@ -167,6 +171,7 @@ UseStatement: () = {
                                 .alias
                                 .clone()
                                 .unwrap_or(use_path.path[use_path.path.len() - 1].clone()),
+                            hygienic: false,
                             span: use_path.span.clone(),
                         },
                         use_path.span.clone(),
@@ -262,6 +267,7 @@ LetName: (Ident, Option<&'a str>) = {
 
         let name = Ident {
             name: id.0.to_owned(),
+            hygienic: id.1,
             span: (context.span_from)(l, r),
         };
 
@@ -999,7 +1005,7 @@ PathWithLast<Last>: Path = {
             .use_paths
             .iter()
             .find(|use_path| use_path.matches_suffix(&path_prefix))
-            .map(|use_path| {
+            .and_then(|use_path| {
                 // We've found a use path which matches.  Construct a full path by joining the it
                 // with the parsed path. `parsed_path_iter` is our parsed path except for the first
                 // element.
@@ -1038,7 +1044,13 @@ PathWithLast<Last>: Path = {
                     span: (context.span_from)(l, r),
                 });
 
-                full_path_str
+                if last.hygienic {
+                    // This identifier is hygienic and should not have 'use' paths prepended
+                    // afterall.
+                    None
+                } else {
+                    Some(full_path_str)
+                }
             })
             .unwrap_or_else(|| {
                 // We didn't find a matching use path.  Just return the parsed path as is.
@@ -1167,6 +1179,7 @@ ImmediateInt: Immediate = {
 pub Ident: Ident = {
     <l:@L> <id:"ident"> <r:@R> => Ident {
         name: id.0.to_string(),
+        hygienic: id.1,
         span: (context.span_from)(l, r),
     }
 }
@@ -1174,6 +1187,7 @@ pub Ident: Ident = {
 IdentFromToken<Tok>: Ident = {
     <l:@L> <id:Tok> <r:@R> => Ident {
         name: id.to_string(),
+        hygienic: false,
         span: (context.span_from)(l, r),
     }
 }

--- a/pintc/tests/macros/macro_hygiene.pnt
+++ b/pintc/tests/macros/macro_hygiene.pnt
@@ -6,20 +6,29 @@ macro @foo($x) {
 @foo(11);
 @foo(22);
 
+let a: int;
+@foo(a);
+
 solve satisfy;
 
 // intermediate <<<
+// var ::a: int;
 // var ::anon@0::a: int;
 // var ::anon@1::a: int;
+// var ::anon@2::a: int;
 // constraint (::anon@0::a == 11);
 // constraint (::anon@1::a == 22);
+// constraint (::anon@2::a == ::a);
 // solve satisfy;
 // >>>
 
 // flattened <<<
+// var ::a: int;
 // var ::anon@0::a: int;
 // var ::anon@1::a: int;
+// var ::anon@2::a: int;
 // constraint (::anon@0::a == 11);
 // constraint (::anon@1::a == 22);
+// constraint (::anon@2::a == ::a);
 // solve satisfy;
 // >>>

--- a/pintc/tests/sets_of_intents/name_clash/main.pnt
+++ b/pintc/tests/sets_of_intents/name_clash/main.pnt
@@ -27,15 +27,15 @@ intent Boo {
 // parse_failure <<<
 // symbol `Foo` has already been declared
 // @20..23: previous declaration of the symbol `Foo` here
-// @34..46: `Foo` redeclared here
+// @34..44: `Foo` redeclared here
 // `Foo` must be declared or imported only once in this scope
 // symbol `Bar` has already been declared
 // @94..97: previous declaration of the symbol `Bar` here
-// @106..118: `Bar` redeclared here
+// @106..116: `Bar` redeclared here
 // `Bar` must be declared or imported only once in this scope
 // symbol `Boo` has already been declared
-// @161..173: previous declaration of the symbol `Boo` here
-// @197..209: `Boo` redeclared here
+// @161..171: previous declaration of the symbol `Boo` here
+// @197..207: `Boo` redeclared here
 // `Boo` must be declared or imported only once in this scope
 // symbol `::Foo` has already been declared
 // @20..23: previous declaration of the symbol `::Foo` here


### PR DESCRIPTION
While looking at #514 (which I don't think can be resolved in the short term) I noticed some fixable problems with macro hygiene which I have fixed with this PR.

It's a bit gross in that it adds a `hygienic` flag to the `expr::Ident` which isn't used after parsing, but I couldn't see a reasonable alternative.