### PR TITLE
Ensure constraint expressions evaluate to a bool and adjust tests

### DIFF
--- a/pintc/src/error/compile_error.rs
+++ b/pintc/src/error/compile_error.rs
@@ -141,6 +141,8 @@ pub enum CompileError {
     #[error("branches in if-expression must have the same type")]
     IfBranchesTypeMismatch { large_err: Box<LargeTypeError> },
     #[error("attempt to index into a non-indexable value")]
+    InvalidConstraintExpression { span: Span },
+    #[error("expression for constraint must evaluate to a boolean")]
     IndexExprNonIndexable {
         non_indexable_type: String,
         span: Span,
@@ -609,6 +611,14 @@ impl ReportableError for CompileError {
                 }]
             }
 
+            InvalidConstraintExpression { span } => {
+                vec![ErrorLabel {
+                    message: "expression for constraint must evaluate to a boolean".to_string(),
+                    span: span.clone(),
+                    color: Color::Red,
+                }]
+            }
+
             IndexExprNonIndexable {
                 non_indexable_type,
                 span,
@@ -1013,6 +1023,7 @@ impl ReportableError for CompileError {
             | UndefinedType { .. }
             | IfCondTypeNotBool(_)
             | IfBranchesTypeMismatch { .. }
+            | InvalidConstraintExpression { .. }
             | OperatorTypeError { .. }
             | StateVarInitTypeError { .. }
             | StateVarTypeIsMap { .. }
@@ -1127,6 +1138,7 @@ impl Spanned for CompileError {
             | UnknownType { span }
             | UndefinedType { span }
             | IfCondTypeNotBool(span)
+            | InvalidConstraintExpression { span }
             | IndexExprNonIndexable { span, .. }
             | ArrayAccessWithWrongType { span, .. }
             | StorageMapAccessWithWrongType { span, .. }

--- a/pintc/src/intermediate/transform/validate.rs
+++ b/pintc/src/intermediate/transform/validate.rs
@@ -348,24 +348,6 @@ fn expr_types() {
 
 #[test]
 fn exprs() {
-    // macrocall
-    let src = "macro @equal($x, $y) {
-        $x == $y
-    }
-    macro @foo($x) {
-        let a: int;
-        constraint a == $x;
-    }
-    intent Foo {
-       @foo(3);
-       constraint @equal(4; 4);
-    }";
-    check(
-        &run_test(src),
-        expect_test::expect![[
-            r#"compiler internal error: invalid intermediate intent expr_types slotmap key"#
-        ]],
-    );
     // tuple and tuple field access
     let src = "let t = { y: 3, 2 };
     let x = t.1;";

--- a/pintc/tests/arrays/bad_const_index.pnt
+++ b/pintc/tests/arrays/bad_const_index.pnt
@@ -16,4 +16,5 @@ solve satisfy;
 // attempt to index an array with a mismatched value
 // @42..46: array access must be with an int value
 // found access using type `real`
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/arrays/bad_indexed_value.pnt
+++ b/pintc/tests/arrays/bad_indexed_value.pnt
@@ -13,4 +13,5 @@ solve satisfy;
 // typecheck_failure <<<
 // no intrinsic named `__foo` is found
 // @24..31: intrinsic not found
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/arrays/index_enum_with_int.pnt
+++ b/pintc/tests/arrays/index_enum_with_int.pnt
@@ -16,4 +16,5 @@ solve satisfy;
 // attempt to index an array with a mismatched value
 // @72..73: array access must be with a `::Num` variant
 // found access using type `int`
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/arrays/index_int_with_enum.pnt
+++ b/pintc/tests/arrays/index_int_with_enum.pnt
@@ -16,4 +16,5 @@ solve satisfy;
 // attempt to index an array with a mismatched value
 // @70..78: array access must be with an int value
 // found access using type `::Num`
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/arrays/non_existent_array_access.pnt
+++ b/pintc/tests/arrays/non_existent_array_access.pnt
@@ -10,4 +10,5 @@ solve satisfy;
 // typecheck_failure <<<
 // cannot find value `::b` in this scope
 // @11..12: not found in this scope
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/basic_tests/mismatch_enums.pnt
+++ b/pintc/tests/basic_tests/mismatch_enums.pnt
@@ -20,4 +20,5 @@ solve satisfy;
 // binary operator type error
 // @218..229: operator `==` argument has unexpected type `::Key`
 // @201..214: expecting type `::Chord`
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/generators/generator_type_errors.pnt
+++ b/pintc/tests/generators/generator_type_errors.pnt
@@ -44,4 +44,12 @@ solve satisfy;
 // @366..371: invalid type `int`, expecting `bool`
 // body for `exists` must be a `bool` expression
 // @405..410: invalid type `int`, expecting `bool`
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/intrinsics/incorrect_args.pnt
+++ b/pintc/tests/intrinsics/incorrect_args.pnt
@@ -122,4 +122,21 @@ solve satisfy;
 // @526..534: type of this expression is ambiguous
 // unable to determine expression type
 // @553..561: type of this expression is ambiguous
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/macros/macro_non_expression_call.pnt
+++ b/pintc/tests/macros/macro_non_expression_call.pnt
@@ -24,4 +24,5 @@ solve satisfy;
 // macros which contain only declarations may only be used at the top level of an intent and not as an expression
 // unable to determine expression type
 // @124..125: type of this expression is ambiguous
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/storage/invalid_next_state.pnt
+++ b/pintc/tests/storage/invalid_next_state.pnt
@@ -12,4 +12,5 @@ solve satisfy;
 // typecheck_failure <<<
 // `next state` access must be bound to a state variable
 // @23..24: `next state` access must be bound to a state variable
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/bad_in_expr.pnt
+++ b/pintc/tests/types/bad_in_expr.pnt
@@ -37,5 +37,10 @@ solve satisfy;
 // @282..283: array element type mismatch; expecting `::SupperGuest` type, found `int` type
 // value type and array element type in range differ
 // @120..243: array element type mismatch; expecting `int` type, found `::SupperGuest` type
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>
 

--- a/pintc/tests/types/bad_tuple_name_index.pnt
+++ b/pintc/tests/types/bad_tuple_name_index.pnt
@@ -15,4 +15,5 @@ solve satisfy;
 // invalid tuple accessor
 // @40..43: unable to get field from tuple using `z`
 // tuple has type `{x: int, y: real}`
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/bad_tuple_num_index.pnt
+++ b/pintc/tests/types/bad_tuple_num_index.pnt
@@ -15,4 +15,5 @@ solve satisfy;
 // invalid tuple accessor
 // @36..39: unable to get field from tuple using `4`
 // tuple has type `{int, int, int}`
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/binary_ops.pnt
+++ b/pintc/tests/types/binary_ops.pnt
@@ -169,4 +169,24 @@ solve satisfy;
 // @580..581: type of this expression is ambiguous
 // unable to determine expression type
 // @615..616: type of this expression is ambiguous
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/clashing_enums.pnt
+++ b/pintc/tests/types/clashing_enums.pnt
@@ -27,4 +27,5 @@ solve satisfy;
 // this symbol is a variant of enums `::AttackingBird` and `::AppropriateDefence` and may need a fully qualified path
 // unable to determine expression type
 // @234..252: type of this expression is ambiguous
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/empty_array.pnt
+++ b/pintc/tests/types/empty_array.pnt
@@ -13,4 +13,5 @@ solve satisfy;
 // typecheck_failure <<<
 // illegal empty array value
 // @37..39: empty array values are illegal
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/enum_variant_unqualified.pnt
+++ b/pintc/tests/types/enum_variant_unqualified.pnt
@@ -19,4 +19,5 @@ solve satisfy;
 // this symbol is a variant of enums `::Foo` and `::Bar` and may need a fully qualified path
 // unable to determine expression type
 // @51..52: type of this expression is ambiguous
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/heterogeneous_array.pnt
+++ b/pintc/tests/types/heterogeneous_array.pnt
@@ -14,4 +14,5 @@ solve satisfy;
 // array element type mismatch
 // @40..44: array element has type `bool`
 // expecting array element type `int`
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/if_branches.pnt
+++ b/pintc/tests/types/if_branches.pnt
@@ -12,4 +12,5 @@ solve satisfy;
 // branches in if-expression must have the same type
 // @23..25: 'then' branch has the type `int`
 // @35..39: 'else' branch has the type `real`
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/if_cond.pnt
+++ b/pintc/tests/types/if_cond.pnt
@@ -21,4 +21,5 @@ solve satisfy;
 // typecheck_failure <<<
 // condition in if-expression must be a boolean
 // @98..99: condition must be a boolean
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/new_type_mismatch.pnt
+++ b/pintc/tests/types/new_type_mismatch.pnt
@@ -18,4 +18,5 @@ solve satisfy;
 // binary operator type error
 // @41..45: operator `==` argument has unexpected type `real`
 // @34..35: expecting type `::I (int)`
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/new_type_unknown.pnt
+++ b/pintc/tests/types/new_type_unknown.pnt
@@ -16,4 +16,5 @@ solve satisfy;
 // @43..68: not found in this scope
 // unable to determine expression type
 // @39..40: type of this expression is ambiguous
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/non_array_access.pnt
+++ b/pintc/tests/types/non_array_access.pnt
@@ -11,6 +11,7 @@ solve satisfy;
 // >>>
 
 // typecheck_failure <<<
-// attempt to index into a non-indexable value
+// expression for constraint must evaluate to a boolean
 // @25..29: value must be an array or a storage map; found `real`
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/non_int_array_access.pnt
+++ b/pintc/tests/types/non_int_array_access.pnt
@@ -14,4 +14,5 @@ solve satisfy;
 // attempt to index an array with a mismatched value
 // @33..38: array access must be with an int value
 // found access using type `bool`
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/non_tuple_access.pnt
+++ b/pintc/tests/types/non_tuple_access.pnt
@@ -13,4 +13,5 @@ solve satisfy;
 // typecheck_failure <<<
 // attempt to access tuple field from a non-tuple value
 // @25..28: value must be a tuple; found `bool`
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/recursive_array_vars.pnt
+++ b/pintc/tests/types/recursive_array_vars.pnt
@@ -30,4 +30,7 @@ solve satisfy;
 // @23..24: type of this expression is ambiguous
 // unable to determine expression type
 // @37..38: type of this expression is ambiguous
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/recursive_scalar_vars.pnt
+++ b/pintc/tests/types/recursive_scalar_vars.pnt
@@ -30,4 +30,7 @@ solve satisfy;
 // @19..20: type of this expression is ambiguous
 // unable to determine expression type
 // @34..35: type of this expression is ambiguous
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/state_in_ops.pnt
+++ b/pintc/tests/types/state_in_ops.pnt
@@ -28,4 +28,5 @@ solve satisfy;
 // @103..111: expecting type `bool`
 // unable to determine expression type
 // @93..100: type of this expression is ambiguous
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/unary_ops.pnt
+++ b/pintc/tests/types/unary_ops.pnt
@@ -35,4 +35,8 @@ solve satisfy;
 // @36..37: type of this expression is ambiguous
 // unable to determine expression type
 // @49..50: type of this expression is ambiguous
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>

--- a/pintc/tests/types/undefined_types.pnt
+++ b/pintc/tests/types/undefined_types.pnt
@@ -33,4 +33,5 @@ solve satisfy;
 // casts may only be made to an int or a real
 // unable to determine expression type
 // @65..66: type of this expression is ambiguous
+// compiler internal error: missing expr key in expr_types slotmap when checking constraint expr types
 // >>>


### PR DESCRIPTION
Closes #537 


// macrocall
    let src = "macro @equal($x, $y) {
        $x == $y
    }
    macro @foo($x) {
        let a: int;
        constraint a == $x;
    }
    intent Foo {
       @foo(3);
       constraint @equal(4; 4);
    }";
    check(
        &run_test(src),
        expect_test::expect![[
            r#"compiler internal error: invalid intermediate intent expr_types slotmap key"#
        ]],
    );