### PR TITLE
Add an extra type check for undefined custom types.

### DIFF
--- a/pintc/src/error/compile_error.rs
+++ b/pintc/src/error/compile_error.rs
@@ -130,6 +130,8 @@ pub enum CompileError {
     CannotIndexIntoValue { span: Span, index_span: Span },
     #[error("unable to determine expression type")]
     UnknownType { span: Span },
+    #[error("undefined type")]
+    UndefinedType { span: Span },
     #[error("condition in if-expression must be a boolean")]
     IfCondTypeNotBool(Span),
     #[error("branches in if-expression must have the same type")]
@@ -547,6 +549,12 @@ impl ReportableError for CompileError {
                 color: Color::Red,
             }],
 
+            UndefinedType { span } => vec![ErrorLabel {
+                message: "type is undefined".to_string(),
+                span: span.clone(),
+                color: Color::Red,
+            }],
+
             IfCondTypeNotBool(span) => {
                 vec![ErrorLabel {
                     message: "condition must be a boolean".to_string(),
@@ -924,6 +932,7 @@ impl ReportableError for CompileError {
             | MacroUnrecognizedSpliceVar { .. }
             | MacroSpliceVarNotArray { .. }
             | UnknownType { .. }
+            | UndefinedType { .. }
             | IfCondTypeNotBool(_)
             | IfBranchesTypeMismatch { .. }
             | OperatorTypeError { .. }
@@ -1033,6 +1042,7 @@ impl Spanned for CompileError {
             | ArrayIndexOutOfBounds { span }
             | CannotIndexIntoValue { span, .. }
             | UnknownType { span }
+            | UndefinedType { span }
             | IfCondTypeNotBool(span)
             | IndexExprNonIndexable { span, .. }
             | ArrayAccessWithWrongType { span, .. }

--- a/pintc/tests/types/undefined_types.pnt
+++ b/pintc/tests/types/undefined_types.pnt
@@ -1,0 +1,36 @@
+enum Baz = X | Y;
+type Xyzzy = int;
+
+let a: int;
+let b: Foo;
+let c = a as Bar;
+
+let d: Baz;
+let e = a as Xyzzy;
+
+solve satisfy;
+
+// intermediate <<<
+// var ::a: int;
+// var ::b: ::Foo;
+// var ::c;
+// var ::d: ::Baz;
+// var ::e;
+// enum ::Baz = X | Y;
+// type ::Xyzzy = int;
+// constraint (::c == ::a as ::Bar);
+// constraint (::e == ::a as ::Xyzzy);
+// solve satisfy;
+// >>>
+
+// typecheck_failure <<<
+// undefined type
+// @56..59: type is undefined
+// undefined type
+// @74..77: type is undefined
+// invalid cast
+// @69..77: illegal cast to a `::Bar`
+// casts may only be made to an int or a real
+// unable to determine expression type
+// @65..66: type of this expression is ambiguous
+// >>>


### PR DESCRIPTION
Closes #547.  I also tweaked the `IntermediateIntent::Exprs` iterator to include directives and also to avoid the bad macro calls which aren't actually expressions.