### PR TITLE
Add `nil` and `__state_len` intrinsic

### DIFF
--- a/docs/book/src/appendix/intrinsics.md
+++ b/docs/book/src/appendix/intrinsics.md
@@ -58,6 +58,15 @@ __sha256(data: <any>) -> b256
 ---
 
 ```pint
+__state_len(data: <state>) -> int
+```
+
+**Description:** Returns the length of a state variable. the argument `data` must be a state
+variable or a "next state" expression but can have any type.
+
+---
+
+```pint
 __verify_ed25519(data: <any>, sig: { b256, b256 }, pub_key: b256) -> bool
 ```
 

--- a/pintc/src/expr.rs
+++ b/pintc/src/expr.rs
@@ -101,6 +101,7 @@ pub enum TupleAccess {
 #[derive(Clone, Debug, PartialEq)]
 pub enum Immediate {
     Error,
+    Nil,
     Real(f64),
     Int(i64),
     Bool(bool),
@@ -194,6 +195,16 @@ impl Spanned for Expr {
 }
 
 impl Expr {
+    pub fn is_nil(&self) -> bool {
+        matches!(
+            self,
+            Expr::Immediate {
+                value: Immediate::Nil,
+                ..
+            }
+        )
+    }
+
     pub fn replace_ref<F: FnMut(&mut ExprKey)>(&mut self, mut replace: F) {
         match self {
             Expr::Immediate { value, .. } => match value {
@@ -201,6 +212,7 @@ impl Expr {
                 Immediate::Tuple(fields) => fields.iter_mut().for_each(|(_, expr)| replace(expr)),
 
                 Immediate::Error
+                | Immediate::Nil
                 | Immediate::Real(_)
                 | Immediate::Int(_)
                 | Immediate::Bool(_)

--- a/pintc/src/expr/display.rs
+++ b/pintc/src/expr/display.rs
@@ -123,6 +123,7 @@ impl DisplayWithII for super::Immediate {
     fn fmt(&self, f: &mut Formatter, ii: &IntermediateIntent) -> Result {
         match self {
             super::Immediate::Error => write!(f, "Error"),
+            super::Immediate::Nil => write!(f, "nil"),
             super::Immediate::Real(n) => write!(f, "{n:e}"),
             super::Immediate::Int(n) => write!(f, "{n}"),
             super::Immediate::Bool(b) => write!(f, "{b}"),

--- a/pintc/src/expr/evaluate.rs
+++ b/pintc/src/expr/evaluate.rs
@@ -327,7 +327,8 @@ impl Evaluator {
                     }
 
                     // Invalid to cast from these values.
-                    Imm::String(_)
+                    Imm::Nil
+                    | Imm::String(_)
                     | Imm::B256(_)
                     | Imm::Array { .. }
                     | Imm::Tuple(_)
@@ -420,6 +421,7 @@ impl ExprKey {
                 }
 
                 Imm::Error
+                | Imm::Nil
                 | Imm::Real(_)
                 | Imm::Int(_)
                 | Imm::Bool(_)

--- a/pintc/src/intermediate.rs
+++ b/pintc/src/intermediate.rs
@@ -400,6 +400,7 @@ impl IntermediateIntent {
                 }
 
                 Immediate::Error
+                | Immediate::Nil
                 | Immediate::Real(_)
                 | Immediate::Int(_)
                 | Immediate::Bool(_)

--- a/pintc/src/intermediate/exprs.rs
+++ b/pintc/src/intermediate/exprs.rs
@@ -150,6 +150,7 @@ impl<'a> Iterator for ExprsIter<'a> {
                 }
 
                 Immediate::Error
+                | Immediate::Nil
                 | Immediate::Real(_)
                 | Immediate::Int(_)
                 | Immediate::Bool(_)

--- a/pintc/src/intermediate/transform.rs
+++ b/pintc/src/intermediate/transform.rs
@@ -36,7 +36,8 @@ mod validate;
 use crate::error::{ErrorEmitted, Handler};
 use canonicalize_solve_directive::canonicalize_solve_directive;
 use lower::{
-    lower_aliases, lower_bools, lower_casts, lower_enums, lower_ifs, lower_imm_accesses, lower_ins,
+    lower_aliases, lower_bools, lower_casts, lower_compares_to_nil, lower_enums, lower_ifs,
+    lower_imm_accesses, lower_ins,
 };
 use scalarize::scalarize;
 use unroll::unroll_generators;
@@ -50,6 +51,8 @@ impl super::Program {
             // other passes are safe to assume that `if` declarations and their content have
             // already been converted to raw constraints.
             lower_ifs(ii);
+
+            let _ = lower_compares_to_nil(handler, ii);
 
             // Unroll each generator into one large conjuction
             let _ = handler.scope(|handler| unroll_generators(handler, ii));

--- a/pintc/src/lexer.rs
+++ b/pintc/src/lexer.rs
@@ -85,6 +85,8 @@ pub enum Token {
     True,
     #[token("false")]
     False,
+    #[token("nil")]
+    Nil,
     #[token("string")]
     String,
     #[token("b256")]
@@ -210,6 +212,7 @@ pub(super) static KEYWORDS: &[Token] = &[
     Token::Bool,
     Token::True,
     Token::False,
+    Token::Nil,
     Token::String,
     Token::B256,
     Token::ForAll,
@@ -279,6 +282,7 @@ impl fmt::Display for Token {
             Token::Bool => write!(f, "bool"),
             Token::True => write!(f, "true"),
             Token::False => write!(f, "false"),
+            Token::Nil => write!(f, "nil"),
             Token::String => write!(f, "string"),
             Token::B256 => write!(f, "b256"),
             Token::Fn => write!(f, "fn"),
@@ -765,7 +769,7 @@ pub fn get_token_error_category(lalrpop_token: &Option<String>) -> Option<String
     if let Some(token) = lalrpop_token {
         match token.as_str() {
             "int_ty" | "real_ty" | "bool_ty" | "string_ty" | "b256_ty" => Some("a type".to_owned()),
-            "int_lit" | "real_lit" | "str_lit" => Some("a literal".to_owned()),
+            "int_lit" | "real_lit" | "str_lit" | "nil" => Some("a literal".to_owned()),
             "true" | "false" => Some("a boolean".to_owned()),
             "ident" => Some("an identifier".to_owned()),
             "satisfy" => Some("a directive".to_owned()),

--- a/pintc/src/lexer/tests.rs
+++ b/pintc/src/lexer/tests.rs
@@ -157,6 +157,7 @@ fn bools() {
     assert_eq!(lex_one_success("false"), Token::False);
     assert_ne!(lex_one_success("false"), Token::True);
     assert_ne!(lex_one_success("true"), Token::False);
+    assert_eq!(lex_one_success("nil"), Token::Nil);
 }
 
 #[test]

--- a/pintc/src/parser.rs
+++ b/pintc/src/parser.rs
@@ -283,6 +283,7 @@ impl<'a> ProjectParser<'a> {
                         }
                     }
                     Immediate::Error
+                    | Immediate::Nil
                     | Immediate::Real(_)
                     | Immediate::Int(_)
                     | Immediate::Bool(_)

--- a/pintc/src/parser/tests.rs
+++ b/pintc/src/parser/tests.rs
@@ -274,6 +274,17 @@ fn storage_types() {
 fn immediates() {
     let immediate = (yp::TestDelegateParser::new(), "expr");
 
+    check(&run_parser!(immediate, "nil"), expect_test::expect!["nil"]);
+
+    check(
+        &run_parser!(immediate, "true"),
+        expect_test::expect!["true"],
+    );
+    check(
+        &run_parser!(immediate, "false"),
+        expect_test::expect!["false"],
+    );
+
     check(&run_parser!(immediate, "0x88"), expect_test::expect!["136"]);
     check(&run_parser!(immediate, "0b111"), expect_test::expect!["7"]);
     check(&run_parser!(immediate, "1"), expect_test::expect!["1"]);

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -955,6 +955,7 @@ Immediate: Immediate = {
     <s:"real_lit"> => Immediate::Real(s.replace('_', "").parse().unwrap()),
     "true" => Immediate::Bool(true),
     "false" => Immediate::Bool(false),
+    "nil" => Immediate::Nil,
     <s:"str_lit"> => Immediate::String(s),
 };
 
@@ -1161,6 +1162,7 @@ extern {
 
         "true" => lexer::Token::True,
         "false" => lexer::Token::False,
+        "nil" => lexer::Token::Nil,
 
         "fn" => lexer::Token::Fn,
         "if" => lexer::Token::If,

--- a/pintc/src/types.rs
+++ b/pintc/src/types.rs
@@ -10,6 +10,7 @@ pub type Path = String;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum PrimitiveKind {
+    Nil,
     Bool,
     Int,
     Real,
@@ -83,6 +84,10 @@ impl Type {
         } else {
             None
         }
+    }
+
+    pub fn is_nil(&self) -> bool {
+        check_alias!(self, is_nil, is_primitive!(self, PrimitiveKind::Nil))
     }
 
     pub fn is_bool(&self) -> bool {

--- a/pintc/src/types/display.rs
+++ b/pintc/src/types/display.rs
@@ -15,6 +15,7 @@ impl DisplayWithII for super::Type {
             super::Type::Unknown(..) => write!(f, "Unknown"),
 
             super::Type::Primitive { kind, .. } => match kind {
+                super::PrimitiveKind::Nil => write!(f, "nil"),
                 super::PrimitiveKind::Bool => write!(f, "bool"),
                 super::PrimitiveKind::Int => write!(f, "int"),
                 super::PrimitiveKind::Real => write!(f, "real"),

--- a/pintc/tests/basic_tests/bad_nil.pnt
+++ b/pintc/tests/basic_tests/bad_nil.pnt
@@ -1,0 +1,40 @@
+var x: int = nil;
+var y: int = 1 + nil;
+var z: int;
+constraint z < nil;
+constraint nil;
+
+// intermediate <<<
+// var ::x: int;
+// var ::y: int;
+// var ::z: int;
+// constraint (::x == nil);
+// constraint (::y == (1 + nil));
+// constraint (::z < nil);
+// constraint nil;
+// solve satisfy;
+// >>>
+
+// typecheck_failure <<<
+// binary operator type error
+// @4..5: unexpected argument for operator `==`
+// only state variables and next state expressions can be compared to `nil`
+// binary operator type error
+// @35..38: operator `+` argument has unexpected type `nil`
+// binary operator type error
+// @67..70: operator `<` argument has unexpected type `nil`
+// constraint expression type error
+// @0..16: constraint expression has unexpected type `Unknown`
+// @0..16: expecting type `bool`
+// constraint expression type error
+// @18..38: constraint expression has unexpected type `Unknown`
+// @18..38: expecting type `bool`
+// constraint expression type error
+// @52..70: constraint expression has unexpected type `Unknown`
+// @52..70: expecting type `bool`
+// constraint expression type error
+// @72..86: constraint expression has unexpected type `nil`
+// @72..86: expecting type `bool`
+// >>>
+
+solve satisfy;

--- a/pintc/tests/basic_tests/nil.pnt
+++ b/pintc/tests/basic_tests/nil.pnt
@@ -1,0 +1,72 @@
+storage {
+    x: int,
+    z: {int, int, int},
+}
+
+state x = storage::x;
+state z = storage::z;
+
+constraint nil == nil;
+constraint nil != nil;
+
+constraint x == nil;
+constraint nil == x;
+
+constraint z == nil;
+constraint nil == z;
+
+constraint x != nil;
+constraint nil != x;
+
+constraint z != nil;
+constraint nil != z;
+
+constraint (nil == z) && (nil != x);
+constraint (nil != z) && (nil == x);
+
+solve satisfy;
+
+// intermediate <<<
+// storage {
+//     x: int,
+//     z: {int, int, int},
+// }
+// state ::x = storage::x;
+// state ::z = storage::z;
+// constraint (nil == nil);
+// constraint (nil != nil);
+// constraint (::x == nil);
+// constraint (nil == ::x);
+// constraint (::z == nil);
+// constraint (nil == ::z);
+// constraint (::x != nil);
+// constraint (nil != ::x);
+// constraint (::z != nil);
+// constraint (nil != ::z);
+// constraint ((nil == ::z) && (nil != ::x));
+// constraint ((nil != ::z) && (nil == ::x));
+// solve satisfy;
+// >>>
+
+// flattened <<<
+
+// storage {
+//     x: int,
+//     z: {int, int, int},
+// }
+// state ::x: int = storage::x;
+// state ::z: {int, int, int} = storage::z;
+// constraint 0;
+// constraint 0;
+// constraint (__state_len(::x) == 0);
+// constraint (__state_len(::x) == 0);
+// constraint (__state_len(::z) == 0);
+// constraint (__state_len(::z) == 0);
+// constraint (__state_len(::x) != 0);
+// constraint (__state_len(::x) != 0);
+// constraint (__state_len(::z) != 0);
+// constraint (__state_len(::z) != 0);
+// constraint ((__state_len(::z) == 0) && (__state_len(::x) != 0));
+// constraint ((__state_len(::z) != 0) && (__state_len(::x) == 0));
+// solve satisfy;
+// >>>

--- a/pintc/tests/intrinsics/bad_state_len_arg.pnt
+++ b/pintc/tests/intrinsics/bad_state_len_arg.pnt
@@ -1,0 +1,31 @@
+var x: int;
+var y = __state_len(x);
+var z = __state_len(5);
+
+solve satisfy;
+
+// intermediate <<<
+// var ::x: int;
+// var ::y;
+// var ::z;
+// constraint (::y == __state_len(::x));
+// constraint (::z == __state_len(5));
+// solve satisfy;
+// >>>
+
+// typecheck_failure <<<
+// intrinsic argument must be a state variable
+// @20..34: intrinsic argument must be a state variable
+// intrinsic argument must be a state variable
+// @44..58: intrinsic argument must be a state variable
+// unable to determine expression type
+// @16..17: type of this expression is ambiguous
+// unable to determine expression type
+// @40..41: type of this expression is ambiguous
+// constraint expression type error
+// @12..34: constraint expression has unexpected type `Unknown`
+// @12..34: expecting type `bool`
+// constraint expression type error
+// @36..58: constraint expression has unexpected type `Unknown`
+// @36..58: expecting type `bool`
+// >>>

--- a/pintc/tests/intrinsics/incorrect_args.pnt
+++ b/pintc/tests/intrinsics/incorrect_args.pnt
@@ -29,9 +29,20 @@ var recover_secp256k1_1: { b256, int } = __recover_secp256k1(hash0, { hash0, has
 var recover_secp256k1_2: { b256, int } = __recover_secp256k1(hash0);
 var recover_secp256k1_3: { b256, int } = __recover_secp256k1(hash0, {hash0, hash0, 69}, hash0);
 
+storage {
+    x: int,
+}
+state x = storage::x;
+
+var bad_state_len_1 = __state_len(x, 0);
+var bad_state_len_2 = __state_len();
+
 solve satisfy;
 
 // intermediate <<<
+// storage {
+//     x: int,
+// }
 // var ::hash0: b256;
 // var ::mut_keys_len;
 // var ::mut_keys_contains_0: bool;
@@ -50,6 +61,9 @@ solve satisfy;
 // var ::recover_secp256k1_1: {b256, int};
 // var ::recover_secp256k1_2: {b256, int};
 // var ::recover_secp256k1_3: {b256, int};
+// var ::bad_state_len_1;
+// var ::bad_state_len_2;
+// state ::x = storage::x;
 // constraint (::mut_keys_len == __mut_keys_len(42));
 // constraint (::mut_keys_contains_0 == __mut_keys_contains(5));
 // constraint (::mut_keys_contains_1 == __mut_keys_contains());
@@ -67,6 +81,8 @@ solve satisfy;
 // constraint (::recover_secp256k1_1 == __recover_secp256k1(::hash0, {::hash0, ::hash0}));
 // constraint (::recover_secp256k1_2 == __recover_secp256k1(::hash0));
 // constraint (::recover_secp256k1_3 == __recover_secp256k1(::hash0, {::hash0, ::hash0, 69}, ::hash0));
+// constraint (::bad_state_len_1 == __state_len(::x, 0));
+// constraint (::bad_state_len_2 == __state_len());
 // solve satisfy;
 // >>>
 
@@ -110,6 +126,10 @@ solve satisfy;
 // @1064..1090: unexpected number of arguments here
 // this intrinsic takes 2 arguments but 3 arguments were supplied
 // @1133..1186: unexpected number of arguments here
+// this intrinsic takes 1 argument but 2 arguments were supplied
+// @1258..1275: unexpected number of arguments here
+// this intrinsic takes 1 argument but 0 arguments were supplied
+// @1299..1312: unexpected number of arguments here
 // unable to determine expression type
 // @179..191: type of this expression is ambiguous
 // unable to determine expression type
@@ -122,6 +142,10 @@ solve satisfy;
 // @526..534: type of this expression is ambiguous
 // unable to determine expression type
 // @553..561: type of this expression is ambiguous
+// unable to determine expression type
+// @1240..1255: type of this expression is ambiguous
+// unable to determine expression type
+// @1281..1296: type of this expression is ambiguous
 // constraint expression type error
 // @175..212: constraint expression has unexpected type `Unknown`
 // @175..212: expecting type `bool`
@@ -173,4 +197,10 @@ solve satisfy;
 // constraint expression type error
 // @1092..1186: constraint expression has unexpected type `Unknown`
 // @1092..1186: expecting type `bool`
+// constraint expression type error
+// @1236..1275: constraint expression has unexpected type `Unknown`
+// @1236..1275: expecting type `bool`
+// constraint expression type error
+// @1277..1312: constraint expression has unexpected type `Unknown`
+// @1277..1312: expecting type `bool`
 // >>>

--- a/pintc/tests/intrinsics/state_len.pnt
+++ b/pintc/tests/intrinsics/state_len.pnt
@@ -1,0 +1,66 @@
+enum MyEnum = A | B;
+
+storage {
+    a: int,
+    b: bool,
+    c: b256,
+    d: { int, bool },
+}
+
+state a = storage::a;
+state b = storage::b;
+state c = storage::c;
+state d = storage::d;
+
+var a_len = __state_len(a);
+var b_len = __state_len(b);
+var c_len = __state_len(c);
+var d_len = __state_len(d);
+
+solve satisfy;
+
+// intermediate <<<,
+// storage {
+//     a: int,
+//     b: bool,
+//     c: b256,
+//     d: {int, bool},
+// }
+// var ::a_len;
+// var ::b_len;
+// var ::c_len;
+// var ::d_len;
+// state ::a = storage::a;
+// state ::b = storage::b;
+// state ::c = storage::c;
+// state ::d = storage::d;
+// enum ::MyEnum = A | B;
+// constraint (::a_len == __state_len(::a));
+// constraint (::b_len == __state_len(::b));
+// constraint (::c_len == __state_len(::c));
+// constraint (::d_len == __state_len(::d));
+// solve satisfy;
+// >>>
+
+// flattened <<<,
+// storage {
+//     a: int,
+//     b: bool,
+//     c: b256,
+//     d: {int, bool},
+// }
+// var ::a_len: int;
+// var ::b_len: int;
+// var ::c_len: int;
+// var ::d_len: int;
+// state ::a: int = storage::a;
+// state ::b: int = storage::b;
+// state ::c: b256 = storage::c;
+// state ::d: {int, bool} = storage::d;
+// enum ::MyEnum = A | B;
+// constraint (::a_len == __state_len(::a));
+// constraint (::b_len == __state_len(::b));
+// constraint (::c_len == __state_len(::c));
+// constraint (::d_len == __state_len(::d));
+// solve satisfy;
+// >>>

--- a/tests/validation_tests/intrinsics.pnt
+++ b/tests/validation_tests/intrinsics.pnt
@@ -1,3 +1,16 @@
+// db <<<
+// 0, 42
+// 1, 43
+// 3, 1 1 1 1
+// >>>
+
+storage {
+    x: int,
+    y: int,
+    z: int,
+    w: b256,
+}
+
 // Intent with address `0x0000000000000000000000000000000000000000000000000000000000000000`
 intent First { }
 
@@ -7,21 +20,23 @@ intent Bar { }
 // Intent with address `0x0000000000000000000000000000000000000000000000000000000000000002`
 intent Foo {
     var mut_keys_len: int = __mut_keys_len();
-    constraint mut_keys_len == 3;
+    constraint mut_keys_len == 4;
 
     // Solution contains these 
     var mut_keys_contains_0: bool = __mut_keys_contains([0]);
     var mut_keys_contains_1: bool = __mut_keys_contains([1]);
     var mut_keys_contains_2: bool = __mut_keys_contains([2]);
+    var mut_keys_contains_3: bool = __mut_keys_contains([3]);
     constraint mut_keys_contains_0 == true;
     constraint mut_keys_contains_1 == true;
     constraint mut_keys_contains_2 == true;
+    constraint mut_keys_contains_3 == true;
 
     // Solution does not contain these
-    var mut_keys_contains_3: bool = __mut_keys_contains([3]);
     var mut_keys_contains_4: bool = __mut_keys_contains([4]);
-    constraint mut_keys_contains_3 == false;
+    var mut_keys_contains_5: bool = __mut_keys_contains([5]);
     constraint mut_keys_contains_4 == false;
+    constraint mut_keys_contains_5 == false;
 
     var this_address: b256 = __this_address();
     constraint this_address == 0x0000000000000000000000000000000000000000000000000000000000000002;
@@ -70,6 +85,27 @@ intent Foo {
         );
 
     constraint recover_secp256k1 == { 0x0308f06a2a35c484909a2480ce681b24967cfd55fca22fcd705769ac55db6279, 13 };
+
+    state x = storage::x;
+    state y = storage::y;
+    state z = storage::z;
+    state w = storage::w;
+
+    // `x` is set in the pre state db and in the solution
+    constraint __state_len(x) == 1;
+    constraint __state_len(x) == 1;
+
+    // `y` is set in the pre state db and in the solution
+    constraint __state_len(y) == 1;
+    constraint __state_len(y') == 1;
+
+    // `z` is not set in the pre state db but is set in the solution
+    constraint __state_len(z) == 0;
+    constraint __state_len(z') == 1;
+
+    // `w` is set in the pre state db but unset in the solution
+    constraint __state_len(w) == 4;
+    constraint __state_len(w') == 0;
 }
 
 

--- a/tests/validation_tests/intrinsics.toml
+++ b/tests/validation_tests/intrinsics.toml
@@ -1,7 +1,7 @@
 [[data]]
 decision_variables = [
   # ::mut_keys_len
-  3,
+  4,
 
   # ::mut_keys_contains_0
   1,
@@ -13,9 +13,12 @@ decision_variables = [
   1,
 
   # ::mut_keys_contains_3
-  0,
+  1,
 
   # ::mut_keys_contains_4
+  0,
+
+  # ::mut_keys_contains_5
   0,
 
   # ::this_address
@@ -86,5 +89,9 @@ state_mutations = [
     2,
   ], value = [
     44,
+  ] },
+  { key = [
+    3,
+  ], value = [
   ] },
 ]

--- a/tests/validation_tests/nil.pnt
+++ b/tests/validation_tests/nil.pnt
@@ -1,0 +1,36 @@
+// db <<<
+// 0, 42
+// 1, 43
+// 3, 1 1 1 1
+// >>>
+
+storage {
+    x: int,
+    y: int,
+    z: int,
+    w: b256,
+}
+
+// Intent with address `0x0000000000000000000000000000000000000000000000000000000000000000`
+intent Foo {
+    state x = storage::x;
+    state y = storage::y;
+    state z = storage::z;
+    state w = storage::w;
+
+    // `x` is set in the pre state db and in the solution
+    constraint x != nil;
+    constraint nil != x';
+
+    // `y` is set in the pre state db and in the solution
+    constraint nil != y;
+    constraint y' != nil;
+
+    // `z` is not set in the pre state db but is set in the solution
+    constraint z == nil;
+    constraint z' != 1;
+
+    // `w` is set in the pre state db but unset in the solution
+    constraint w != nil;
+    constraint nil == w';
+}

--- a/tests/validation_tests/nil.toml
+++ b/tests/validation_tests/nil.toml
@@ -1,0 +1,24 @@
+[[data]]
+decision_variables = []
+intent_to_solve = { set = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", intent = "::Foo" }
+state_mutations = [
+  { key = [
+    0,
+  ], value = [
+    42,
+  ] },
+  { key = [
+    1,
+  ], value = [
+    98,
+  ] },
+  { key = [
+    2,
+  ], value = [
+    44,
+  ] },
+  { key = [
+    3,
+  ], value = [
+  ] },
+]


### PR DESCRIPTION
Closes #634

* Adds intrinsic `__state_len(..)` which takes a state var or a "next state" expression. It returns the result of the `StateLen` or `StateLenRange` opcode depending on how wide the data is.
* Adds `nil`, an immediate that represents the absence of a value. For now, only state vars and "next state" expressions can be `nil`. In the future, we may extend this to `pub var` as well.
* `x == nil` becomes `__state_len(x) == 0` and `x != nil` becomes `__state_len(x) != 0`. All that happens in a new pass in `lower.rs`.