### PR TITLE
Update the validator to allow tuples in storage.

### DIFF
--- a/pintc/src/asm_gen.rs
+++ b/pintc/src/asm_gen.rs
@@ -331,13 +331,7 @@ impl AsmBuilder {
                     BinaryOp::Div => asm.push(Op::Alu(Alu::Div)),
                     BinaryOp::Mod => asm.push(Op::Alu(Alu::Mod)),
                     BinaryOp::Equal => {
-                        if matches!(
-                            intent.expr_types[*lhs],
-                            Type::Primitive {
-                                kind: PrimitiveKind::B256,
-                                ..
-                            }
-                        ) {
+                        if intent.expr_types[*lhs].is_b256() {
                             asm.push(Op::Pred(Pred::Eq4));
                         } else {
                             asm.push(Op::Pred(Pred::Eq));


### PR DESCRIPTION
This turned out to be easier than I expected.  The validator will recursively check a tuple access to see whether it resolves down to a `StorageAccess` before flagging as invalid.  The same is done for the type check for `Tuple`.