### PR TITLE
Allow type aliases for storage vars.

### DIFF
--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -94,7 +94,8 @@ PredicateClose: () = {
 
 StorageVar: StorageVar = {
     <l:@L> <name:Ident> ":" <ty:StorageVarType> <r:@R> => {
-        context.parse_storage_var(handler, name, ty, (l, r))
+        let span = (context.span_from)(l, r);
+        StorageVar { name, ty, span }
     }
 }
 

--- a/pintc/src/predicate/analyse.rs
+++ b/pintc/src/predicate/analyse.rs
@@ -49,6 +49,7 @@ impl Contract {
 
             pred.check_undefined_types(handler);
             pred.lower_newtypes(handler)?;
+            pred.check_storage_types(handler);
             pred.type_check_all_exprs(handler, &self.consts);
             pred.check_inits(handler, &self.consts);
             pred.check_constraint_types(handler);

--- a/pintc/tests/storage/new_types.pnt
+++ b/pintc/tests/storage/new_types.pnt
@@ -1,0 +1,75 @@
+type OneOrTheOther = bool;
+type Count = int;
+type Haaash = b256;
+
+storage {
+    m: ( OneOrTheOther => int ),
+    n: ( bool => Count ),
+    o: ( OneOrTheOther => Haaash ),
+}
+
+predicate test {
+    state x = storage::m[true];
+    state y = storage::n[false];
+    state z = storage::o[false];
+
+    constraint x == 11;
+    constraint y' < 22;
+    constraint z != 0x3333333333333333333333333333333333333333333333333333333333333333;
+}
+
+// parsed <<<
+// storage {
+//     m: ( ::OneOrTheOther => int ),
+//     n: ( bool => ::Count ),
+//     o: ( ::OneOrTheOther => ::Haaash ),
+// }
+// type ::OneOrTheOther = bool;
+// type ::Count = int;
+// type ::Haaash = b256;
+//
+// predicate ::test {
+//     storage {
+//         m: ( ::OneOrTheOther => int ),
+//         n: ( bool => ::Count ),
+//         o: ( ::OneOrTheOther => ::Haaash ),
+//     }
+//     state ::x = storage::m[true];
+//     state ::y = storage::n[false];
+//     state ::z = storage::o[false];
+//     type ::OneOrTheOther = bool;
+//     type ::Count = int;
+//     type ::Haaash = b256;
+//     constraint (::x == 11);
+//     constraint (::y' < 22);
+//     constraint (::z != 0x3333333333333333333333333333333333333333333333333333333333333333);
+// }
+// >>>
+
+// flattened <<<
+// storage {
+//     m: ( bool => int ),
+//     n: ( bool => int ),
+//     o: ( bool => b256 ),
+// }
+// type ::OneOrTheOther = bool;
+// type ::Count = int;
+// type ::Haaash = b256;
+//
+// predicate ::test {
+//     storage {
+//         m: ( bool => int ),
+//         n: ( bool => int ),
+//         o: ( bool => b256 ),
+//     }
+//     state ::x: int = storage::m[true];
+//     state ::y: int = storage::n[false];
+//     state ::z: b256 = storage::o[false];
+//     type ::OneOrTheOther = bool;
+//     type ::Count = int;
+//     type ::Haaash = b256;
+//     constraint (::x == 11);
+//     constraint (::y' < 22);
+//     constraint (::z != 0x3333333333333333333333333333333333333333333333333333333333333333);
+// }
+// >>>


### PR DESCRIPTION
This moves the type check for storage vars out of the parser and into the type checker.

The check is done after custom types have been lowered, so checks like `ty.is_bool()` will work, even if they're aliases.  This wasn't possible at the parse stage.

It also ensures that custom types are lowered for storage vars (they didn't have to be until now -- the parser used to reject them) and they are also lowered for flattening.

Argh, the diff is a bit confused because I refactored the instance type checking into their own methods and then put the storage checks where it used to be... 

Closes #745.

Note: this is based on #758 and should probably be merged after it's in.