### PR TITLE
Basic arrays in storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,9 +233,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
+checksum = "ac367972e516d45567c7eafc73d24e1c193dcf200a8d94e9db7b3d38b349572d"
 
 [[package]]
 name = "cexpr"
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "embedded-io"
@@ -985,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",

--- a/abi-types/src/lib.rs
+++ b/abi-types/src/lib.rs
@@ -69,6 +69,10 @@ pub enum KeyedTypeABI {
         fields: Vec<KeyedTupleField>,
         key: Key,
     },
+    Array {
+        ty: Box<KeyedTypeABI>,
+        size: i64,
+    },
     Map {
         ty_from: TypeABI, // not in storage hence `TypeABI` instead of `KeyedTypeABI`
         ty_to: Box<Self>,

--- a/pint-pkg/src/build.rs
+++ b/pint-pkg/src/build.rs
@@ -291,7 +291,7 @@ fn build_pkg(plan: &Plan, built_pkgs: &BuiltPkgs, n: NodeIx) -> Result<BuiltPkg,
             };
 
             // Produce the ABI for the flattened program.
-            let Ok(abi) = flattened.abi() else {
+            let Ok(abi) = flattened.abi(&handler) else {
                 let kind = BuildPkgErrorKind::from(PintcError::ABIGen);
                 return Err(BuildPkgError { handler, kind });
             };

--- a/pintc/src/asm_gen/tests.rs
+++ b/pintc/src/asm_gen/tests.rs
@@ -1420,6 +1420,255 @@ predicate Bar {
 }
 
 #[test]
+fn storage_access_arrays() {
+    let compiled_program = &compile(
+        r#"
+storage {
+    x: int,
+    v: int[2][3],
+}
+
+predicate Foo {
+    state v = storage::v;
+    state v1 = storage::v[1];
+    state v12 = storage::v[1][2];
+}
+        "#,
+    );
+
+    check(
+        &format!("{compiled_program}"),
+        expect_test::expect![[r#"
+            predicate ::Foo {
+                --- Constraints ---
+                --- State Reads ---
+                state read 0
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(0)))
+                  Constraint(Stack(Push(6)))
+                  StateSlots(AllocSlots)
+                  Constraint(Stack(Push(2)))
+                  Constraint(Stack(Push(6)))
+                  Constraint(Stack(Push(0)))
+                  KeyRange
+                  Constraint(TotalControlFlow(Halt))
+                state read 1
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(0)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(3)))
+                  Constraint(Alu(Mul))
+                  Constraint(Alu(Add))
+                  Constraint(Stack(Push(3)))
+                  StateSlots(AllocSlots)
+                  Constraint(Stack(Push(2)))
+                  Constraint(Stack(Push(3)))
+                  Constraint(Stack(Push(0)))
+                  KeyRange
+                  Constraint(TotalControlFlow(Halt))
+                state read 2
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(0)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(3)))
+                  Constraint(Alu(Mul))
+                  Constraint(Alu(Add))
+                  Constraint(Stack(Push(2)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Alu(Mul))
+                  Constraint(Alu(Add))
+                  Constraint(Stack(Push(1)))
+                  StateSlots(AllocSlots)
+                  Constraint(Stack(Push(2)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(0)))
+                  KeyRange
+                  Constraint(TotalControlFlow(Halt))
+            }
+
+        "#]],
+    );
+}
+
+#[test]
+fn storage_access_arrays_in_maps() {
+    let compiled_program = &compile(
+        r#"
+storage {
+    x: int,
+    map_to_arrays: ( int => int[3] ),
+}
+
+predicate Foo {
+    state map_to_arrays_69 = storage::map_to_arrays[69];
+    state map_to_arrays_69_2 = storage::map_to_arrays[69][2];
+}
+        "#,
+    );
+
+    check(
+        &format!("{compiled_program}"),
+        expect_test::expect![[r#"
+            predicate ::Foo {
+                --- Constraints ---
+                --- State Reads ---
+                state read 0
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(69)))
+                  Constraint(Stack(Push(0)))
+                  Constraint(Stack(Push(3)))
+                  StateSlots(AllocSlots)
+                  Constraint(Stack(Push(3)))
+                  Constraint(Stack(Push(3)))
+                  Constraint(Stack(Push(0)))
+                  KeyRange
+                  Constraint(TotalControlFlow(Halt))
+                state read 1
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(69)))
+                  Constraint(Stack(Push(0)))
+                  Constraint(Stack(Push(2)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Alu(Mul))
+                  Constraint(Alu(Add))
+                  Constraint(Stack(Push(1)))
+                  StateSlots(AllocSlots)
+                  Constraint(Stack(Push(3)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(0)))
+                  KeyRange
+                  Constraint(TotalControlFlow(Halt))
+            }
+
+        "#]],
+    );
+}
+
+#[test]
+fn storage_access_arrays_extern() {
+    let compiled_program = &compile(
+        r#"
+interface Foo {
+    storage {
+        v: int[2][3],
+        map_to_arrays: ( int => int[3] ),
+    }
+}
+
+predicate Bar {
+    interface FooInstance = Foo(0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE);
+
+    state foo_v = FooInstance::storage::v;
+    state foo_v1 = FooInstance::storage::v[1];
+    state foo_v12 = FooInstance::storage::v[1][2];
+
+    state foo_map_to_arrays_69 = FooInstance::storage::map_to_arrays[69];
+    state foo_map_to_arrays_69_1 = FooInstance::storage::map_to_arrays[69][1];
+}
+        "#,
+    );
+
+    check(
+        &format!("{compiled_program}"),
+        expect_test::expect![[r#"
+            predicate ::Bar {
+                --- Constraints ---
+                --- State Reads ---
+                state read 0
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(0)))
+                  Constraint(Stack(Push(0)))
+                  Constraint(Stack(Push(6)))
+                  StateSlots(AllocSlots)
+                  Constraint(Stack(Push(2)))
+                  Constraint(Stack(Push(6)))
+                  Constraint(Stack(Push(0)))
+                  KeyRangeExtern
+                  Constraint(TotalControlFlow(Halt))
+                state read 1
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(0)))
+                  Constraint(Stack(Push(0)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(3)))
+                  Constraint(Alu(Mul))
+                  Constraint(Alu(Add))
+                  Constraint(Stack(Push(3)))
+                  StateSlots(AllocSlots)
+                  Constraint(Stack(Push(2)))
+                  Constraint(Stack(Push(3)))
+                  Constraint(Stack(Push(0)))
+                  KeyRangeExtern
+                  Constraint(TotalControlFlow(Halt))
+                state read 2
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(0)))
+                  Constraint(Stack(Push(0)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(3)))
+                  Constraint(Alu(Mul))
+                  Constraint(Alu(Add))
+                  Constraint(Stack(Push(2)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Alu(Mul))
+                  Constraint(Alu(Add))
+                  Constraint(Stack(Push(1)))
+                  StateSlots(AllocSlots)
+                  Constraint(Stack(Push(2)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(0)))
+                  KeyRangeExtern
+                  Constraint(TotalControlFlow(Halt))
+                state read 3
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(69)))
+                  Constraint(Stack(Push(0)))
+                  Constraint(Stack(Push(3)))
+                  StateSlots(AllocSlots)
+                  Constraint(Stack(Push(3)))
+                  Constraint(Stack(Push(3)))
+                  Constraint(Stack(Push(0)))
+                  KeyRangeExtern
+                  Constraint(TotalControlFlow(Halt))
+                state read 4
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(-1229782938247303442)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(69)))
+                  Constraint(Stack(Push(0)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Alu(Mul))
+                  Constraint(Alu(Add))
+                  Constraint(Stack(Push(1)))
+                  StateSlots(AllocSlots)
+                  Constraint(Stack(Push(3)))
+                  Constraint(Stack(Push(1)))
+                  Constraint(Stack(Push(0)))
+                  KeyRangeExtern
+                  Constraint(TotalControlFlow(Halt))
+            }
+
+        "#]],
+    );
+}
+
+#[test]
 fn storage_access_complex_maps() {
     let compiled_program = &compile(
         r#"

--- a/pintc/src/main.rs
+++ b/pintc/src/main.rs
@@ -58,13 +58,15 @@ fn main() -> anyhow::Result<()> {
     json_abi_path.set_extension("json");
 
     // Compute the JSON ABI
-    let abi = match flattened.abi() {
+    let abi = match handler.scope(|handler| flattened.abi(handler)) {
         Ok(abi) => abi,
-        Err(error) => {
+        Err(_) => {
+            let errors = handler.consume();
+            let errors_len = errors.len();
             if !cfg!(test) {
-                error::print_errors(&error::Errors(vec![error::Error::Compile { error }]));
+                error::print_errors(&error::Errors(errors));
             }
-            pintc::pintc_bail!(1, filepath)
+            pintc::pintc_bail!(errors_len, filepath)
         }
     };
 

--- a/pintc/src/parser/context.rs
+++ b/pintc/src/parser/context.rs
@@ -61,7 +61,7 @@ impl<'a> ParserContext<'a> {
         (l, r): (usize, usize),
     ) -> StorageVar {
         let span = (self.span_from)(l, r);
-        if ty.is_bool() || ty.is_int() || ty.is_b256() || ty.is_tuple() {
+        if ty.is_bool() || ty.is_int() || ty.is_b256() || ty.is_tuple() || ty.is_array() {
             StorageVar { name, ty, span }
         } else if let Type::Map {
             ref ty_from,
@@ -74,7 +74,8 @@ impl<'a> ParserContext<'a> {
                     || ty_to.is_int()
                     || ty_to.is_b256()
                     || ty_to.is_map()
-                    || ty_to.is_tuple())
+                    || ty_to.is_tuple()
+                    || ty_to.is_array())
             {
                 StorageVar { name, ty, span }
             } else {

--- a/pintc/src/predicate/transform/scalarize.rs
+++ b/pintc/src/predicate/transform/scalarize.rs
@@ -81,7 +81,12 @@ fn fix_array_sizes(handler: &Handler, pred: &mut Predicate) -> Result<(), ErrorE
         range_expr_key: Option<ExprKey>,
         array_ty_span: Span,
     ) -> Result<Type, ErrorEmitted> {
-        if !(el_ty.is_array() || el_ty.is_int() || el_ty.is_real() || el_ty.is_bool()) {
+        if !(el_ty.is_array()
+            || el_ty.is_int()
+            || el_ty.is_real()
+            || el_ty.is_bool()
+            || el_ty.is_b256())
+        {
             // Eventually, this will go away. Hence why it's an internal error for the time being.
             return Err(handler.emit_err(Error::Compile {
                 error: CompileError::Internal {

--- a/pintc/src/predicate/transform/validate.rs
+++ b/pintc/src/predicate/transform/validate.rs
@@ -158,18 +158,6 @@ fn check_expr(expr_key: &ExprKey, handler: &Handler, pred: &Predicate) -> Result
             "macro call",
             "exprs"
         )),
-        Expr::Index { expr, span, .. } => {
-            if !expr.get_ty(pred).is_map() {
-                Err(emit_illegal_type_error!(
-                    handler,
-                    span,
-                    "array element access",
-                    "exprs"
-                ))
-            } else {
-                Ok(())
-            }
-        }
         Expr::In { span, .. } => Err(emit_illegal_type_error!(
             handler,
             span,
@@ -203,6 +191,7 @@ fn check_expr(expr_key: &ExprKey, handler: &Handler, pred: &Predicate) -> Result
         | Expr::Select { .. }
         | Expr::Cast { .. }
         | Expr::TupleFieldAccess { .. }
+        | Expr::Index { .. }
         | Expr::ExternalStorageAccess { .. } => Ok(()),
     }
 }
@@ -300,14 +289,6 @@ fn expr_types() {
 #[test]
 fn exprs() {
     // array and array field access
-    let src = "var a = [1, 2, 3];
-    var b = a[1];";
-    check(
-        &run_test(src),
-        expect_test::expect![
-            "compiler internal error: array element access present in final predicate exprs slotmap"
-        ],
-    );
     let src = "var x: bool = 5 in [3, 4, 5];";
     check(
         &run_test(src),
@@ -334,8 +315,6 @@ fn exprs() {
         &run_test(src),
         expect_test::expect![[r#"
             compiler internal error: exists generator present in final predicate exprs slotmap
-            compiler internal error: array element access present in final predicate exprs slotmap
-            compiler internal error: array element access present in final predicate exprs slotmap
             compiler internal error: range present in final predicate exprs slotmap
             compiler internal error: range present in final predicate exprs slotmap"#]],
     );

--- a/pintc/src/predicate/vars.rs
+++ b/pintc/src/predicate/vars.rs
@@ -1,6 +1,6 @@
 use super::{DisplayWithPred, Ident, Predicate};
 use crate::{
-    error::{CompileError, ErrorEmitted, Handler},
+    error::{ErrorEmitted, Handler},
     span::Span,
     types::{Path, Type},
 };
@@ -100,7 +100,7 @@ impl VarKey {
     }
 
     /// Generate a `VarABI` given a `VarKey` and an `Predicate`
-    pub fn abi(&self, pred: &Predicate) -> Result<VarABI, CompileError> {
+    pub fn abi(&self, pred: &Predicate) -> Result<VarABI, ErrorEmitted> {
         Ok(VarABI {
             name: self.get(pred).name.clone(),
             ty: self.get_ty(pred).abi()?,

--- a/pintc/tests/abi/arrays-abi.json
+++ b/pintc/tests/abi/arrays-abi.json
@@ -1,0 +1,120 @@
+{
+  "predicates": [
+    {
+      "name": "",
+      "vars": [],
+      "pub_vars": []
+    },
+    {
+      "name": "::Foo",
+      "vars": [],
+      "pub_vars": []
+    }
+  ],
+  "storage": [
+    {
+      "name": "a1",
+      "ty": {
+        "Array": {
+          "ty": {
+            "Int": [0, 0]
+          },
+          "size": 5
+        }
+      }
+    },
+    {
+      "name": "a2",
+      "ty": {
+        "Array": {
+          "ty": {
+            "Array": {
+              "ty": {
+                "B256": [1, 0]
+              },
+              "size": 2
+            }
+          },
+          "size": 3
+        }
+      }
+    },
+    {
+      "name": "a3",
+      "ty": {
+        "Array": {
+          "ty": {
+            "Array": {
+              "ty": {
+                "Tuple": {
+                  "fields": [
+                    {
+                      "name": null,
+                      "ty": {
+                        "Int": [2, 0]
+                      }
+                    },
+                    {
+                      "name": null,
+                      "ty": {
+                        "B256": [2, 1]
+                      }
+                    }
+                  ],
+                  "key": [2, 0]
+                }
+              },
+              "size": 4
+            }
+          },
+          "size": 3
+        }
+      }
+    },
+    {
+      "name": "my_map",
+      "ty": {
+        "Map": {
+          "ty_from": "Int",
+          "ty_to": {
+            "Array": {
+              "ty": {
+                "Array": {
+                  "ty": {
+                    "Int": [3, null, 0]
+                  },
+                  "size": 9
+                }
+              },
+              "size": 5
+            }
+          },
+          "key": [3]
+        }
+      }
+    },
+    {
+      "name": "my_nested_map",
+      "ty": {
+        "Map": {
+          "ty_from": "Int",
+          "ty_to": {
+            "Map": {
+              "ty_from": "B256",
+              "ty_to": {
+                "Array": {
+                  "ty": {
+                    "Int": [4, null, null, null, null, null, 0]
+                  },
+                  "size": 3
+                }
+              },
+              "key": [4, null]
+            }
+          },
+          "key": [4]
+        }
+      }
+    }
+  ]
+}

--- a/pintc/tests/abi/arrays.pnt
+++ b/pintc/tests/abi/arrays.pnt
@@ -1,0 +1,50 @@
+storage {
+    a1: int[5],
+    a2: b256[3][2],
+    a3: { int, b256 }[3][4],
+    my_map: (int => int[5][9]),
+    my_nested_map: (int => (b256 => int[3])),
+}
+
+predicate Foo {
+}
+
+// parsed <<<
+// storage {
+//     a1: int[5],
+//     a2: b256[2][3],
+//     a3: {int, b256}[4][3],
+//     my_map: ( int => int[9][5] ),
+//     my_nested_map: ( int => ( b256 => int[3] ) ),
+// }
+// 
+// predicate ::Foo {
+//     storage {
+//         a1: int[5],
+//         a2: b256[2][3],
+//         a3: {int, b256}[4][3],
+//         my_map: ( int => int[9][5] ),
+//         my_nested_map: ( int => ( b256 => int[3] ) ),
+//     }
+// }
+// >>>
+
+// flattened <<<
+// storage {
+//     a1: int[5],
+//     a2: b256[2][3],
+//     a3: {int, b256}[4][3],
+//     my_map: ( int => int[9][5] ),
+//     my_nested_map: ( int => ( b256 => int[3] ) ),
+// }
+// 
+// predicate ::Foo {
+//     storage {
+//         a1: int[5],
+//         a2: b256[2][3],
+//         a3: {int, b256}[4][3],
+//         my_map: ( int => int[9][5] ),
+//         my_nested_map: ( int => ( b256 => int[3] ) ),
+//     }
+// }
+// >>>

--- a/pintc/tests/storage/storage_array.pnt
+++ b/pintc/tests/storage/storage_array.pnt
@@ -1,0 +1,171 @@
+storage {
+    v: int[2][3],
+    map_to_arrays: ( int => int[3] ),
+}
+
+interface Foo {
+    storage {
+        v: int[2][3],
+        map_to_arrays: ( int => int[3] ),
+    }
+}
+
+predicate Bar {
+    interface FooInstance = Foo(0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE);
+
+    state v = storage::v;
+    state v1 = storage::v[1];
+    state v10 = storage::v[1][0];
+
+    state map_to_arrays_69 = storage::map_to_arrays[69];
+    state map_to_arrays_69_1 = storage::map_to_arrays[69][1];
+
+    constraint v' == [
+        [42, 43, 44], 
+        [52, 53, 54], 
+    ];
+    constraint (v')[1] == [52, 53, 54];
+    constraint (v')[0][2] == 44;
+
+    constraint v1' == [52, 53, 54];
+    constraint (v1')[2] == 54;
+
+    constraint v10' == 52;
+
+    constraint map_to_arrays_69' == [99, 100, 101];
+    constraint (map_to_arrays_69')[2] == 101;
+    constraint map_to_arrays_69_1' == 100;
+
+    state foo_v = FooInstance::storage::v;
+    state foo_v1 = FooInstance::storage::v[1];
+    state foo_v10 = FooInstance::storage::v[1][0];
+
+    state foo_map_to_arrays_69 = FooInstance::storage::map_to_arrays[69];
+    state foo_map_to_arrays_69_1 = FooInstance::storage::map_to_arrays[69][1];
+
+    constraint foo_v' == [
+        [142, 143, 144], 
+        [152, 153, 154], 
+    ];
+    constraint (foo_v')[1] == [152, 153, 154];
+    constraint (foo_v')[0][2] == 144;
+
+    constraint foo_v1' == [152, 153, 154];
+    constraint (foo_v1')[2] == 154;
+
+    constraint foo_v10' == 152;
+
+    constraint foo_map_to_arrays_69' == [199, 1100, 1101];
+    constraint (foo_map_to_arrays_69')[2] == 1101;
+    constraint foo_map_to_arrays_69_1' == 1100;
+}
+
+// parsed <<<
+// storage {
+//     v: int[3][2],
+//     map_to_arrays: ( int => int[3] ),
+// }
+// interface ::Foo {
+//     storage {
+//         v: int[3][2],
+//         map_to_arrays: ( int => int[3] ),
+//     }
+// }
+// 
+// predicate ::Bar {
+//     storage {
+//         v: int[3][2],
+//         map_to_arrays: ( int => int[3] ),
+//     }
+//     interface ::Foo {
+//         storage {
+//             v: int[3][2],
+//             map_to_arrays: ( int => int[3] ),
+//         }
+//     }
+//     interface ::FooInstance = ::Foo(0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE)
+//     state ::v = storage::v;
+//     state ::v1 = storage::v[1];
+//     state ::v10 = storage::v[1][0];
+//     state ::map_to_arrays_69 = storage::map_to_arrays[69];
+//     state ::map_to_arrays_69_1 = storage::map_to_arrays[69][1];
+//     state ::foo_v = ::FooInstance::storage::v;
+//     state ::foo_v1 = ::FooInstance::storage::v[1];
+//     state ::foo_v10 = ::FooInstance::storage::v[1][0];
+//     state ::foo_map_to_arrays_69 = ::FooInstance::storage::map_to_arrays[69];
+//     state ::foo_map_to_arrays_69_1 = ::FooInstance::storage::map_to_arrays[69][1];
+//     constraint (::v' == [[42, 43, 44], [52, 53, 54]]);
+//     constraint (::v'[1] == [52, 53, 54]);
+//     constraint (::v'[0][2] == 44);
+//     constraint (::v1' == [52, 53, 54]);
+//     constraint (::v1'[2] == 54);
+//     constraint (::v10' == 52);
+//     constraint (::map_to_arrays_69' == [99, 100, 101]);
+//     constraint (::map_to_arrays_69'[2] == 101);
+//     constraint (::map_to_arrays_69_1' == 100);
+//     constraint (::foo_v' == [[142, 143, 144], [152, 153, 154]]);
+//     constraint (::foo_v'[1] == [152, 153, 154]);
+//     constraint (::foo_v'[0][2] == 144);
+//     constraint (::foo_v1' == [152, 153, 154]);
+//     constraint (::foo_v1'[2] == 154);
+//     constraint (::foo_v10' == 152);
+//     constraint (::foo_map_to_arrays_69' == [199, 1100, 1101]);
+//     constraint (::foo_map_to_arrays_69'[2] == 1101);
+//     constraint (::foo_map_to_arrays_69_1' == 1100);
+// }
+// >>>
+
+// flattened <<<
+// storage {
+//     v: int[3][2],
+//     map_to_arrays: ( int => int[3] ),
+// }
+// interface ::Foo {
+//     storage {
+//         v: int[3][2],
+//         map_to_arrays: ( int => int[3] ),
+//     }
+// }
+// 
+// predicate ::Bar {
+//     storage {
+//         v: int[3][2],
+//         map_to_arrays: ( int => int[3] ),
+//     }
+//     interface ::Foo {
+//         storage {
+//             v: int[3][2],
+//             map_to_arrays: ( int => int[3] ),
+//         }
+//     }
+//     interface ::FooInstance = ::Foo(0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE)
+//     state ::v: int[3][2] = storage::v;
+//     state ::v1: int[3] = storage::v[1];
+//     state ::v10: int = storage::v[1][0];
+//     state ::map_to_arrays_69: int[3] = storage::map_to_arrays[69];
+//     state ::map_to_arrays_69_1: int = storage::map_to_arrays[69][1];
+//     state ::foo_v: int[3][2] = ::FooInstance::storage::v;
+//     state ::foo_v1: int[3] = ::FooInstance::storage::v[1];
+//     state ::foo_v10: int = ::FooInstance::storage::v[1][0];
+//     state ::foo_map_to_arrays_69: int[3] = ::FooInstance::storage::map_to_arrays[69];
+//     state ::foo_map_to_arrays_69_1: int = ::FooInstance::storage::map_to_arrays[69][1];
+//     constraint ((((::v'[0][0] == 42) && (::v'[0][1] == 43)) && (::v'[0][2] == 44)) && (((::v'[1][0] == 52) && (::v'[1][1] == 53)) && (::v'[1][2] == 54)));
+//     constraint (((::v'[1][0] == 52) && (::v'[1][1] == 53)) && (::v'[1][2] == 54));
+//     constraint (::v'[0][2] == 44);
+//     constraint (((::v1'[0] == 52) && (::v1'[1] == 53)) && (::v1'[2] == 54));
+//     constraint (::v1'[2] == 54);
+//     constraint (::v10' == 52);
+//     constraint (((::map_to_arrays_69'[0] == 99) && (::map_to_arrays_69'[1] == 100)) && (::map_to_arrays_69'[2] == 101));
+//     constraint (::map_to_arrays_69'[2] == 101);
+//     constraint (::map_to_arrays_69_1' == 100);
+//     constraint ((((::foo_v'[0][0] == 142) && (::foo_v'[0][1] == 143)) && (::foo_v'[0][2] == 144)) && (((::foo_v'[1][0] == 152) && (::foo_v'[1][1] == 153)) && (::foo_v'[1][2] == 154)));
+//     constraint (((::foo_v'[1][0] == 152) && (::foo_v'[1][1] == 153)) && (::foo_v'[1][2] == 154));
+//     constraint (::foo_v'[0][2] == 144);
+//     constraint (((::foo_v1'[0] == 152) && (::foo_v1'[1] == 153)) && (::foo_v1'[2] == 154));
+//     constraint (::foo_v1'[2] == 154);
+//     constraint (::foo_v10' == 152);
+//     constraint (((::foo_map_to_arrays_69'[0] == 199) && (::foo_map_to_arrays_69'[1] == 1100)) && (::foo_map_to_arrays_69'[2] == 1101));
+//     constraint (::foo_map_to_arrays_69'[2] == 1101);
+//     constraint (::foo_map_to_arrays_69_1' == 1100);
+// }
+// >>>

--- a/pintc/tests/tests.rs
+++ b/pintc/tests/tests.rs
@@ -68,7 +68,8 @@ fn run_tests(sub_dir: &str) -> anyhow::Result<()> {
 
             if let Ok(mut file) = File::open(&path) {
                 // The JSON ABI of the produce program
-                let json_abi = serde_json::to_string_pretty(&program.abi().unwrap())?;
+                let handler = Handler::default();
+                let json_abi = serde_json::to_string_pretty(&program.abi(&handler).unwrap())?;
 
                 // The JSON ABI from the reference file
                 let mut json_abi_reference = String::new();

--- a/tests/validation_tests/storage_array.pnt
+++ b/tests/validation_tests/storage_array.pnt
@@ -1,0 +1,177 @@
+storage {
+    u: int[2],
+    t: b256[3],
+    v: int[2][3],
+    map_to_arrays: ( int => int[3] ),
+}
+
+interface Foo {
+    storage {
+        u: int[2],
+        t: b256[3],
+        v: int[2][3],
+        map_to_arrays: ( int => int[3] ),
+    }
+}
+
+predicate Bar {
+    interface FooInstance = Foo(0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE);
+
+    state u = storage::u;
+    state u0 = storage::u[0];
+    state u1 = storage::u[1];
+
+    state t = storage::t;
+    state t0 = storage::t[0];
+    state t1 = storage::t[1];
+    state t2 = storage::t[2];
+
+    state v = storage::v;
+    state v0 = storage::v[0];
+    state v1 = storage::v[1];
+    state v00 = storage::v[0][0];
+    state v01 = storage::v[0][1];
+    state v02 = storage::v[0][2];
+    state v10 = storage::v[1][0];
+    state v11 = storage::v[1][1];
+    state v12 = storage::v[1][2];
+
+    state map_to_arrays_69 = storage::map_to_arrays[69];
+    state map_to_arrays_69_0 = storage::map_to_arrays[69][0];
+    state map_to_arrays_69_1 = storage::map_to_arrays[69][1];
+    state map_to_arrays_69_2 = storage::map_to_arrays[69][2];
+
+    constraint u' == [2, 3];
+    constraint (u')[0] == 2;
+    constraint (u')[1] == 3;
+    constraint u0' == 2;
+    constraint u1' == 3;
+
+    constraint t' == [
+        0x0000000000000001000000000000000100000000000000010000000000000001,
+        0x0000000000000002000000000000000200000000000000020000000000000002,
+        0x0000000000000003000000000000000300000000000000030000000000000003,
+    ];
+    constraint (t')[0] == 0x0000000000000001000000000000000100000000000000010000000000000001;
+    constraint (t')[1] == 0x0000000000000002000000000000000200000000000000020000000000000002;
+    constraint (t')[2] == 0x0000000000000003000000000000000300000000000000030000000000000003;
+    constraint t0' == 0x0000000000000001000000000000000100000000000000010000000000000001;
+    constraint t1' == 0x0000000000000002000000000000000200000000000000020000000000000002;
+    constraint t2' == 0x0000000000000003000000000000000300000000000000030000000000000003;
+
+    constraint v' == [
+        [42, 43, 44], 
+        [52, 53, 54], 
+    ];
+    constraint (v')[0] == [42, 43, 44];
+    constraint (v')[1] == [52, 53, 54];
+    constraint (v')[0][0] == 42;
+    constraint (v')[0][1] == 43;
+    constraint (v')[0][2] == 44;
+    constraint (v')[1][0] == 52;
+    constraint (v')[1][1] == 53;
+    constraint (v')[1][2] == 54;
+
+    constraint v0' == [42, 43, 44];
+    constraint (v0')[0] == 42;
+    constraint (v0')[1] == 43;
+    constraint (v0')[2] == 44;
+    constraint v1' == [52, 53, 54];
+    constraint (v1')[0] == 52;
+    constraint (v1')[1] == 53;
+    constraint (v1')[2] == 54;
+
+    constraint v00' == 42;
+    constraint v01' == 43;
+    constraint v02' == 44;
+    constraint v10' == 52;
+    constraint v11' == 53;
+    constraint v12' == 54;
+
+    constraint map_to_arrays_69' == [99, 100, 101];
+    constraint (map_to_arrays_69')[0] == 99;
+    constraint (map_to_arrays_69')[1] == 100;
+    constraint (map_to_arrays_69')[2] == 101;
+    constraint map_to_arrays_69_0' == 99;
+    constraint map_to_arrays_69_1' == 100;
+    constraint map_to_arrays_69_2' == 101;
+
+    state foo_u =  FooInstance::storage::u;
+    state foo_u0 = FooInstance::storage::u[0];
+    state foo_u1 = FooInstance::storage::u[1];
+
+    state foo_t = FooInstance::storage::t;
+    state foo_t0 = FooInstance::storage::t[0];
+    state foo_t1 = FooInstance::storage::t[1];
+    state foo_t2 = FooInstance::storage::t[2];
+
+    state foo_v = FooInstance::storage::v;
+    state foo_v0 = FooInstance::storage::v[0];
+    state foo_v1 = FooInstance::storage::v[1];
+    state foo_v00 = FooInstance::storage::v[0][0];
+    state foo_v01 = FooInstance::storage::v[0][1];
+    state foo_v02 = FooInstance::storage::v[0][2];
+    state foo_v10 = FooInstance::storage::v[1][0];
+    state foo_v11 = FooInstance::storage::v[1][1];
+    state foo_v12 = FooInstance::storage::v[1][2];
+
+    state foo_map_to_arrays_69 = FooInstance::storage::map_to_arrays[69];
+    state foo_map_to_arrays_69_0 = FooInstance::storage::map_to_arrays[69][0];
+    state foo_map_to_arrays_69_1 = FooInstance::storage::map_to_arrays[69][1];
+    state foo_map_to_arrays_69_2 = FooInstance::storage::map_to_arrays[69][2];
+
+    constraint foo_u' == [12, 13];
+    constraint (foo_u')[0] == 12;
+    constraint (foo_u')[1] == 13;
+    constraint foo_u0' == 12;
+    constraint foo_u1' == 13;
+
+    constraint foo_t' == [
+        0x000000000000000B000000000000000B000000000000000B000000000000000B,
+        0x000000000000000C000000000000000C000000000000000C000000000000000C,
+        0x000000000000000D000000000000000D000000000000000D000000000000000D,
+    ];
+    constraint (foo_t')[0] == 0x000000000000000B000000000000000B000000000000000B000000000000000B;
+    constraint (foo_t')[1] == 0x000000000000000C000000000000000C000000000000000C000000000000000C;
+    constraint (foo_t')[2] == 0x000000000000000D000000000000000D000000000000000D000000000000000D;
+    constraint foo_t0' == 0x000000000000000B000000000000000B000000000000000B000000000000000B;
+    constraint foo_t1' == 0x000000000000000C000000000000000C000000000000000C000000000000000C;
+    constraint foo_t2' == 0x000000000000000D000000000000000D000000000000000D000000000000000D;
+
+    constraint foo_v' == [
+        [142, 143, 144], 
+        [152, 153, 154], 
+    ];
+    constraint (foo_v')[0] == [142, 143, 144];
+    constraint (foo_v')[1] == [152, 153, 154];
+    constraint (foo_v')[0][0] == 142;
+    constraint (foo_v')[0][1] == 143;
+    constraint (foo_v')[0][2] == 144;
+    constraint (foo_v')[1][0] == 152;
+    constraint (foo_v')[1][1] == 153;
+    constraint (foo_v')[1][2] == 154;
+
+    constraint foo_v0' == [142, 143, 144];
+    constraint (foo_v0')[0] == 142;
+    constraint (foo_v0')[1] == 143;
+    constraint (foo_v0')[2] == 144;
+    constraint foo_v1' == [152, 153, 154];
+    constraint (foo_v1')[0] == 152;
+    constraint (foo_v1')[1] == 153;
+    constraint (foo_v1')[2] == 154;
+
+    constraint foo_v00' == 142;
+    constraint foo_v01' == 143;
+    constraint foo_v02' == 144;
+    constraint foo_v10' == 152;
+    constraint foo_v11' == 153;
+    constraint foo_v12' == 154;
+
+    constraint foo_map_to_arrays_69' == [199, 1100, 1101];
+    constraint (foo_map_to_arrays_69')[0] == 199;
+    constraint (foo_map_to_arrays_69')[1] == 1100;
+    constraint (foo_map_to_arrays_69')[2] == 1101;
+    constraint foo_map_to_arrays_69_0' == 199;
+    constraint foo_map_to_arrays_69_1' == 1100;
+    constraint foo_map_to_arrays_69_2' == 1101;
+}

--- a/tests/validation_tests/storage_array.toml
+++ b/tests/validation_tests/storage_array.toml
@@ -1,0 +1,239 @@
+[[data]]
+decision_variables = []
+predicate_to_solve = { set = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", predicate = "::Bar" }
+state_mutations = [
+  { key = [
+    0,
+    0,
+  ], value = [
+    2,
+  ] },
+  { key = [
+    0,
+    1,
+  ], value = [
+    3,
+  ] },
+  { key = [
+    1,
+    0,
+  ], value = [
+    1,
+    1,
+    1,
+    1,
+  ] },
+  { key = [
+    1,
+    1,
+  ], value = [
+    2,
+    2,
+    2,
+    2,
+  ] },
+  { key = [
+    1,
+    2,
+  ], value = [
+    3,
+    3,
+    3,
+    3,
+  ] },
+  { key = [
+    2,
+    0,
+  ], value = [
+    42,
+  ] },
+  { key = [
+    2,
+    1,
+  ], value = [
+    43,
+  ] },
+  { key = [
+    2,
+    2,
+  ], value = [
+    44,
+  ] },
+  { key = [
+    2,
+    3,
+  ], value = [
+    52,
+  ] },
+  { key = [
+    2,
+    4,
+  ], value = [
+    53,
+  ] },
+  { key = [
+    2,
+    5,
+  ], value = [
+    54,
+  ] },
+  { key = [
+    3,
+    69,
+    0,
+  ], value = [
+    99,
+  ] },
+  { key = [
+    3,
+    69,
+    1,
+  ], value = [
+    100,
+  ] },
+  { key = [
+    3,
+    69,
+    2,
+  ], value = [
+    101,
+  ] },
+]
+
+[[data]]
+decision_variables = []
+predicate_to_solve = { set = "0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE", predicate = "" }
+state_mutations = [
+  { key = [
+    0,
+    0,
+  ], value = [
+    12,
+  ] },
+  { key = [
+    0,
+    1,
+  ], value = [
+    13,
+  ] },
+  { key = [
+    1,
+    0,
+  ], value = [
+    11,
+    11,
+    11,
+    11,
+  ] },
+  { key = [
+    1,
+    1,
+  ], value = [
+    12,
+    12,
+    12,
+    12,
+  ] },
+  { key = [
+    1,
+    2,
+  ], value = [
+    13,
+    13,
+    13,
+    13,
+  ] },
+  { key = [
+    2,
+    0,
+  ], value = [
+    142,
+  ] },
+  { key = [
+    2,
+    1,
+  ], value = [
+    143,
+  ] },
+  { key = [
+    2,
+    2,
+  ], value = [
+    144,
+  ] },
+  { key = [
+    2,
+    3,
+  ], value = [
+    152,
+  ] },
+  { key = [
+    2,
+    4,
+  ], value = [
+    153,
+  ] },
+  { key = [
+    2,
+    5,
+  ], value = [
+    154,
+  ] },
+  { key = [
+    3,
+    69,
+    0,
+  ], value = [
+    199,
+  ] },
+  { key = [
+    3,
+    69,
+    1,
+  ], value = [
+    1100,
+  ] },
+  { key = [
+    3,
+    69,
+    2,
+  ], value = [
+    1101,
+  ] },
+  { key = [
+    4,
+    0,
+  ], value = [
+    70,
+  ] },
+  { key = [
+    4,
+    1,
+  ], value = [
+    71,
+  ] },
+  { key = [
+    4,
+    2,
+  ], value = [
+    72,
+  ] },
+  { key = [
+    4,
+    3,
+  ], value = [
+    73,
+  ] },
+  { key = [
+    4,
+    4,
+  ], value = [
+    74,
+  ] },
+  { key = [
+    4,
+    5,
+  ], value = [
+    75,
+  ] },
+]


### PR DESCRIPTION
This is just a first steps towards full support. Tuples in arrays don't work yet. We also still need to support other types include aliases. Aliases are not allowed in storage blocks yet.

closes https://github.com/essential-contributions/essential-integration/issues/18