### PR TITLE
refactor: Rename pint_solve to pint-solve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "pint_solve"
+name = "pint-solve"
 version = "0.1.0"
 dependencies = [
  "anyhow",
@@ -1237,7 +1237,7 @@ dependencies = [
  "lalrpop-util",
  "logos",
  "pint-abi-types",
- "pint_solve",
+ "pint-solve",
  "regex",
  "serde",
  "serde_json",

--- a/pint-solve/Cargo.toml
+++ b/pint-solve/Cargo.toml
@@ -1,15 +1,11 @@
 [package]
-name = "pint_solve"
+name = "pint-solve"
 version = "0.1.0"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
-
-[lib]
-name = "pint_solve"
-path = "src/lib.rs"
 
 [build-dependencies]
 lalrpop = "0.20"

--- a/pintc/Cargo.toml
+++ b/pintc/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 lalrpop = "0.20"
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["pint_solve"]
+normal = ["pint-solve"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -33,7 +33,7 @@ itertools = { workspace = true }
 lalrpop-util = "0.20"
 logos = { workspace = true }
 pint-abi-types = { workspace = true }
-pint_solve = { path = "../pint-solve", default-features = false }
+pint-solve = { path = "../pint-solve", default-features = false }
 regex = "1.10"
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -49,4 +49,4 @@ test-util = { path = "../test-util" }
 test_bin = "0.4"
 
 [features]
-solver-scip = ["pint_solve/solver-scip"]
+solver-scip = ["pint-solve/solver-scip"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = { workspace = true }
 essential-constraint-vm = { git = "ssh://git@github.com/essential-contributions/essential-base.git", package = "essential-constraint-vm" }
 essential-state-read-vm = { git = "ssh://git@github.com/essential-contributions/essential-base.git", package = "essential-state-read-vm" }
 essential-types = { workspace = true }
-#pint_solve = { path = "../pint-solve", default-features = false }
+#pint-solve = { path = "../pint-solve", default-features = false }
 pintc = { path = "../pintc", default-features = false }
 test-util = { path = "../test-util" }
 thiserror = "1"
@@ -31,4 +31,4 @@ name = "validation_tests"
 path = "validation_tests.rs"
 
 #[features]
-#solver-scip = ["pint_solve/solver-scip", "pintc/solver-scip"]
+#solver-scip = ["pint-solve/solver-scip", "pintc/solver-scip"]


### PR DESCRIPTION
In anticipation of publishing to crates.io and for consistency with the other `pint-*` crate names.