### PR TITLE
Use `SelectRange` for ternary operators with large types

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -27,16 +27,16 @@ lint:
         - name: CARGO_NET_GIT_FETCH_WITH_CLI
           value: true
   enabled:
-    - checkov@3.2.120
+    - checkov@3.2.125
     - osv-scanner@1.7.4
     - oxipng@9.1.1
-    - trivy@0.51.4
-    - trufflehog@3.77.0
+    - trivy@0.52.0
+    - trufflehog@3.78.0
     - actionlint@1.7.1
     - clippy@1.77.2
     - git-diff-check
     - markdownlint@0.41.0
-    - prettier@3.2.5
+    - prettier@3.3.0
     - rustfmt@1.77.2
     - taplo@0.8.1
     - yamllint@1.35.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys",
 ]
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a483f3cbf7cec2e153d424d0e92329d816becc6421389bd494375c6065921b9b"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "essential-asm-gen"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#f099cbed3f59e2b77abf7f2f87e4a9fb3e75b5c4"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#57bf5dd89e38c40ba218471e803081dcbb4305b9"
 dependencies = [
  "essential-asm-spec",
  "essential-types",
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "essential-asm-spec"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#f099cbed3f59e2b77abf7f2f87e4a9fb3e75b5c4"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#57bf5dd89e38c40ba218471e803081dcbb4305b9"
 dependencies = [
  "serde",
  "serde_yaml",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "essential-constraint-asm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#f099cbed3f59e2b77abf7f2f87e4a9fb3e75b5c4"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#57bf5dd89e38c40ba218471e803081dcbb4305b9"
 dependencies = [
  "essential-asm-gen",
  "essential-types",
@@ -556,7 +556,7 @@ dependencies = [
 [[package]]
 name = "essential-constraint-vm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#f099cbed3f59e2b77abf7f2f87e4a9fb3e75b5c4"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#57bf5dd89e38c40ba218471e803081dcbb4305b9"
 dependencies = [
  "ed25519-dalek",
  "essential-constraint-asm",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "essential-state-asm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#f099cbed3f59e2b77abf7f2f87e4a9fb3e75b5c4"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#57bf5dd89e38c40ba218471e803081dcbb4305b9"
 dependencies = [
  "essential-asm-gen",
  "essential-constraint-asm",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "essential-state-read-vm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#f099cbed3f59e2b77abf7f2f87e4a9fb3e75b5c4"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#57bf5dd89e38c40ba218471e803081dcbb4305b9"
 dependencies = [
  "essential-constraint-vm",
  "essential-state-asm",
@@ -591,7 +591,7 @@ dependencies = [
 [[package]]
 name = "essential-types"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#f099cbed3f59e2b77abf7f2f87e4a9fb3e75b5c4"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#57bf5dd89e38c40ba218471e803081dcbb4305b9"
 dependencies = [
  "base64",
  "hex",
@@ -1111,9 +1111,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -1593,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "pin-project-lite",
@@ -1604,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1615,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1636,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
  "indexmap",
  "serde",
@@ -1661,9 +1661,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
@@ -1823,9 +1823,9 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c949fede1d13936a99f14fafd3e76fd642b556dd2ce96287fbe2e0151bfac6"
+checksum = "56c52728401e1dc672a56e81e593e912aa54c78f40246869f78359a2bf24d29d"
 dependencies = [
  "memchr",
 ]

--- a/pintc/src/asm_gen.rs
+++ b/pintc/src/asm_gen.rs
@@ -578,12 +578,13 @@ impl AsmBuilder {
                 let type_size = then_expr.get_ty(intent).size();
                 self.compile_expr(handler, asm, else_expr, intent)?;
                 self.compile_expr(handler, asm, then_expr, intent)?;
-                self.compile_expr(handler, asm, condition, intent)?;
                 if type_size == 1 {
+                    self.compile_expr(handler, asm, condition, intent)?;
                     asm.push(Constraint::Stack(Stack::Select));
                 } else {
-                    // `SelectRange` when it's available
-                    todo!()
+                    asm.push(Constraint::Stack(Stack::Push(type_size as i64)));
+                    self.compile_expr(handler, asm, condition, intent)?;
+                    asm.push(Constraint::Stack(Stack::SelectRange));
                 }
             }
             Expr::Error(_)

--- a/pintc/src/asm_gen/tests.rs
+++ b/pintc/src/asm_gen/tests.rs
@@ -167,6 +167,120 @@ fn select() {
 }
 
 #[test]
+fn select_range() {
+    check(
+        &format!(
+            "{}",
+            compile(
+                r#"
+            var z = true ? 0x0000000000000001000000000000000200000000000000030000000000000004
+                         : 0x0000000000000005000000000000000600000000000000070000000000000008;
+            solve satisfy;
+            "#,
+            )
+        ),
+        expect_test::expect![[r#"
+            --- Constraints ---
+            constraint 0
+              Stack(Push(0))
+              Access(DecisionVar)
+              Stack(Push(1))
+              Access(DecisionVar)
+              Stack(Push(2))
+              Access(DecisionVar)
+              Stack(Push(3))
+              Access(DecisionVar)
+              Stack(Push(5))
+              Stack(Push(6))
+              Stack(Push(7))
+              Stack(Push(8))
+              Stack(Push(1))
+              Stack(Push(2))
+              Stack(Push(3))
+              Stack(Push(4))
+              Stack(Push(4))
+              Stack(Push(1))
+              Stack(SelectRange)
+              Stack(Push(4))
+              Pred(EqRange)
+            --- State Reads ---
+        "#]],
+    );
+
+    check(
+        &format!(
+            "{}",
+            compile(
+                r#"
+            var z = true ? { 0, 1 } : { 2, 3 };
+            solve satisfy;
+            "#,
+            )
+        ),
+        expect_test::expect![[r#"
+            --- Constraints ---
+            constraint 0
+              Stack(Push(0))
+              Access(DecisionVar)
+              Stack(Push(1))
+              Access(DecisionVar)
+              Stack(Push(2))
+              Stack(Push(3))
+              Stack(Push(0))
+              Stack(Push(1))
+              Stack(Push(2))
+              Stack(Push(1))
+              Stack(SelectRange)
+              Stack(Push(2))
+              Pred(EqRange)
+            --- State Reads ---
+        "#]],
+    );
+
+    check(
+        &format!(
+            "{}",
+            compile(
+                r#"
+            var c: bool; var x: int[3]; var y: int[3];
+            var z = c ? x : y;
+            solve satisfy;
+            "#,
+            )
+        ),
+        expect_test::expect![[r#"
+            --- Constraints ---
+            constraint 0
+              Stack(Push(2))
+              Access(DecisionVar)
+              Stack(Push(8))
+              Access(DecisionVar)
+              Stack(Push(9))
+              Access(DecisionVar)
+              Stack(Push(1))
+              Access(DecisionVar)
+              Stack(Push(6))
+              Access(DecisionVar)
+              Stack(Push(7))
+              Access(DecisionVar)
+              Stack(Push(3))
+              Access(DecisionVar)
+              Stack(Push(4))
+              Access(DecisionVar)
+              Stack(Push(5))
+              Access(DecisionVar)
+              Stack(Push(3))
+              Stack(Push(0))
+              Access(DecisionVar)
+              Stack(SelectRange)
+              Stack(Push(3))
+              Pred(EqRange)
+            --- State Reads ---
+        "#]],
+    );
+}
+
+#[test]
 fn binary_ops() {
     check(
         &format!(

--- a/pintc/src/error/compile_error.rs
+++ b/pintc/src/error/compile_error.rs
@@ -161,6 +161,8 @@ pub enum CompileError {
         expected_ty: String,
         span: Span,
     },
+    #[error("invalid array range type {found_ty}")]
+    InvalidArrayRangeType { found_ty: String, span: Span },
     #[error("attempt to index a storage map with a mismatched value")]
     StorageMapAccessWithWrongType {
         found_ty: String,
@@ -660,6 +662,14 @@ impl ReportableError for CompileError {
                 }]
             }
 
+            InvalidArrayRangeType { span, .. } => {
+                vec![ErrorLabel {
+                    message: "array access must be of type `int` or `enum`".to_string(),
+                    span: span.clone(),
+                    color: Color::Red,
+                }]
+            }
+
             StorageMapAccessWithWrongType {
                 expected_ty, span, ..
             } => {
@@ -1047,6 +1057,10 @@ impl ReportableError for CompileError {
                 Some(format!("found access using type `{found_ty}`"))
             }
 
+            InvalidArrayRangeType { found_ty, .. } => {
+                Some(format!("found range type `{found_ty}`"))
+            }
+
             StorageMapAccessWithWrongType { found_ty, .. } => {
                 Some(format!("found access using type `{found_ty}`"))
             }
@@ -1207,6 +1221,7 @@ impl Spanned for CompileError {
             | NonBoolConditional { span, .. }
             | IndexExprNonIndexable { span, .. }
             | ArrayAccessWithWrongType { span, .. }
+            | InvalidArrayRangeType { span, .. }
             | StorageMapAccessWithWrongType { span, .. }
             | MismatchedArrayComparisonSizes { span, .. }
             | TupleAccessNonTuple { span, .. }

--- a/pintc/tests/types/bad_array_range_expr.pnt
+++ b/pintc/tests/types/bad_array_range_expr.pnt
@@ -1,0 +1,53 @@
+// Bad
+var a: int[true];
+var b: int[false];
+var d: int[0x0000000000000000000000000000000000000000000000000000000000000000];
+var e: int[{1, 2}];
+var f: int[[1, 2]];
+var g: int["str"];
+var h: int[10.0];
+
+// Ok
+enum MyEnum = A | B;
+var i: int[10];
+var j: int[MyEnum];
+
+solve satisfy;
+
+// intermediate <<<
+//+var ::a: int[true];
+//+var ::b: int[false];
+//+var ::d: int[0x0000000000000000000000000000000000000000000000000000000000000000];
+//+var ::e: int[{1, 2}];
+//+var ::f: int[[1, 2]];
+//+var ::g: int["str"];
+//+var ::h: int[1e1];
+//+var ::i: int[10];
+//+var ::j: int[::MyEnum];
+//+enum ::MyEnum = A | B;
+//+solve satisfy;
+// >>>
+
+// typecheck_failure <<<
+// invalid array range type bool
+// @18..22: array access must be of type `int` or `enum`
+// found range type `bool`
+// invalid array range type bool
+// @36..41: array access must be of type `int` or `enum`
+// found range type `bool`
+// invalid array range type b256
+// @55..121: array access must be of type `int` or `enum`
+// found range type `b256`
+// invalid array range type {int, int}
+// @135..141: array access must be of type `int` or `enum`
+// found range type `{int, int}`
+// invalid array range type int[2]
+// @155..161: array access must be of type `int` or `enum`
+// found range type `int[2]`
+// invalid array range type string
+// @175..180: array access must be of type `int` or `enum`
+// found range type `string`
+// invalid array range type real
+// @194..198: array access must be of type `int` or `enum`
+// found range type `real`
+// >>>

--- a/tests/validation_tests.rs
+++ b/tests/validation_tests.rs
@@ -247,7 +247,7 @@ fn parse_solution(
                     .unwrap_or(&Vec::new())
                     .iter()
                     .map(|d| {
-                        d.as_integer().ok_or_else(|| {
+                        d.as_integer().map(|d| vec![d]).ok_or_else(|| {
                             anyhow!("Invalid integer value in list of decision variables")
                         })
                     })

--- a/tests/validation_tests/select.pnt
+++ b/tests/validation_tests/select.pnt
@@ -3,4 +3,22 @@ var y: int = 3;
 var z1: int = true ? x + y : x * y;
 var z2: int = false ? x + y : x * y;
 
+var p: b256 = 0x0000000000000001000000000000000200000000000000030000000000000004;
+var q: b256 = 0x0000000000000004000000000000000300000000000000020000000000000001;
+var w1: b256 = true ? p : q;
+var w2: b256 = false ? p : q;
+constraint w1 == p;
+constraint w2 == q;
+
+var a = { 5, 6 };
+var b = { 8, 9 };
+var c1 = true ? a : b;
+var c2 = false ? a : b;
+constraint c1.0 == 5;
+constraint c1.1 == 6;
+constraint c1 == a;
+constraint c2.0 == 8;
+constraint c2.1 == 9;
+constraint c2 == b;
+
 solve satisfy;

--- a/tests/validation_tests/select.toml
+++ b/tests/validation_tests/select.toml
@@ -4,5 +4,29 @@ decision_variables = [
   3, # y
   5, # z1 = x + y
   6, # z2 = x * y
+  1,
+  2,
+  3,
+  4, # p
+  4,
+  3,
+  2,
+  1, # q
+  1,
+  2,
+  3,
+  4, # w1
+  4,
+  3,
+  2,
+  1, # w2
+  5,
+  6, #a
+  8,
+  9, #b
+  5,
+  6, #c1
+  8,
+  9, #c2
 ]
 intent_to_solve = { set = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", intent = "" }

--- a/tests/validation_tests/select_array.pnt
+++ b/tests/validation_tests/select_array.pnt
@@ -1,0 +1,12 @@
+var d = [ 5, 6 ];
+var e = [ 8, 9 ];
+var f1 = true ? d : e;
+var f2 = false ? d : e;
+constraint f1[0] == 5;
+constraint f1[1] == 6;
+constraint f1 == d;
+constraint f2[0] == 8;
+constraint f2[1] == 9;
+constraint f2 == e;
+
+solve satisfy;

--- a/tests/validation_tests/select_array.toml
+++ b/tests/validation_tests/select_array.toml
@@ -1,0 +1,12 @@
+[[data]]
+decision_variables = [
+  8, #e[0]
+  5, #f1[0]
+  8, #f2[0]
+  5, #d[0]
+  6, #d[1]
+  9, #e[1]
+  6, #f1[1]
+  9, #f2[1]
+]
+intent_to_solve = { set = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", intent = "" }


### PR DESCRIPTION
Closes #591 

Fairly simple. If the type is larger than 1 word, use `SelectRange`.

I also had to make a small change to the type checker to type check array range expressions by going through all possible types and type checking the range of the type is an array.