### PR TITLE
Fix some precedence rules

### DIFF
--- a/docs/specs/src/pint/expressions/atoms/precedence.md
+++ b/docs/specs/src/pint/expressions/atoms/precedence.md
@@ -2,17 +2,16 @@
 
 The precedence of Pint operators and expressions is ordered as follows, going from strong to weak. Binary Operators at the same precedence level are grouped in the order given by their associativity.
 
-| Operator                         | Associativity        |
-| -------------------------------- | -------------------- |
-| Paths                            |                      |
-| Tuple field access expressions   | left to right        |
-| Call expressions, array indexing |                      |
-| Unary `-`, `!`                   |                      |
-| `as`                             | left to right        |
-| `in`                             | left to right        |
-| `*`, `/`, `%`                    | left to right        |
-| Binary `+`, Binary `-`           | left to right        |
-| `==`, `!=`, `<`, `>`, `<=`, `>=` | Requires parentheses |
-| `&&`                             | left to right        |
-| `\|\|`                           | left to right        |
-| `..`                             | Requires parentheses |
+| Operator                           | Associativity        |
+| ---------------------------------- | -------------------- |
+| Paths, intrinsic call expressions  |                      |
+| Tuple field access, array indexing | left to right        |
+| Unary `-`, `!`                     |                      |
+| `as`                               | left to right        |
+| `in`                               | left to right        |
+| `*`, `/`, `%`                      | left to right        |
+| Binary `+`, Binary `-`             | left to right        |
+| `==`, `!=`, `<`, `>`, `<=`, `>=`   | Requires parentheses |
+| `&&`                               | left to right        |
+| `\|\|`                             | left to right        |
+| `..`                               | Requires parentheses |

--- a/examples/ch_3_2.pnt
+++ b/examples/ch_3_2.pnt
@@ -82,7 +82,7 @@ const next_count = counts[default_idx + 1];
 const min_size = { valid: true, size: 10 };
 
 var my_size: int;
-constraint !(min_size.valid) || my_size >= min_size.size;
+constraint !min_size.valid || my_size >= min_size.size;
 // ANCHOR_END: const_compound_types
 
 solve satisfy;

--- a/pintc/src/parser/tests.rs
+++ b/pintc/src/parser/tests.rs
@@ -1470,6 +1470,14 @@ fn unary_op_exprs() {
         expect_test::expect!["!--!---1"],
     );
     check(
+        &run_parser!(expr, "! - - !  --  -t.0.1.2"),
+        expect_test::expect!["!--!---::t.0.1.2"],
+    );
+    check(
+        &run_parser!(expr, "! - - !  --  -a[5][3].1"),
+        expect_test::expect!["!--!---::a[5][3].1"],
+    );
+    check(
         &run_parser!(expr, "! - x '  '  "),
         expect_test::expect!["!-::x''"],
     );
@@ -2377,6 +2385,16 @@ fn tuple_field_accesses() {
     check(
         &run_parser!(expr, "{1_100.4e3, 2_0e3}.x"),
         expect_test::expect!["{1.1004e6, 2e4}.x"],
+    );
+
+    check(
+        &run_parser!(expr, "a[5][3].foo.2[4].1"),
+        expect_test::expect!["::a[5][3].foo.2[4].1"],
+    );
+
+    check(
+        &run_parser!(expr, "a.foo[5][3].1"),
+        expect_test::expect!["::a.foo[5][3].1"],
     );
 
     let pint = (yp::PintParser::new(), "");

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -652,46 +652,6 @@ AsOp: ExprKey = {
             Type::Unknown(span),
         )
      },
-    <TupleFieldOp>,
-};
-
-TupleFieldOp: ExprKey = {
-    <l:@L> <tuple:TupleFieldOp> "." <name:Ident> <r:@R> => {
-        context.parse_tuple_field_op_with_ident(tuple, name, (l, r))
-    },
-    <l:@L> <tuple:TupleFieldOp> "." <m:@L> <num_str:"int_lit"> <r:@R> => {
-        context.parse_tuple_field_op_with_int(handler, tuple, num_str, (l, m, r))
-    },
-    <l:@L> <tuple:TupleFieldOp> "." <m:@L> <num_str:"real_lit"> <r:@R> => {
-        context.parse_tuple_field_op_with_real(handler, tuple, num_str, (l, m, r))
-    },
-    <IndexOp>,
-};
-
-IndexOp: ExprKey = {
-    <l:@L> <expr:IndexOp> "[" <index:Expr> "]" <r:@R> => {
-        let span = (context.span_from)(l, r);
-        context.current_ii().exprs.insert(
-            Expr::Index {
-                expr,
-                index,
-                span: span.clone(),
-            },
-            Type::Unknown(span),
-        )
-    },
-    <l:@L> <expr:IndexOp> "[" "]" <r:@R> => {
-        let span = (context.span_from)(l, r);
-        handler.emit_err(Error::Parse {
-            error: ParseError::EmptyIndexAccess { span: span.clone() },
-        });
-
-        // Recover with a malformed expression
-        context
-            .current_ii()
-            .exprs
-            .insert(Expr::Error(span.clone()), Type::Unknown(span))
-    },
     <PrimeOp>,
 };
 
