### PR TITLE
Update how tuple keys are computed in the JSON ABI to match asm_gen

### DIFF
--- a/pint-pkg/src/build.rs
+++ b/pint-pkg/src/build.rs
@@ -105,6 +105,8 @@ pub enum PintcError {
     TypeCheck,
     #[error("flattening error")]
     Flatten,
+    #[error("abi gen")]
+    ABIGen,
     #[error("intent-gen error")]
     IntentGen,
 }
@@ -273,7 +275,10 @@ fn build_pkg(plan: &Plan, built_pkgs: &BuiltPkgs, n: NodeIx) -> Result<BuiltPkg,
             };
 
             // Produce the ABI for the flattened program.
-            let abi = flattened.abi();
+            let Ok(abi) = flattened.abi() else {
+                let kind = BuildPkgErrorKind::from(PintcError::ABIGen);
+                return Err(BuildPkgError { handler, kind });
+            };
 
             // Generate the assembly and the intents.
             let Ok(contract) = handler.scope(|h| program_to_intents(h, &flattened)) else {

--- a/pintc/src/intermediate/vars.rs
+++ b/pintc/src/intermediate/vars.rs
@@ -1,6 +1,6 @@
 use super::{DisplayWithII, Ident, IntermediateIntent};
 use crate::{
-    error::{ErrorEmitted, Handler},
+    error::{CompileError, ErrorEmitted, Handler},
     span::Span,
     types::{Path, Type},
 };
@@ -100,11 +100,11 @@ impl VarKey {
     }
 
     /// Generate a `VarABI` given a `VarKey` and an `IntermediateIntent`
-    pub fn abi(&self, ii: &IntermediateIntent) -> VarABI {
-        VarABI {
+    pub fn abi(&self, ii: &IntermediateIntent) -> Result<VarABI, CompileError> {
+        Ok(VarABI {
             name: self.get(ii).name.clone(),
-            ty: self.get_ty(ii).abi(),
-        }
+            ty: self.get_ty(ii).abi()?,
+        })
     }
 }
 

--- a/pintc/tests/abi/simple-abi.json
+++ b/pintc/tests/abi/simple-abi.json
@@ -104,7 +104,7 @@
               }
             }
           ],
-          "key": [3]
+          "key": [3, 0]
         }
       }
     },
@@ -133,13 +133,13 @@
                     {
                       "name": null,
                       "ty": {
-                        "Int": [4, 2, 0]
+                        "Int": [4, 2]
                       }
                     },
                     {
                       "name": null,
                       "ty": {
-                        "Int": [4, 2, 1]
+                        "Int": [4, 3]
                       }
                     }
                   ],
@@ -148,7 +148,7 @@
               }
             }
           ],
-          "key": [4]
+          "key": [4, 0]
         }
       }
     },
@@ -174,13 +174,13 @@
                         {
                           "name": null,
                           "ty": {
-                            "B256": [5, null, 1, 0]
+                            "B256": [5, null, 1]
                           }
                         },
                         {
                           "name": null,
                           "ty": {
-                            "Int": [5, null, 1, 1]
+                            "Int": [5, null, 2]
                           }
                         }
                       ],
@@ -189,7 +189,7 @@
                   }
                 }
               ],
-              "key": [5, null]
+              "key": [5, null, 0]
             }
           },
           "key": [5]
@@ -221,13 +221,13 @@
                             {
                               "name": null,
                               "ty": {
-                                "B256": [6, null, null, null, null, null, 1, 0]
+                                "B256": [6, null, null, null, null, null, 1]
                               }
                             },
                             {
                               "name": null,
                               "ty": {
-                                "Int": [6, null, null, null, null, null, 1, 1]
+                                "Int": [6, null, null, null, null, null, 2]
                               }
                             }
                           ],
@@ -236,7 +236,7 @@
                       }
                     }
                   ],
-                  "key": [6, null, null, null, null, null]
+                  "key": [6, null, null, null, null, null, 0]
                 }
               },
               "key": [6, null]

--- a/pintc/tests/tests.rs
+++ b/pintc/tests/tests.rs
@@ -68,7 +68,7 @@ fn run_tests(sub_dir: &str) -> anyhow::Result<()> {
 
             if let Ok(mut file) = File::open(&path) {
                 // The JSON ABI of the produce program
-                let json_abi = serde_json::to_string_pretty(&program.abi())?;
+                let json_abi = serde_json::to_string_pretty(&program.abi().unwrap())?;
 
                 // The JSON ABI from the reference file
                 let mut json_abi_reference = String::new();


### PR DESCRIPTION
Just closing the gap between the JSON ABI generation and asm_gen. Tuple are "flattened" out in storage. Meaning, the tuple data is laid out sequentially starting at key `[ index, 0 ]` up to key `[ index, <tuple_size> -1 ]` regardless of the tuple contains (including nested tuples).

Closes #677 