### PR TITLE
feat: rename to match essential base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,12 +156,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,7 +552,7 @@ dependencies = [
 [[package]]
 name = "essential-asm-gen"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#d058acf6a1d77cbe58dcb4428d7164b698356bbc"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#9e731f4070a56b92414245a16e26d3f6329f6dca"
 dependencies = [
  "essential-asm-spec",
  "essential-types",
@@ -570,7 +564,7 @@ dependencies = [
 [[package]]
 name = "essential-asm-spec"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#d058acf6a1d77cbe58dcb4428d7164b698356bbc"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#9e731f4070a56b92414245a16e26d3f6329f6dca"
 dependencies = [
  "serde",
  "serde_yaml",
@@ -579,7 +573,7 @@ dependencies = [
 [[package]]
 name = "essential-constraint-asm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#d058acf6a1d77cbe58dcb4428d7164b698356bbc"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#9e731f4070a56b92414245a16e26d3f6329f6dca"
 dependencies = [
  "essential-asm-gen",
  "essential-types",
@@ -589,7 +583,7 @@ dependencies = [
 [[package]]
 name = "essential-constraint-vm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#d058acf6a1d77cbe58dcb4428d7164b698356bbc"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#9e731f4070a56b92414245a16e26d3f6329f6dca"
 dependencies = [
  "ed25519-dalek",
  "essential-constraint-asm",
@@ -603,7 +597,7 @@ dependencies = [
 [[package]]
 name = "essential-hash"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#d058acf6a1d77cbe58dcb4428d7164b698356bbc"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#9e731f4070a56b92414245a16e26d3f6329f6dca"
 dependencies = [
  "essential-types",
  "postcard",
@@ -614,7 +608,7 @@ dependencies = [
 [[package]]
 name = "essential-state-asm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#d058acf6a1d77cbe58dcb4428d7164b698356bbc"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#9e731f4070a56b92414245a16e26d3f6329f6dca"
 dependencies = [
  "essential-asm-gen",
  "essential-constraint-asm",
@@ -624,7 +618,7 @@ dependencies = [
 [[package]]
 name = "essential-state-read-vm"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#d058acf6a1d77cbe58dcb4428d7164b698356bbc"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#9e731f4070a56b92414245a16e26d3f6329f6dca"
 dependencies = [
  "essential-constraint-vm",
  "essential-state-asm",
@@ -635,9 +629,8 @@ dependencies = [
 [[package]]
 name = "essential-types"
 version = "0.1.0"
-source = "git+ssh://git@github.com/essential-contributions/essential-base.git#d058acf6a1d77cbe58dcb4428d7164b698356bbc"
+source = "git+ssh://git@github.com/essential-contributions/essential-base.git#9e731f4070a56b92414245a16e26d3f6329f6dca"
 dependencies = [
- "base64",
  "hex",
  "serde",
 ]

--- a/pint-pkg/tests/build.rs
+++ b/pint-pkg/tests/build.rs
@@ -81,12 +81,12 @@ solve satisfy;"#;
         };
 
         // There's only one nameless predicate in our simple `foo` test contract.
-        assert_eq!(&contract.predicates[0].name, "");
-        let predicate = &contract.predicates[0];
+        assert_eq!(&contract.predicate_metadata[0].name, "");
+        let predicate = &contract.contract.predicates[0];
 
         // It should have at least one constraint.
         assert!(
-            !predicate.predicate.constraints.is_empty(),
+            !predicate.constraints.is_empty(),
             "built foo should have at least one constraint"
         );
     });
@@ -162,12 +162,12 @@ solve satisfy;"#;
         };
 
         // There's only one nameless predicate in our simple `foo` test contract.
-        assert_eq!(&contract.predicates[0].name, "");
-        let predicate = &contract.predicates[0];
+        assert_eq!(&contract.predicate_metadata[0].name, "");
+        let predicate = &contract.contract.predicates[0];
 
         // It should have at least one constraint.
         assert!(
-            !predicate.predicate.constraints.is_empty(),
+            !predicate.constraints.is_empty(),
             "built foo should have at least one constraint"
         );
     });
@@ -239,7 +239,7 @@ solve satisfy;"#;
             name: &str,
         ) -> &'a ContentAddress {
             &contract
-                .predicates
+                .predicate_metadata
                 .iter()
                 .find(|i| i.name.contains(name))
                 .unwrap()
@@ -267,8 +267,8 @@ solve satisfy;"#;
             // in the bytecode, the CA is "pushed" to the stack one word at a time.
             for ca_chunk in ca.0.chunks(std::mem::size_of::<Word>()) {
                 let mut contains_chunk = false;
-                for predicate in &contract.predicates {
-                    for constraint in &predicate.predicate.constraints {
+                for predicate in &contract.contract.predicates {
+                    for constraint in &predicate.constraints {
                         if constraint.windows(ca_chunk.len()).any(|w| w == ca_chunk) {
                             contains_chunk |= true;
                         }

--- a/pint/src/build.rs
+++ b/pint/src/build.rs
@@ -112,11 +112,10 @@ pub(crate) fn cmd(args: Args) -> anyhow::Result<()> {
             // Write the contract predicates to JSON, and write the ABI.
             BuiltPkg::Contract(contract) => {
                 // Write the predicates.
-                let predicates: Vec<_> = contract.predicates.iter().map(|i| &i.predicate).collect();
-                let predicates_string = serde_json::to_string_pretty(&predicates)
+                let contract_string = serde_json::to_string_pretty(&contract.contract)
                     .context("failed to serialize predicates to JSON")?;
                 let predicates_path = profile_dir.join(&pinned.name).with_extension("json");
-                std::fs::write(&predicates_path, predicates_string)
+                std::fs::write(&predicates_path, contract_string)
                     .with_context(|| format!("failed to write {predicates_path:?}"))?;
 
                 // Write the ABI.
@@ -157,7 +156,7 @@ pub(crate) fn cmd(args: Args) -> anyhow::Result<()> {
 
         // For contracts, print their predicates too.
         if let BuiltPkg::Contract(contract) = built {
-            let mut iter = contract.predicates.iter().peekable();
+            let mut iter = contract.predicate_metadata.iter().peekable();
             while let Some(predicate) = iter.next() {
                 let name = format!("{}{}", pinned.name, predicate.name);
                 let pipe = iter.peek().map(|_| "├──").unwrap_or("└──");
@@ -174,7 +173,7 @@ pub(crate) fn cmd(args: Args) -> anyhow::Result<()> {
 fn name_col_w(name: &str, built: &BuiltPkg) -> usize {
     let mut name_w = 0;
     if let BuiltPkg::Contract(contract) = built {
-        for predicate in &contract.predicates {
+        for predicate in &contract.predicate_metadata {
             let w = predicate.name.chars().count();
             name_w = std::cmp::max(name_w, w);
         }

--- a/pintc/src/asm_gen.rs
+++ b/pintc/src/asm_gen.rs
@@ -8,10 +8,9 @@ use crate::{
     span::empty_span,
     types::Type,
 };
-use essential_types::intent::{Directive, Intent as CompiledPredicate};
+use essential_types::predicate::{Directive, Predicate as CompiledPredicate};
 use state_asm::{
-    Access, Alu, Constraint, ControlFlow, Crypto, Op as StateRead, Pred, Stack, StateSlots,
-    TotalControlFlow,
+    Access, Alu, Constraint, Crypto, Op as StateRead, Pred, Stack, StateSlots, TotalControlFlow,
 };
 
 mod display;
@@ -22,6 +21,7 @@ mod tests;
 pub struct CompiledProgram {
     pub kind: ProgramKind,
     pub names: Vec<String>,
+    pub salt: [u8; 32],
     pub predicates: Vec<CompiledPredicate>,
 }
 
@@ -73,6 +73,8 @@ pub fn compile_program(
     Ok(CompiledProgram {
         kind: program.kind.clone(),
         names,
+        // Salt is not used by pint yet.
+        salt: Default::default(),
         predicates,
     })
 }
@@ -720,7 +722,7 @@ impl AsmBuilder {
 
                 "__this_set_address" => {
                     assert!(args.is_empty());
-                    asm.push(Constraint::Access(Access::ThisSetAddress));
+                    asm.push(Constraint::Access(Access::ThisContractAddress));
                 }
 
                 "__this_pathway" => {
@@ -1075,7 +1077,7 @@ impl AsmBuilder {
             } else {
                 StateRead::KeyRange
             },
-            StateRead::ControlFlow(ControlFlow::Halt),
+            TotalControlFlow::Halt.into(),
         ]);
         self.s_asm.push(s_asm);
 

--- a/pintc/src/asm_gen/display.rs
+++ b/pintc/src/asm_gen/display.rs
@@ -1,6 +1,6 @@
 use super::CompiledProgram;
 use crate::predicate::ProgramKind;
-use essential_types::intent::Intent as CompiledPredicate;
+use essential_types::predicate::Predicate as CompiledPredicate;
 use state_asm::{Constraint, Op as StateRead};
 use std::fmt::{Display, Formatter};
 

--- a/pintc/src/asm_gen/tests.rs
+++ b/pintc/src/asm_gen/tests.rs
@@ -208,7 +208,7 @@ fn select() {
               Constraint(Stack(Push(1)))
               Constraint(Stack(Push(0)))
               KeyRange
-              ControlFlow(Halt)
+              Constraint(TotalControlFlow(Halt))
         "#]],
     );
 }
@@ -548,7 +548,7 @@ fn state_read() {
               Constraint(Stack(Push(1)))
               Constraint(Stack(Push(0)))
               KeyRange
-              ControlFlow(Halt)
+              Constraint(TotalControlFlow(Halt))
             state read 1
               Constraint(Stack(Push(2)))
               Constraint(Stack(Push(2)))
@@ -560,7 +560,7 @@ fn state_read() {
               Constraint(Stack(Push(1)))
               Constraint(Stack(Push(0)))
               KeyRange
-              ControlFlow(Halt)
+              Constraint(TotalControlFlow(Halt))
         "#]],
     );
 
@@ -622,7 +622,7 @@ fn state_read_extern() {
               Constraint(Stack(Push(1)))
               Constraint(Stack(Push(0)))
               KeyRangeExtern
-              ControlFlow(Halt)
+              Constraint(TotalControlFlow(Halt))
             state read 1
               Constraint(Stack(Push(5)))
               Constraint(Stack(Push(6)))
@@ -638,7 +638,7 @@ fn state_read_extern() {
               Constraint(Stack(Push(1)))
               Constraint(Stack(Push(0)))
               KeyRangeExtern
-              ControlFlow(Halt)
+              Constraint(TotalControlFlow(Halt))
         "#]],
     );
 
@@ -688,7 +688,7 @@ fn next_state() {
               Constraint(Stack(Push(1)))
               Constraint(Stack(Push(0)))
               KeyRange
-              ControlFlow(Halt)
+              Constraint(TotalControlFlow(Halt))
         "#]],
     );
 
@@ -791,7 +791,7 @@ predicate Simple {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 1
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(69)))
@@ -801,7 +801,7 @@ predicate Simple {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 2
                   Constraint(Stack(Push(2)))
                   Constraint(Stack(Push(2459565876494606882)))
@@ -814,7 +814,7 @@ predicate Simple {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
             }
 
         "#]],
@@ -900,7 +900,7 @@ predicate Simple {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 1
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(1)))
@@ -909,7 +909,7 @@ predicate Simple {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 2
                   Constraint(Stack(Push(2)))
                   Constraint(Stack(Push(69)))
@@ -919,7 +919,7 @@ predicate Simple {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 3
                   Constraint(Stack(Push(3)))
                   Constraint(Stack(Push(1)))
@@ -932,7 +932,7 @@ predicate Simple {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
             }
 
         "#]],
@@ -982,7 +982,7 @@ predicate Foo {
                   Constraint(Stack(Push(2)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 1
                   Constraint(Stack(Push(0)))
                   Constraint(Stack(Push(0)))
@@ -994,7 +994,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 2
                   Constraint(Stack(Push(0)))
                   Constraint(Stack(Push(0)))
@@ -1006,7 +1006,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 3
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
@@ -1016,7 +1016,7 @@ predicate Foo {
                   Constraint(Stack(Push(3)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 4
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
@@ -1028,7 +1028,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 5
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
@@ -1042,7 +1042,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 6
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
@@ -1056,7 +1056,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 7
                   Constraint(Stack(Push(2)))
                   Constraint(Stack(Push(0)))
@@ -1066,7 +1066,7 @@ predicate Foo {
                   Constraint(Stack(Push(3)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 8
                   Constraint(Stack(Push(2)))
                   Constraint(Stack(Push(0)))
@@ -1078,7 +1078,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 9
                   Constraint(Stack(Push(2)))
                   Constraint(Stack(Push(0)))
@@ -1092,7 +1092,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 10
                   Constraint(Stack(Push(2)))
                   Constraint(Stack(Push(0)))
@@ -1106,7 +1106,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
             }
 
         "#]],
@@ -1147,7 +1147,7 @@ predicate Foo {
                   Constraint(Stack(Push(3)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 1
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(69)))
@@ -1160,7 +1160,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 2
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(69)))
@@ -1175,7 +1175,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 3
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(69)))
@@ -1190,7 +1190,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
             }
 
         "#]],
@@ -1248,7 +1248,7 @@ predicate Bar {
                   Constraint(Stack(Push(2)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 1
                   Constraint(Stack(Push(1229782938247303441)))
                   Constraint(Stack(Push(1229782938247303441)))
@@ -1264,7 +1264,7 @@ predicate Bar {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 2
                   Constraint(Stack(Push(1229782938247303441)))
                   Constraint(Stack(Push(1229782938247303441)))
@@ -1280,7 +1280,7 @@ predicate Bar {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 3
                   Constraint(Stack(Push(1229782938247303441)))
                   Constraint(Stack(Push(1229782938247303441)))
@@ -1294,7 +1294,7 @@ predicate Bar {
                   Constraint(Stack(Push(3)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 4
                   Constraint(Stack(Push(1229782938247303441)))
                   Constraint(Stack(Push(1229782938247303441)))
@@ -1310,7 +1310,7 @@ predicate Bar {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 5
                   Constraint(Stack(Push(1229782938247303441)))
                   Constraint(Stack(Push(1229782938247303441)))
@@ -1328,7 +1328,7 @@ predicate Bar {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 6
                   Constraint(Stack(Push(1229782938247303441)))
                   Constraint(Stack(Push(1229782938247303441)))
@@ -1346,7 +1346,7 @@ predicate Bar {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 7
                   Constraint(Stack(Push(1229782938247303441)))
                   Constraint(Stack(Push(1229782938247303441)))
@@ -1360,7 +1360,7 @@ predicate Bar {
                   Constraint(Stack(Push(3)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 8
                   Constraint(Stack(Push(1229782938247303441)))
                   Constraint(Stack(Push(1229782938247303441)))
@@ -1376,7 +1376,7 @@ predicate Bar {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 9
                   Constraint(Stack(Push(1229782938247303441)))
                   Constraint(Stack(Push(1229782938247303441)))
@@ -1394,7 +1394,7 @@ predicate Bar {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 10
                   Constraint(Stack(Push(1229782938247303441)))
                   Constraint(Stack(Push(1229782938247303441)))
@@ -1412,7 +1412,7 @@ predicate Bar {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
             }
 
         "#]],
@@ -1473,7 +1473,7 @@ predicate Simple {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 1
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(88)))
@@ -1488,7 +1488,7 @@ predicate Simple {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRange
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
             }
 
         "#]],
@@ -1584,7 +1584,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 1
                   Constraint(Stack(Push(1311506517218527985)))
                   Constraint(Stack(Push(8106469911493893863)))
@@ -1599,7 +1599,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 2
                   Constraint(Stack(Push(870781680972594289)))
                   Constraint(Stack(Push(104754439867348082)))
@@ -1612,7 +1612,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
                 state read 3
                   Constraint(Stack(Push(870781680972594289)))
                   Constraint(Stack(Push(104754439867348082)))
@@ -1630,7 +1630,7 @@ predicate Foo {
                   Constraint(Stack(Push(1)))
                   Constraint(Stack(Push(0)))
                   KeyRangeExtern
-                  ControlFlow(Halt)
+                  Constraint(TotalControlFlow(Halt))
             }
 
         "#]],

--- a/pintc/src/asm_gen/tests/intrinsics.rs
+++ b/pintc/src/asm_gen/tests/intrinsics.rs
@@ -131,7 +131,7 @@ fn this_set_address() {
               Stack(Push(0))
               Stack(Push(4))
               Access(DecisionVarRange)
-              Access(ThisSetAddress)
+              Access(ThisContractAddress)
               Stack(Push(4))
               Pred(EqRange)
             --- State Reads ---

--- a/pintc/src/main.rs
+++ b/pintc/src/main.rs
@@ -124,7 +124,10 @@ fn main() -> anyhow::Result<()> {
                     } else {
                         File::create(filepath.with_extension("json"))?
                     },
-                    &compiled_program.predicates,
+                    &essential_types::contract::Contract {
+                        predicates: compiled_program.predicates,
+                        salt: compiled_program.salt,
+                    },
                 )?;
             }
             Err(_) => {


### PR DESCRIPTION
Mostly just renames.
We no longer write out a `Vec<Intent>` as a compiled json artifact. It's now a:
```rust
pub struct Contract {
  pub predicates: Vec<Predicate>,
  pub salt: Hash,
}
```
I updated where this happens in `pintc` and in `pint`. Hopefully there's nowhere else outputting compiled artifacts that I missed.