@@ -710,6 +670,19 @@ PrimeOp: ExprKey = {
     <UnaryOp>,
 }
 
+UnaryOpOp: UnaryOp = {
+    <l:@L> "+" <r:@R> => {
+        handler.emit_err(Error::Parse {
+            error: ParseError::UnsupportedLeadingPlus {
+                span: (context.span_from)(l, r),
+            },
+        });
+        UnaryOp::Error
+    },
+    "-" => UnaryOp::Neg,
+    "!" => UnaryOp::Not,
+};
+
 UnaryOp: ExprKey = {
     <l:@L> <op:UnaryOpOp> <expr:UnaryOp> <r:@R> => {
         let span = (context.span_from)(l, r);
@@ -722,20 +695,43 @@ UnaryOp: ExprKey = {
             Type::Unknown(span),
         )
     },
-    <Term>,
+    <TupleFieldOpOrIndexOp>,
 };
 
-UnaryOpOp: UnaryOp = {
-    <l:@L> "+" <r:@R> => {
-        handler.emit_err(Error::Parse {
-            error: ParseError::UnsupportedLeadingPlus {
-                span: (context.span_from)(l, r),
+TupleFieldOpOrIndexOp: ExprKey = {
+    <l:@L> <expr:TupleFieldOpOrIndexOp> "[" <index:Expr> "]" <r:@R> => {
+        let span = (context.span_from)(l, r);
+        context.current_ii().exprs.insert(
+            Expr::Index {
+                expr,
+                index,
+                span: span.clone(),
             },
-        });
-        UnaryOp::Error
+            Type::Unknown(span),
+        )
     },
-    "-" => UnaryOp::Neg,
-    "!" => UnaryOp::Not,
+    <l:@L> <expr:TupleFieldOpOrIndexOp> "[" "]" <r:@R> => {
+        let span = (context.span_from)(l, r);
+        handler.emit_err(Error::Parse {
+            error: ParseError::EmptyIndexAccess { span: span.clone() },
+        });
+
+        // Recover with a malformed expression
+        context
+            .current_ii()
+            .exprs
+            .insert(Expr::Error(span.clone()), Type::Unknown(span))
+    },
+    <l:@L> <tuple:TupleFieldOpOrIndexOp> "." <name:Ident> <r:@R> => {
+        context.parse_tuple_field_op_with_ident(tuple, name, (l, r))
+    },
+    <l:@L> <tuple:TupleFieldOpOrIndexOp> "." <m:@L> <num_str:"int_lit"> <r:@R> => {
+        context.parse_tuple_field_op_with_int(handler, tuple, num_str, (l, m, r))
+    },
+    <l:@L> <tuple:TupleFieldOpOrIndexOp> "." <m:@L> <num_str:"real_lit"> <r:@R> => {
+        context.parse_tuple_field_op_with_real(handler, tuple, num_str, (l, m, r))
+    },
+    <Term>,
 };
 
 Term: ExprKey = {

--- a/pintc/tests/basic_tests/unary_op_precedence.pnt
+++ b/pintc/tests/basic_tests/unary_op_precedence.pnt
@@ -1,0 +1,25 @@
+var a: {int, bool};
+constraint !a.1;
+
+var b: bool[5][3];
+constraint !!b[0][1];
+
+var c: {int, bool}[5];
+constraint !!c[0].1;
+
+solve satisfy;
+
+// intermediate <<<
+// var ::a: {int, bool};
+// var ::b: bool[3][5];
+// var ::c: {int, bool}[5];
+// constraint !::a.1;
+// constraint !!::b[0][1];
+// constraint !!::c[0].1;
+// solve satisfy;
+// >>>
+
+// Should pass type checking
+// flattening_failure <<<
+// compiler internal error: only arrays of ints, reals, and bools are currently supported
+// >>>


### PR DESCRIPTION
- Make tuple field and array index take precedence over unary ops
- Make tuple field op and array index peers (no precedence between them)

Closes #672 