### PR TITLE
feat: Add `--print-flat` and `--silent` flags to `pint` (freesig's PR rebased)

### DIFF
--- a/pint-pkg/src/build.rs
+++ b/pint-pkg/src/build.rs
@@ -57,6 +57,8 @@ pub struct BuiltContract {
     pub lib_entry_point: PathBuf,
     /// The ABI for the contract.
     pub abi: ProgramABI,
+    /// The flattened program.
+    pub flattened: pintc::predicate::Program,
 }
 
 /// An predicate built as a part of a contract.
@@ -390,6 +392,7 @@ fn build_pkg(plan: &Plan, built_pkgs: &BuiltPkgs, n: NodeIx) -> Result<BuiltPkg,
                 },
                 lib_entry_point,
                 abi,
+                flattened,
             };
             BuiltPkg::Contract(contract)
         }

--- a/pint/src/build.rs
+++ b/pint/src/build.rs
@@ -3,7 +3,7 @@
 use anyhow::Context;
 use clap::{builder::styling::Style, Parser};
 use pint_pkg::{build::BuiltPkg, manifest::ManifestFile};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Build a package, writing the generated artifacts to `out/`.
 #[derive(Parser, Debug)]
@@ -14,6 +14,12 @@ pub(crate) struct Args {
     /// recursively until a manifest is found.
     #[arg(long = "manifest-path")]
     manifest_path: Option<PathBuf>,
+    /// Print the flattened pint program.
+    #[arg(long)]
+    print_flat: bool,
+    /// Don't print anything that wasn't explicitly requested.
+    #[arg(long)]
+    silent: bool,
 }
 
 // Find the file within the current directory or parent directories with the given name.
@@ -59,23 +65,18 @@ pub(crate) fn cmd(args: Args) -> anyhow::Result<()> {
     while let Some(prebuilt) = builder.next_pkg() {
         let pinned = prebuilt.pinned();
         let manifest = &plan.manifests()[&pinned.id()];
+        let source_str = source_string(pinned, manifest.dir());
 
-        // Package name formatted (including source if not a member).
-        let source_str = match pinned.source {
-            pint_pkg::source::Pinned::Member(_) => {
-                format!("{}", manifest.dir().display())
-            }
-            _ => format!("{}", pinned.source),
-        };
-
-        println!(
-            "   {}Compiling{} {} [{}] ({})",
-            bold.render(),
-            bold.render_reset(),
-            pinned.name,
-            manifest.pkg.kind,
-            source_str,
-        );
+        if !args.silent {
+            println!(
+                "   {}Compiling{} {} [{}] ({})",
+                bold.render(),
+                bold.render_reset(),
+                pinned.name,
+                manifest.pkg.kind,
+                source_str,
+            );
+        }
 
         // Build the package.
         let _built = match prebuilt.build() {
@@ -107,13 +108,15 @@ pub(crate) fn cmd(args: Args) -> anyhow::Result<()> {
             .write_to_dir(&pinned.name, &profile_dir)
             .with_context(|| format!("failed to write output artifacts to {profile_dir:?}"))?;
 
-        // Print the build summary.
-        println!(
-            "    {}Finished{} build [{profile}] in {:?}",
-            bold.render(),
-            bold.render_reset(),
-            build_start.elapsed()
-        );
+        if !args.silent {
+            // Print the build summary.
+            println!(
+                "    {}Finished{} build [{profile}] in {:?}",
+                bold.render(),
+                bold.render_reset(),
+                build_start.elapsed()
+            );
+        }
 
         // Print the build summary for our member package.
         let kind_str = format!("{}", manifest.pkg.kind);
@@ -125,13 +128,15 @@ pub(crate) fn cmd(args: Args) -> anyhow::Result<()> {
         };
         let name_col_w = name_col_w(&pinned.name, built);
 
-        println!(
-            "{padding}{}{kind_str}{} {:<name_col_w$} {}",
-            bold.render(),
-            bold.render_reset(),
-            pinned.name,
-            ca,
-        );
+        if !args.silent {
+            println!(
+                "{padding}{}{kind_str}{} {:<name_col_w$} {}",
+                bold.render(),
+                bold.render_reset(),
+                pinned.name,
+                ca,
+            );
+        }
 
         // For contracts, print their predicates too.
         if let BuiltPkg::Contract(contract) = built {
@@ -139,12 +144,44 @@ pub(crate) fn cmd(args: Args) -> anyhow::Result<()> {
             while let Some(predicate) = iter.next() {
                 let name = format!("{}{}", pinned.name, predicate.name);
                 let pipe = iter.peek().map(|_| "├──").unwrap_or("└──");
-                println!("         {pipe} {:<name_col_w$} {}", name, predicate.ca);
+                if !args.silent {
+                    println!("         {pipe} {:<name_col_w$} {}", name, predicate.ca);
+                }
+            }
+        }
+    }
+
+    // Print all flattened contract packages if the flag is set.
+    if args.print_flat {
+        for &n in plan.compilation_order() {
+            let built = &builder.built_pkgs()[&n];
+            let pinned = &plan.graph()[n];
+            let manifest = &plan.manifests()[&pinned.id()];
+            let source_str = source_string(pinned, manifest.dir());
+            if let BuiltPkg::Contract(built) = built {
+                println!(
+                    "{}{}{} ({})",
+                    bold.render(),
+                    pinned.name,
+                    bold.render_reset(),
+                    source_str,
+                );
+                println!("{}", built.flattened);
             }
         }
     }
 
     Ok(())
+}
+
+// Package name formatted (including source if not a member).
+fn source_string(pinned: &pint_pkg::plan::Pinned, manifest_dir: &Path) -> String {
+    match pinned.source {
+        pint_pkg::source::Pinned::Member(_) => {
+            format!("{}", manifest_dir.display())
+        }
+        _ => format!("{}", pinned.source),
+    }
 }
 
 /// Determine the width of the column required to fit the name and all


### PR DESCRIPTION
*Based on #724.*

This is #722 but rebased onto #724. Includes small tweaks to formatting to include source package location and avoids iterating over a hashmap when writing flattened output.