### PR TITLE
Rework generator unrolling to be less brittle.

### DIFF
--- a/pintc/tests/arrays/compare_different_sizes.pnt
+++ b/pintc/tests/arrays/compare_different_sizes.pnt
@@ -20,9 +20,13 @@ solve satisfy;
 // solve satisfy;
 // >>>
 
-// Only getting the single error here until we support error recovery in the middle end.
-//
 // flattening_failure <<<
+// comparison between differently sized arrays
+// @113..131: cannot compare arrays of different sizes
+// the left-hand side argument of the `!=` operator has 2 elements while the right-hand side argument has 3 elements
+// comparison between differently sized arrays
+// @94..100: cannot compare arrays of different sizes
+// the left-hand side argument of the `!=` operator has 4 elements while the right-hand side argument has 2 elements
 // comparison between differently sized arrays
 // @75..81: cannot compare arrays of different sizes
 // the left-hand side argument of the `==` operator has 4 elements while the right-hand side argument has 5 elements


### PR DESCRIPTION
Closes #539. Use the root set to find generators rather than all expressions and then order them explicitly to be sure nested inner generators are unrolled before the outer.

Also just replace the generator expression with the unrolled expression rather than deleting it.  The removal was a bit blunt and didn't check for potential other 'uses'.

And:
- Add `IntermediateIntent::visitor()`.
- Remove `IntermediateIntent::remove_expr()`.
- Use `IntermediateIntent::Expr` iterator in `scalarize.rs`.
- Improve error recovery for array comparison lowering in `scalarize.rs`.

The new unrolling seems to be slower though.  Our largest test file `sudoku.rs` has a bunch of unrolling in it and on my machine it takes a debug build 4.5s to compile it.  But a release compile is only 0.5s so perhaps it's not worth worrying about (yet).