### PR TITLE
Allow `{ 0 }` and `{ int }` without the trailing comma

### DIFF
--- a/docs/specs/src/pint/expressions/atoms/tuples.md
+++ b/docs/specs/src/pint/expressions/atoms/tuples.md
@@ -6,12 +6,12 @@ Tuple expressions are written as:
 <tuple-expr> ::= "{" ( [ <ident> ":" ] <expr> "," ... ) "}"
 ```
 
-For example: `let t = { x: 5, 3, "foo" };`. The type of this tuple can be inferred by the compiler to be `{ x: int, int, string }`.
+For example: `var t = { x: 5, 3, "foo" };`. The type of this tuple can be inferred by the compiler to be `{ x: int, int, string }`.
 
 The following is another example:
 
 ```pint
-let t: { x: int, real } = { 6, 5.0 }
+var t: { x: int, real } = { 6, 5.0 }
 ```
 
 where the type of the tuple is indicated by the type annotation and has a named field `x`, but that named field is not actually used in the tuple expression. This is allowed because `{ x: int, real }` and `{ int, real }` coerce into each other.
@@ -19,18 +19,18 @@ where the type of the tuple is indicated by the type annotation and has a named 
 Tuple fields can be initialized out of order only if and only if all the fields have names and their names are used in the tuple expression. For example, the following is allowed:
 
 ```pint
-let t: { x: int, y: real } = { y: 5.0, x: 6 };
+var t: { x: int, y: real } = { y: 5.0, x: 6 };
 ```
 
 while the following are not:
 
 ```pint
-let t: { x: int, real } = { 5.0, x: 6 };
-let t: { x: int, y: real } = { 5.0, x: 6 };
-let t: { x: int, y: real } = { 5.0, 6 }; // This is a type mismatch!
+var t: { x: int, real } = { 5.0, x: 6 };
+var t: { x: int, y: real } = { 5.0, x: 6 };
+var t: { x: int, y: real } = { 5.0, 6 }; // This is a type mismatch!
 ```
 
-Tuple expressions that contain a single _unnamed_ field require the trailing `,` as in `let t = { 4.0, };`. Otherwise, the expression becomes a code block that simply evaluates to its contained expression. Tuple expressions that contain a single _named_ field do not require the trailing `,`.
+Tuple expressions that contain a single field do not require the trailing `,` as in `var t = { 4.0 };` or `var t = { x: 5 }`.
 
 Note that the grammar disallows empty tuple expressions `{ }`.
 

--- a/pintc/src/parser/tests.rs
+++ b/pintc/src/parser/tests.rs
@@ -2200,13 +2200,9 @@ fn array_element_accesses() {
 fn tuple_expressions() {
     let expr = (yp::TestDelegateParser::new(), "expr");
 
-    // Should probably allow this. Won't worry about it for now.
     check(
         &run_parser!(expr, r#"{ 0 }"#),
-        expect_test::expect![[r#"
-            expected `,`, found `}`
-            @15..16: expected `,`
-        "#]],
+        expect_test::expect![[r#"{0}"#]],
     );
 
     check(

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -1254,7 +1254,6 @@ TupleExpr: Expr = {
 
         Expr::Error(span)
     },
-
 };
 
 TupleExprFields: Vec<(Option<Ident>, ExprKey)> = {
@@ -1262,6 +1261,11 @@ TupleExprFields: Vec<(Option<Ident>, ExprKey)> = {
         // Special case for a single field with a field label which does not require the trailing
         // comma to distinguish it from a block expression.
         vec![(Some(id), expr)]
+    },
+    <expr:Expr> => {
+        // Special case for a single field which does not require the trailing
+        // comma to distinguish it from a block expression.
+        vec![(None, expr)]
     },
     <Sep1List<TupleExprField, ",">>,
 };


### PR DESCRIPTION
Closes #590

All tuple types and tuple field expressions below are now allowed.

```pnt
var t = { g: 5, 3, "foo", };
var r = { s: 5, 3, "foo", };
var x = { 0 };
var j = { 0, };
var k = { z: 0 };
type a = { x: int, w: int, };
type b = { y: int };
type c = { z: int, };
```

I have allowed no trailing comma, but I have not required no trailing comma.

I've updated the documentation to reflect that. It's time to face the music and admit I've been living under a rock while working on my issues. We don't allow `let` anymore, right? 

Also we don't have `blocks` anymore and that's why we can allow a case where there is no trailing comma?