### PR TITLE
feat: Add print-flat and silet to pint

### DIFF
--- a/pint-pkg/src/build.rs
+++ b/pint-pkg/src/build.rs
@@ -54,6 +54,8 @@ pub struct BuiltContract {
     pub lib_entry_point: PathBuf,
     /// The ABI for the contract.
     pub abi: ProgramABI,
+    /// The flattened program.
+    pub flattened: pintc::predicate::Program,
 }
 
 /// An predicate built as a part of a contract.
@@ -354,6 +356,7 @@ fn build_pkg(plan: &Plan, built_pkgs: &BuiltPkgs, n: NodeIx) -> Result<BuiltPkg,
                 },
                 lib_entry_point,
                 abi,
+                flattened,
             };
             BuiltPkg::Contract(contract)
         }


### PR DESCRIPTION
- Adds the ability to print out the flat pint contract.
- Adds the ability to silence default output.

Having the flat representation is really useful for debugging / just understanding how macros work. Unfortunately we can't just use `pintc` if our project has dependencies. 

I'm not entirely sure this is the best way to implement this though