### PR TITLE
Improve the use of `Custom` types.

### DIFF
--- a/pintc/src/expr.rs
+++ b/pintc/src/expr.rs
@@ -9,7 +9,7 @@ use fxhash::FxHashMap;
 mod display;
 pub(crate) mod evaluate;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum Expr {
     Error(Span),
     Immediate {

--- a/pintc/src/intermediate/transform.rs
+++ b/pintc/src/intermediate/transform.rs
@@ -66,6 +66,8 @@ impl super::Program {
             // Scalarize after lowering enums so we only have to deal with integer indices and
             // then lower array and tuple accesses into immediates.  After here there will no
             // longer be aggregate types.
+            //
+            // EXCEPT WE'RE NOW LOWERING ENUMS NEXT.  SCALARISING WILL BE REMOVED SOON.
             let _ = scalarize(handler, ii);
 
             // Transform each enum variant into its integer discriminant

--- a/pintc/tests/root_types/custom.pnt
+++ b/pintc/tests/root_types/custom.pnt
@@ -5,18 +5,18 @@ intent Foo {}
 
 // flattened <<<
 // type ::myAlias = int;
-// type ::myCustom = ::myAlias;
-// 
+// type ::myCustom = ::myAlias (int);
+//
 // intent ::Foo {
 //     type ::myAlias = int;
-//     type ::myCustom = ::myAlias;
+//     type ::myCustom = ::myAlias (int);
 // }
 // >>>
 
 // intermediate <<<
 // type ::myAlias = int;
 // type ::myCustom = ::myAlias;
-// 
+//
 // intent ::Foo {
 //     type ::myAlias = int;
 //     type ::myCustom = ::myAlias;

--- a/pintc/tests/root_types/exprs.pnt
+++ b/pintc/tests/root_types/exprs.pnt
@@ -18,7 +18,7 @@ intent Foo {}
 // type ::myNestedTuple = int[{2, 1}.0];
 // type ::myNestedArray = int[[2, 1][1]];
 // type ::complexType = {::myNestedCast, ::myNestedSelect}[2 in {1, 2, 3} as int];
-// 
+//
 // intent ::Foo {
 //     type ::myAliasForCast = int;
 //     type ::myNestedCast = int[4 as ::myAliasForCast];
@@ -39,8 +39,8 @@ intent Foo {}
 // type ::myNestedSelect = int[((1 > 0) ? 5 : 6)];
 // type ::myNestedTuple = int[{2, 1}.0];
 // type ::myNestedArray = int[[2, 1][1]];
-// type ::complexType = {::myNestedCast, ::myNestedSelect}[2 in {1, 2, 3} as int];
-// 
+// type ::complexType = {::myNestedCast (int[4 as int]), ::myNestedSelect (int[((1 > 0) ? 5 : 6)])}[2 in {1, 2, 3} as int];
+//
 // intent ::Foo {
 //     type ::myAliasForCast = int;
 //     type ::myNestedCast = int[4 as int];
@@ -49,6 +49,6 @@ intent Foo {}
 //     type ::myNestedSelect = int[(0 ? 5 : 6)];
 //     type ::myNestedTuple = int[1.0];
 //     type ::myNestedArray = int[2[1]];
-//     type ::complexType = {::myNestedCast, ::myNestedSelect}[3 as int];
+//     type ::complexType = {::myNestedCast (int[4 as int]), ::myNestedSelect (int[(0 ? 5 : 6)])}[3 as int];
 // }
 // >>>

--- a/pintc/tests/types/new_type_in_new_type.pnt
+++ b/pintc/tests/types/new_type_in_new_type.pnt
@@ -1,0 +1,39 @@
+type A = int;
+type B = A[2];
+type C = { A, A };
+type D = { C, C };
+
+var x: B;
+var y: D;
+constraint x[1] == 11;
+constraint y.1.0 == 22;
+
+solve satisfy;
+
+// intermediate <<<
+// var ::x: ::B;
+// var ::y: ::D;
+// type ::A = int;
+// type ::B = ::A[2];
+// type ::C = {::A, ::A};
+// type ::D = {::C, ::C};
+// constraint (::x[1] == 11);
+// constraint (::y.1.0 == 22);
+// solve satisfy;
+// >>>
+
+// flattened <<<
+// var ::x[0]: int;
+// var ::x[1]: int;
+// var ::y.0.0: int;
+// var ::y.0.1: int;
+// var ::y.1.0: int;
+// var ::y.1.1: int;
+// type ::A = int;
+// type ::B = ::A (int)[2];
+// type ::C = {::A (int), ::A (int)};
+// type ::D = {::C ({::A (int), ::A (int)}), ::C ({::A (int), ::A (int)})};
+// constraint (::x[1] == 11);
+// constraint (::y.1.0 == 22);
+// solve satisfy;
+// >>>

--- a/pintc/tests/types/new_type_in_tuple.pnt
+++ b/pintc/tests/types/new_type_in_tuple.pnt
@@ -1,0 +1,56 @@
+type A = int;
+type B = { x: A, y: A };
+type C = A[3];
+
+var a: A;
+var b: B = { a, a };
+var c: A = b.1;
+var d: A = b.x;
+var e: C = [a, a, a];
+var f: A = e[1];
+var g: A = a;
+
+solve satisfy;
+
+// intermediate <<<
+// var ::a: ::A;
+// var ::b: ::B;
+// var ::c: ::A;
+// var ::d: ::A;
+// var ::e: ::C;
+// var ::f: ::A;
+// var ::g: ::A;
+// type ::A = int;
+// type ::B = {x: ::A, y: ::A};
+// type ::C = ::A[3];
+// constraint (::b == {::a, ::a});
+// constraint (::c == ::b.1);
+// constraint (::d == ::b.x);
+// constraint (::e == [::a, ::a, ::a]);
+// constraint (::f == ::e[1]);
+// constraint (::g == ::a);
+// solve satisfy;
+// >>>
+
+// flattened <<<
+// var ::a: int;
+// var ::b.x: int;
+// var ::b.y: int;
+// var ::c: int;
+// var ::d: int;
+// var ::e[0]: int;
+// var ::e[1]: int;
+// var ::e[2]: int;
+// var ::f: int;
+// var ::g: int;
+// type ::A = int;
+// type ::B = {x: ::A (int), y: ::A (int)};
+// type ::C = ::A (int)[3];
+// constraint ((::b.x == ::a) && (::b.y == ::a));
+// constraint (::c == ::b.y);
+// constraint (::d == ::b.x);
+// constraint (((::e[0] == ::a) && (::e[1] == ::a)) && (::e[2] == ::a));
+// constraint (::f == ::e[1]);
+// constraint (::g == ::a);
+// solve satisfy;
+// >>>

--- a/pintc/tests/types/new_type_recursion.pnt
+++ b/pintc/tests/types/new_type_recursion.pnt
@@ -1,0 +1,36 @@
+type A = { A };
+type B = C[2];
+type C = { B, B };
+type D = A;
+
+var x: A;
+var y: B;
+var z: C;
+
+solve satisfy;
+
+// intermediate <<<
+// var ::x: ::A;
+// var ::y: ::B;
+// var ::z: ::C;
+// type ::A = {::A};
+// type ::B = ::C[2];
+// type ::C = {::B, ::B};
+// type ::D = ::A;
+// solve satisfy;
+// >>>
+
+// typecheck_failure <<<
+// type alias refers to itself
+// @11..12: type alias `::A` is used recursively in declaration
+// @0..14: `::A` is declared here
+// type alias refers to itself
+// @42..43: type alias `::B` is used recursively in declaration
+// @16..29: `::B` is declared here
+// type alias refers to itself
+// @25..26: type alias `::C` is used recursively in declaration
+// @31..48: `::C` is declared here
+// type alias refers to itself
+// @11..12: type alias `::A` is used recursively in declaration
+// @0..14: `::A` is declared here
+// >>>

--- a/pintc/tests/types/undefined_types.pnt
+++ b/pintc/tests/types/undefined_types.pnt
@@ -28,15 +28,4 @@ solve satisfy;
 // @56..59: type is undefined
 // undefined type
 // @74..77: type is undefined
-// invalid cast
-// @69..77: illegal cast to a `::Bar`
-// casts may only be made to an int or a real
-// invalid cast
-// @69..77: illegal cast to a `::Bar`
-// casts may only be made to an int or a real
-// unable to determine expression type
-// @65..66: type of this expression is ambiguous
-// constraint expression type error
-// @61..77: constraint expression has unknown type
-// @61..77: expecting type `bool`
 // >>>


### PR DESCRIPTION
`Type::Custom` was mostly assumed to be references to `enum`s but they're actually used for new types (type aliases) as well.

Closes #662.