### PR TITLE
Fix transient data keys for non-primitive types

### DIFF
--- a/pintc/src/asm_gen/tests/intrinsics.rs
+++ b/pintc/src/asm_gen/tests/intrinsics.rs
@@ -401,6 +401,70 @@ fn sha256() {
             --- State Reads ---
         "#]],
     );
+
+    check(
+        &format!(
+            "{}",
+            compile(
+                r#"
+            pub var foo: int;
+            pub var bar: { int, b256, int[3] };
+            var hash = __sha256({ foo, bar });
+            solve satisfy;
+            "#,
+            )
+        ),
+        expect_test::expect![[r#"
+            --- Constraints ---
+            constraint 0
+              Stack(Push(0))
+              Stack(Push(0))
+              Stack(Push(4))
+              Access(DecisionVarRange)
+              Stack(Push(0))
+              Stack(Push(1))
+              Access(ThisPathway)
+              Access(Transient)
+              Stack(Push(1))
+              Stack(Push(0))
+              Stack(Push(2))
+              Access(ThisPathway)
+              Access(Transient)
+              Stack(Push(1))
+              Stack(Push(0))
+              Stack(Push(1))
+              Alu(Add)
+              Stack(Push(2))
+              Access(ThisPathway)
+              Access(Transient)
+              Stack(Push(1))
+              Stack(Push(0))
+              Stack(Push(2))
+              Alu(Add)
+              Stack(Push(2))
+              Access(ThisPathway)
+              Access(Transient)
+              Stack(Push(1))
+              Stack(Push(0))
+              Stack(Push(3))
+              Alu(Add)
+              Stack(Push(2))
+              Access(ThisPathway)
+              Access(Transient)
+              Stack(Push(1))
+              Stack(Push(0))
+              Stack(Push(4))
+              Alu(Add)
+              Stack(Push(2))
+              Access(ThisPathway)
+              Access(Transient)
+              Stack(Push(9))
+              Crypto(Sha256)
+              Stack(Push(4))
+              Pred(EqRange)
+            --- State Reads ---
+        "#]],
+    );
 }
 
 #[test]

--- a/tests/validation_tests/pub_var_tuple_hash.pnt
+++ b/tests/validation_tests/pub_var_tuple_hash.pnt
@@ -1,0 +1,6 @@
+predicate Foo {
+    pub var foo: int;
+    pub var bar: { int, b256, int[3] };
+    constraint __sha256({ foo, bar }) == __sha256({ foo, bar.0, bar.1, bar.2[0], bar.2[1], bar.2[2] });
+    constraint __sha256({ foo, { bar.0, bar.1 }, bar.2 }) == __sha256({ foo, bar.0, bar.1, bar.2[0], bar.2[1], bar.2[2] });
+}

--- a/tests/validation_tests/pub_var_tuple_hash.toml
+++ b/tests/validation_tests/pub_var_tuple_hash.toml
@@ -1,0 +1,43 @@
+[[data]]
+predicate_to_solve = { set = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", predicate = "::Simple" }
+decision_variables = []
+transient_data = [
+  { key = [
+    0,
+  ], value = [
+    42,
+  ] },
+  { key = [
+    1,
+    0,
+  ], value = [
+    69,
+  ] },
+  { key = [
+    1,
+    1,
+  ], value = [
+    1,
+    2,
+    3,
+    4,
+  ] },
+  { key = [
+    1,
+    2,
+  ], value = [
+    15,
+  ] },
+  { key = [
+    1,
+    3,
+  ], value = [
+    16,
+  ] },
+  { key = [
+    1,
+    4,
+  ], value = [
+    17,
+  ] },
+]


### PR DESCRIPTION
We don't have a`TransientRange` so I'm just doing it manually for now by using as many `Transient` opcodes as needed depending on the size of the type.

Closes #717