### PR TITLE
refactor: Move pint built pkg artifact writing to `pint-pkg`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,7 @@ dependencies = [
  "pint-manifest",
  "pintc",
  "serde",
+ "serde_json",
  "thiserror",
  "toml",
 ]

--- a/pint-pkg/Cargo.toml
+++ b/pint-pkg/Cargo.toml
@@ -16,6 +16,7 @@ petgraph = { workspace = true }
 pint-manifest = { workspace = true }
 pintc = { path = "../pintc", default-features = false }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Previously we were writing output in `pint`, but this upstreams the logic for writing output to a given directory to the `pint-pkg` crate.

Originally included in #679, refactored out here into its own PR.