### PR TITLE
fix(pint): Return non-zero exit status on error. Improve error info.

### DIFF
--- a/pint/src/main.rs
+++ b/pint/src/main.rs
@@ -63,7 +63,7 @@ fn run() -> anyhow::Result<()> {
 fn main() {
     if let Err(err) = run() {
         let bold = Style::new().bold();
-        eprintln!("{}Error:{} {err}", bold.render(), bold.render_reset());
+        eprintln!("{}Error:{} {err:?}", bold.render(), bold.render_reset());
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
Returns the `libc::EXIT_FAILURE` value (1) on error.

Also fixes an issue where anyhow's display output doesn't show error causes. Using the `Debug` gives the error and the cause.

Closes #718.