### PR TITLE
refactor(pint-abi-gen): Add `pint-abi-visit`, programmatic key construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,6 +1185,7 @@ name = "pint-abi-visit"
 version = "0.0.1"
 dependencies = [
  "essential-types",
+ "petgraph",
  "pint-abi-types",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ dependencies = [
  "essential-types",
  "pint-abi-gen",
  "pint-abi-types",
+ "pint-abi-visit",
  "serde_json",
  "thiserror",
 ]
@@ -1150,6 +1151,7 @@ version = "0.1.0"
 dependencies = [
  "essential-types",
  "pint-abi-types",
+ "pint-abi-visit",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -1176,6 +1178,14 @@ name = "pint-abi-types"
 version = "0.1.0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "pint-abi-visit"
+version = "0.0.1"
+dependencies = [
+ "essential-types",
+ "pint-abi-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "pint-abi-gen",
   "pint-abi-gen-tests",
   "pint-abi-types",
+  "pint-abi-visit",
   "pint-cli",
   "pint-manifest",
   "pint-pkg",
@@ -34,6 +35,7 @@ petgraph = "0.6"
 pint-abi = { path = "pint-abi", version = "0.1.0" }
 pint-abi-gen = { path = "pint-abi-gen", version = "0.1.0" }
 pint-abi-types = { path = "pint-abi-types", version = "0.1.0" }
+pint-abi-visit = { path = "pint-abi-visit", version = "0.0.1" }
 pint-manifest = { path = "pint-manifest", version = "0.1.0" }
 pint-pkg = { path = "pint-pkg", version = "0.1.0" }
 pintc = { path = "pintc", version = "0.1.0" }

--- a/pint-abi-gen/Cargo.toml
+++ b/pint-abi-gen/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro = true
 [dependencies]
 essential-types = { workspace = true }
 pint-abi-types = { workspace = true }
+pint-abi-visit = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 serde_json = { workspace = true }

--- a/pint-abi-gen/src/lib.rs
+++ b/pint-abi-gen/src/lib.rs
@@ -16,13 +16,14 @@
 //! including the encoding of keys, values and mutations from higher-level types.
 
 use pint_abi_types::{ContractABI, KeyedTypeABI, KeyedVarABI, PredicateABI, TupleField, TypeABI};
-use pint_abi_visit::{tree_from_keyed_vars, KeyedVarTree, Nesting, NodeIx};
+use pint_abi_visit::Nesting;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::ToTokens;
 use syn::parse_macro_input;
 
 mod map;
+mod mutation;
 mod tuple;
 mod vars;
 
@@ -179,34 +180,6 @@ fn items_from_predicates(predicates: &[PredicateABI]) -> Vec<syn::Item> {
     items
 }
 
-/// The builder struct for mutations.
-fn mutations_struct() -> syn::ItemStruct {
-    syn::parse_quote! {
-        /// A builder for a set of mutations.
-        ///
-        /// Can be constructed via the [`mutations`] function.
-        #[derive(Debug, Default)]
-        pub struct Mutations {
-            /// The set of mutations being built.
-            set: Vec<pint_abi::types::essential::solution::Mutation>,
-            /// The stack of key elements that need to be merged with the
-            /// `&[Nesting]` derived by the `KeyedTypeABI` traversal.
-            ///
-            /// For example, when a map's `entry` method is called, the provided
-            /// key is pushed to this stack. Upon completion of the `entry`
-            /// method, the key is popped.
-            key_elems: Vec<pint_abi::key::Elem>,
-        }
-    }
-}
-
-fn mutation_method_doc_str(name: &str) -> String {
-    format!(
-        "Add a mutation for the `{name}` field into the set.\n\n\
-        Relaces any existing mutation for the given key.",
-    )
-}
-
 /// Given a keyed var `Nesting`, create a Rust expression that results in its value.
 fn nesting_expr(nesting: &[Nesting]) -> syn::ExprArray {
     let elems = nesting
@@ -244,42 +217,12 @@ fn construct_key_expr() -> syn::Expr {
     }
 }
 
-/// A `Mutations` builder method for a single-key mutation.
-fn mutation_method_for_single_key(
-    name: &str,
-    arg_ty: &SingleKeyTy,
-    nesting: &[Nesting],
-) -> syn::ImplItemFn {
-    let method_ident = syn::Ident::new(name, Span::call_site());
-    let abi_key_doc_str = nesting_key_doc_str(nesting);
-    let doc_str = format!(
-        "{}\n\nKey: `{abi_key_doc_str}`",
-        mutation_method_doc_str(name)
-    );
-    let arg_ty = arg_ty.syn_ty();
-    let nesting_expr: syn::ExprArray = nesting_expr(nesting);
-    let construct_key_expr: syn::Expr = construct_key_expr();
-    syn::parse_quote! {
-        #[doc = #doc_str]
-        pub fn #method_ident(mut self, val: #arg_ty) -> Self {
-            use pint_abi::types::essential::{Key, Value, solution::Mutation};
-            let nesting = #nesting_expr;
-            let key: Key = #construct_key_expr;
-            let value: Value = pint_abi::encode(&val);
-            self.set.retain(|m: &Mutation| &m.key != &key);
-            let mutation = Mutation { key, value };
-            self.set.push(mutation);
-            self
-        }
-    }
-}
-
 /// Convert the given type `&[Nesting]` into a string to use for a generated
 /// builder struct name.
 ///
 /// E.g. `[Var { ix: 1 }, MapEntry { key_ty: i64 }, TupleField { ix: 3, .. }]`
 /// becomes `Var1_MapEntry_Tuple3` so that it may be appended to a builder type
-/// name, e.g. `Tuple_Var1_MapEntry_Tuple3`.
+/// name, e.g. `Tuple_1_MapEntry_3`.
 fn nesting_ty_str<'a>(nesting: impl IntoIterator<Item = &'a Nesting>) -> String {
     fn elem_str(nesting: &Nesting) -> String {
         match nesting {
@@ -338,169 +281,12 @@ fn abi_key_from_keyed_type(ty: &KeyedTypeABI) -> &Vec<Option<usize>> {
     }
 }
 
-/// A `DerefMut<Target = Mutations>` impl for the tuple struct.
-///
-/// This allows for sharing the `mutation_method_from_keyed_var` for method
-/// generation between the `Mutations` impl and the `Tuple_*` impls.
-fn mutation_impl_deref(struct_name: &str) -> Vec<syn::ItemImpl> {
-    let struct_ident = syn::Ident::new(struct_name, Span::call_site());
-    let deref_impl = syn::parse_quote! {
-        impl<'a> core::ops::Deref for #struct_ident<'a> {
-            type Target = Mutations;
-            fn deref(&self) -> &Self::Target {
-                &*self.mutations
-            }
-        }
-    };
-    let deref_mut_impl = syn::parse_quote! {
-        impl<'a> core::ops::DerefMut for #struct_ident<'a> {
-            fn deref_mut(&mut self) -> &mut Self::Target {
-                &mut *self.mutations
-            }
-        }
-    };
-    vec![deref_impl, deref_mut_impl]
-}
-
-/// Recursively traverse the given keyed var and create a builder struct for each tuple.
-fn mutations_builders_from_node(tree: &KeyedVarTree, n: NodeIx) -> Vec<syn::Item> {
-    let mut items = vec![];
-    match tree[n].ty {
-        KeyedTypeABI::Map {
-            ty_from,
-            ty_to,
-            key: _,
-        } => {
-            items.extend(map::builder_items(tree, n, ty_from, ty_to));
-        }
-        KeyedTypeABI::Tuple(_fields) => {
-            items.extend(tuple::builder_items(tree, n));
-        }
-        _ => (),
-    }
-    items
-}
-
-/// Recursively traverse the given keyed vars and create a builder structs and
-/// impls for each tuple.
-fn mutations_builders_from_keyed_vars(vars: &[KeyedVarABI]) -> Vec<syn::Item> {
-    let mut items = vec![];
-    let tree = pint_abi_visit::tree_from_keyed_vars(vars);
-    tree.dfs(|n| {
-        items.extend(mutations_builders_from_node(&tree, n));
-    });
-    items
-}
-
-/// A `Mutations` builder method for a map field.
-fn mutation_method_for_map(name: &str, map_nesting: &[Nesting]) -> syn::ImplItemFn {
-    let struct_name = map::mutations_struct_name(map_nesting);
-    let method_ident = syn::Ident::new(name, Span::call_site());
-    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
-    let doc_str = mutation_method_doc_str(name);
-    syn::parse_quote! {
-        #[doc = #doc_str]
-        pub fn #method_ident(mut self, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
-            f(#struct_ident { mutations: &mut self });
-            self
-        }
-    }
-}
-
-/// A `Mutations` builder method for a tuple field.
-fn mutation_method_for_tuple(name: &str, nesting: &[Nesting]) -> syn::ImplItemFn {
-    let struct_name = tuple::mutations_struct_name(nesting);
-    let method_ident = syn::Ident::new(name, Span::call_site());
-    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
-    let doc_str = mutation_method_doc_str(name);
-    syn::parse_quote! {
-        #[doc = #doc_str]
-        pub fn #method_ident(mut self, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
-            f(#struct_ident { mutations: &mut self });
-            self
-        }
-    }
-}
-
-/// A `Mutations` builder method for the given keyed var.
-fn mutation_method_from_node(tree: &KeyedVarTree, n: NodeIx, name: &str) -> syn::ImplItemFn {
-    let nesting = tree.nesting(n);
-    let arg_ty = match &tree[n].ty {
-        KeyedTypeABI::Bool(_key) => SingleKeyTy::Bool,
-        KeyedTypeABI::Int(_key) => SingleKeyTy::Int,
-        KeyedTypeABI::Real(_key) => SingleKeyTy::Real,
-        KeyedTypeABI::String(_key) => SingleKeyTy::String,
-        KeyedTypeABI::B256(_key) => SingleKeyTy::B256,
-        KeyedTypeABI::Array { ty: _, size: _ } => todo!(),
-        // Tuple types take a closure.
-        KeyedTypeABI::Tuple(_) => {
-            return mutation_method_for_tuple(name, &nesting);
-        }
-        // Map types take a closure.
-        KeyedTypeABI::Map { .. } => {
-            return mutation_method_for_map(name, &nesting);
-        }
-    };
-    // A mutation builder method for a single mutation.
-    mutation_method_for_single_key(name, &arg_ty, &nesting)
-}
-
-/// All builder methods for the `Mutations builder type.
-fn mutations_methods_from_keyed_vars(vars: &[KeyedVarABI]) -> Vec<syn::ImplItemFn> {
-    let tree = tree_from_keyed_vars(vars);
-    tree.roots()
-        .iter()
-        .map(|&n| {
-            let name = field_name_from_var_name(tree[n].name.unwrap());
-            mutation_method_from_node(&tree, n, &name)
-        })
-        .collect()
-}
-
-/// The implementation for the `Mutations` builder type.
-fn impl_mutations_from_keyed_vars(vars: &[KeyedVarABI]) -> syn::ItemImpl {
-    let methods = mutations_methods_from_keyed_vars(vars);
-    syn::parse_quote! {
-        impl Mutations {
-            #(
-                #methods
-            )*
-        }
-    }
-}
-
-/// Shorthand constructor for the `Mutations` builder.
-fn mutations_fn() -> syn::ItemFn {
-    syn::parse_quote! {
-        /// Begin building a set of [`Mutations`].
-        pub fn mutations() -> Mutations {
-            Mutations::default()
-        }
-    }
-}
-
-/// The `From<Mutations>` implementation for `Vec<Mutation>`.
-fn impl_from_mutations() -> syn::ItemImpl {
-    syn::parse_quote! {
-        impl From<Mutations> for Vec<pint_abi::types::essential::solution::Mutation> {
-            fn from(m: Mutations) -> Self {
-                m.set
-            }
-        }
-    }
-}
-
 /// The `mutations` and `keys` items for the given keyed vars.
 ///
 /// This is used for both `storage` and `pub_vars` mod generation.
 fn items_from_keyed_vars(vars: &[KeyedVarABI]) -> Vec<syn::Item> {
-    let mut items: Vec<syn::Item> = vec![
-        mutations_struct().into(),
-        mutations_fn().into(),
-        impl_from_mutations().into(),
-        impl_mutations_from_keyed_vars(vars).into(),
-    ];
-    items.extend(mutations_builders_from_keyed_vars(vars));
+    let mut items = vec![];
+    items.extend(mutation::items(vars));
     items
 }
 

--- a/pint-abi-gen/src/lib.rs
+++ b/pint-abi-gen/src/lib.rs
@@ -24,7 +24,6 @@ use syn::parse_macro_input;
 mod map;
 mod tuple;
 mod vars;
-mod visit;
 
 /// The name of the root module within the predicate set produced by the compiler.
 const ROOT_MOD_NAME: &str = "";
@@ -374,7 +373,7 @@ fn mutations_builders_from_keyed_type(ty: &KeyedTypeABI) -> Vec<syn::Item> {
 /// impls for each tuple.
 fn mutations_builders_from_keyed_vars(vars: &[KeyedVarABI]) -> Vec<syn::Item> {
     let mut items = vec![];
-    visit::keyed_vars(vars, |keyed| {
+    pint_abi_visit::keyed_vars(vars, |keyed| {
         items.extend(mutations_builders_from_keyed_type(keyed.ty));
     });
     items

--- a/pint-abi-gen/src/map.rs
+++ b/pint-abi-gen/src/map.rs
@@ -1,21 +1,22 @@
 //! Items related to generating the `Map` mutations and keys builders.
 
 use crate::{
-    abi_key_doc_str, abi_key_expr, abi_key_from_keyed_type, key_str, merge_key_expr,
-    mutation_impl_deref, tuple, ty_from_pint_ty, KeyedTypeABI, SingleKeyTy,
+    abi_key_from_keyed_type, construct_key_expr, mutation_impl_deref, nesting_expr,
+    nesting_key_doc_str, nesting_ty_str, tuple, ty_from_pint_ty, KeyedTypeABI, SingleKeyTy,
 };
 use pint_abi_types::TypeABI;
+use pint_abi_visit::{KeyedVarTree, Nesting, NodeIx};
 use proc_macro2::Span;
 
 /// The name for the a map builder struct.
-pub(crate) fn mutations_struct_name(key: &pint_abi_types::Key) -> String {
-    format!("Map_{}", key_str(key))
+pub(crate) fn mutations_struct_name(nesting: &[Nesting]) -> String {
+    format!("Map_{}", nesting_ty_str(nesting))
 }
 
 /// A builder struct for a map field.
-fn mutations_struct(struct_name: &str, key: &pint_abi_types::Key) -> syn::ItemStruct {
+fn mutations_struct(struct_name: &str, nesting: &[Nesting]) -> syn::ItemStruct {
     let struct_ident = syn::Ident::new(struct_name, Span::call_site());
-    let abi_key_doc_str = abi_key_doc_str(key);
+    let abi_key_doc_str = nesting_key_doc_str(nesting);
     let doc_str = format!(
         "A mutations builder struct for the map at key `{abi_key_doc_str}`.\n\n\
         Generated solely for use within the `Mutations` builder pattern.",
@@ -30,34 +31,34 @@ fn mutations_struct(struct_name: &str, key: &pint_abi_types::Key) -> syn::ItemSt
 }
 
 /// A map mutation builder method for entries with tuple values.
-fn mutation_method_for_tuple(ty_from: &TypeABI, tup_key: &pint_abi_types::Key) -> syn::ImplItemFn {
+fn mutation_method_for_tuple(ty_from: &TypeABI, tup_nesting: &[Nesting]) -> syn::ImplItemFn {
     let key_ty = ty_from_pint_ty(ty_from);
-    let struct_name = tuple::mutations_struct_name(tup_key);
+    let struct_name = tuple::mutations_struct_name(tup_nesting);
     let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
     syn::parse_quote! {
         /// Add mutations for the tuple at the given key.
         pub fn entry(mut self, key: #key_ty, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
             let key_words: pint_abi::types::essential::Key = pint_abi::encode(&key);
-            self.keys.push(key_words);
+            self.key_elems.push(pint_abi::key::Elem::MapKey(key_words));
             f(#struct_ident { mutations: &mut self.mutations });
-            self.keys.pop();
+            self.key_elems.pop();
             self
         }
     }
 }
 
 /// A map mutation builder method for entries with nested map values.
-fn mutation_method_for_map(ty_from: &TypeABI, map_key: &pint_abi_types::Key) -> syn::ImplItemFn {
+fn mutation_method_for_map(ty_from: &TypeABI, map_nesting: &[Nesting]) -> syn::ImplItemFn {
     let key_ty = ty_from_pint_ty(ty_from);
-    let struct_name = mutations_struct_name(map_key);
+    let struct_name = mutations_struct_name(map_nesting);
     let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
     syn::parse_quote! {
         /// Add mutations for the nested map at the given key.
         pub fn entry(mut self, key: #key_ty, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
             let key_words: pint_abi::types::essential::Key = pint_abi::encode(&key);
-            self.keys.push(key_words);
+            self.key_elems.push(pint_abi::key::Elem::MapKey(key_words));
             f(#struct_ident { mutations: &mut self.mutations });
-            self.keys.pop();
+            self.key_elems.pop();
             self
         }
     }
@@ -67,13 +68,13 @@ fn mutation_method_for_map(ty_from: &TypeABI, map_key: &pint_abi_types::Key) -> 
 fn mutation_method_for_single_key(
     ty_from: &TypeABI,
     val_ty: &SingleKeyTy,
-    val_key: &pint_abi_types::Key,
+    val_nesting: &[Nesting],
 ) -> syn::ImplItemFn {
     let key_ty = ty_from_pint_ty(ty_from);
     let val_ty = val_ty.syn_ty();
-    let abi_key_expr: syn::ExprArray = abi_key_expr(val_key);
-    let merge_key_expr: syn::Expr = merge_key_expr();
-    let abi_key_doc_str = abi_key_doc_str(val_key);
+    let nesting_expr: syn::ExprArray = nesting_expr(val_nesting);
+    let construct_key_expr: syn::Expr = construct_key_expr();
+    let abi_key_doc_str = nesting_key_doc_str(val_nesting);
     let merge_doc_str = format!(
         "The given key will be encoded as words and merged into the full key `{abi_key_doc_str}`."
     );
@@ -85,11 +86,11 @@ fn mutation_method_for_single_key(
             use pint_abi::types::essential::{solution::Mutation, Key, Value};
             // Add the map key to the stack.
             let key: Key = pint_abi::encode(&key);
-            self.keys.push(key);
+            self.key_elems.push(pint_abi::key::Elem::MapKey(key));
 
             // Merge the key stack with the ABI key.
-            let abi_key = #abi_key_expr;
-            let key: Key = #merge_key_expr;
+            let nesting = #nesting_expr;
+            let key: Key = #construct_key_expr;
             let value: Value = pint_abi::encode(&val);
 
             // Add the mutation to the set.
@@ -98,39 +99,52 @@ fn mutation_method_for_single_key(
             self.set.push(mutation);
 
             // Pop the entry key from the stack.
-            self.keys.pop();
+            self.key_elems.pop();
             self
         }
     }
 }
 
 /// A map method for inserting mutations for an entry associated with a given key.
-fn map_mutation_method(ty_from: &TypeABI, ty_to: &KeyedTypeABI) -> syn::ImplItemFn {
-    let (val_ty, key) = match ty_to {
-        KeyedTypeABI::Bool(key) => (SingleKeyTy::Bool, key),
-        KeyedTypeABI::Int(key) => (SingleKeyTy::Int, key),
-        KeyedTypeABI::Real(key) => (SingleKeyTy::Real, key),
+fn map_mutation_method(
+    tree: &KeyedVarTree,
+    entry: NodeIx,
+    ty_from: &TypeABI,
+    ty_to: &KeyedTypeABI,
+) -> syn::ImplItemFn {
+    let nesting = tree.nesting(entry);
+    let val_ty = match ty_to {
+        KeyedTypeABI::Bool(_key) => SingleKeyTy::Bool,
+        KeyedTypeABI::Int(_key) => SingleKeyTy::Int,
+        KeyedTypeABI::Real(_key) => SingleKeyTy::Real,
         KeyedTypeABI::Array { ty, size: _ } => {
             let _key = abi_key_from_keyed_type(ty);
             todo!()
         }
-        KeyedTypeABI::String(key) => (SingleKeyTy::String, key),
-        KeyedTypeABI::B256(key) => (SingleKeyTy::B256, key),
-        KeyedTypeABI::Tuple(fields) => {
-            let key = abi_key_from_keyed_type(&fields[0].ty);
-            return mutation_method_for_tuple(ty_from, key);
+        KeyedTypeABI::String(_key) => SingleKeyTy::String,
+        KeyedTypeABI::B256(_key) => SingleKeyTy::B256,
+        KeyedTypeABI::Tuple(_) => {
+            return mutation_method_for_tuple(ty_from, &nesting);
         }
-        KeyedTypeABI::Map { key, .. } => {
-            return mutation_method_for_map(ty_from, key);
+        KeyedTypeABI::Map { .. } => {
+            return mutation_method_for_map(ty_from, &nesting);
         }
     };
-    mutation_method_for_single_key(ty_from, &val_ty, key)
+    mutation_method_for_single_key(ty_from, &val_ty, &nesting)
 }
 
 /// The implementation for the map mutations builder of the given name.
-fn mutations_impl(struct_name: &str, ty_from: &TypeABI, ty_to: &KeyedTypeABI) -> syn::ItemImpl {
+fn mutations_impl(
+    tree: &KeyedVarTree,
+    map: NodeIx,
+    struct_name: &str,
+    ty_from: &TypeABI,
+    ty_to: &KeyedTypeABI,
+) -> syn::ItemImpl {
     let struct_ident = syn::Ident::new(struct_name, Span::call_site());
-    let method = map_mutation_method(ty_from, ty_to);
+    // The node for a map entry is its only child.
+    let entry = tree.children(map)[0];
+    let method = map_mutation_method(tree, entry, ty_from, ty_to);
     syn::parse_quote! {
         impl<'a> #struct_ident<'a> {
             #method
@@ -140,14 +154,16 @@ fn mutations_impl(struct_name: &str, ty_from: &TypeABI, ty_to: &KeyedTypeABI) ->
 
 /// Map builder types and impls for a given keyed map type.
 pub(crate) fn builder_items(
+    tree: &KeyedVarTree,
+    map: NodeIx,
     ty_from: &TypeABI,
     ty_to: &KeyedTypeABI,
-    key: &pint_abi_types::Key,
 ) -> Vec<syn::Item> {
-    let struct_name = mutations_struct_name(key);
+    let nesting = tree.nesting(map);
+    let struct_name = mutations_struct_name(&nesting);
     let mut items = vec![];
-    items.push(mutations_struct(&struct_name, key).into());
-    items.push(mutations_impl(&struct_name, ty_from, ty_to).into());
+    items.push(mutations_struct(&struct_name, &nesting).into());
+    items.push(mutations_impl(tree, map, &struct_name, ty_from, ty_to).into());
     items.extend(
         mutation_impl_deref(&struct_name)
             .into_iter()

--- a/pint-abi-gen/src/map.rs
+++ b/pint-abi-gen/src/map.rs
@@ -1,8 +1,8 @@
 //! Items related to generating the `Map` mutations and keys builders.
 
 use crate::{
-    abi_key_from_keyed_type, construct_key_expr, mutation_impl_deref, nesting_expr,
-    nesting_key_doc_str, nesting_ty_str, tuple, ty_from_pint_ty, KeyedTypeABI, SingleKeyTy,
+    abi_key_from_keyed_type, construct_key_expr, mutation, nesting_expr, nesting_key_doc_str,
+    nesting_ty_str, tuple, ty_from_pint_ty, KeyedTypeABI, SingleKeyTy,
 };
 use pint_abi_types::TypeABI;
 use pint_abi_visit::{KeyedVarTree, Nesting, NodeIx};
@@ -165,7 +165,7 @@ pub(crate) fn builder_items(
     items.push(mutations_struct(&struct_name, &nesting).into());
     items.push(mutations_impl(tree, map, &struct_name, ty_from, ty_to).into());
     items.extend(
-        mutation_impl_deref(&struct_name)
+        mutation::impl_deref_for_nested(&struct_name)
             .into_iter()
             .map(syn::Item::from),
     );

--- a/pint-abi-gen/src/map.rs
+++ b/pint-abi-gen/src/map.rs
@@ -1,0 +1,157 @@
+//! Items related to generating the `Map` mutations and keys builders.
+
+use crate::{
+    abi_key_doc_str, abi_key_expr, abi_key_from_keyed_type, key_str, merge_key_expr,
+    mutation_impl_deref, tuple, ty_from_pint_ty, KeyedTypeABI, SingleKeyTy,
+};
+use pint_abi_types::TypeABI;
+use proc_macro2::Span;
+
+/// The name for the a map builder struct.
+pub(crate) fn mutations_struct_name(key: &pint_abi_types::Key) -> String {
+    format!("Map_{}", key_str(key))
+}
+
+/// A builder struct for a map field.
+fn mutations_struct(struct_name: &str, key: &pint_abi_types::Key) -> syn::ItemStruct {
+    let struct_ident = syn::Ident::new(struct_name, Span::call_site());
+    let abi_key_doc_str = abi_key_doc_str(key);
+    let doc_str = format!(
+        "A mutations builder struct for the map at key `{abi_key_doc_str}`.\n\n\
+        Generated solely for use within the `Mutations` builder pattern.",
+    );
+    syn::parse_quote! {
+        #[doc = #doc_str]
+        #[allow(non_camel_case_types)]
+        pub struct #struct_ident<'a> {
+            mutations: &'a mut Mutations,
+        }
+    }
+}
+
+/// A map mutation builder method for entries with tuple values.
+fn mutation_method_for_tuple(ty_from: &TypeABI, tup_key: &pint_abi_types::Key) -> syn::ImplItemFn {
+    let key_ty = ty_from_pint_ty(ty_from);
+    let struct_name = tuple::mutations_struct_name(tup_key);
+    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
+    syn::parse_quote! {
+        /// Add mutations for the tuple at the given key.
+        pub fn entry(mut self, key: #key_ty, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
+            let key_words: pint_abi::types::essential::Key = pint_abi::encode(&key);
+            self.keys.push(key_words);
+            f(#struct_ident { mutations: &mut self.mutations });
+            self.keys.pop();
+            self
+        }
+    }
+}
+
+/// A map mutation builder method for entries with nested map values.
+fn mutation_method_for_map(ty_from: &TypeABI, map_key: &pint_abi_types::Key) -> syn::ImplItemFn {
+    let key_ty = ty_from_pint_ty(ty_from);
+    let struct_name = mutations_struct_name(map_key);
+    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
+    syn::parse_quote! {
+        /// Add mutations for the nested map at the given key.
+        pub fn entry(mut self, key: #key_ty, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
+            let key_words: pint_abi::types::essential::Key = pint_abi::encode(&key);
+            self.keys.push(key_words);
+            f(#struct_ident { mutations: &mut self.mutations });
+            self.keys.pop();
+            self
+        }
+    }
+}
+
+/// A map mutation builder method for an entry with a single-key value.
+fn mutation_method_for_single_key(
+    ty_from: &TypeABI,
+    val_ty: &SingleKeyTy,
+    val_key: &pint_abi_types::Key,
+) -> syn::ImplItemFn {
+    let key_ty = ty_from_pint_ty(ty_from);
+    let val_ty = val_ty.syn_ty();
+    let abi_key_expr: syn::ExprArray = abi_key_expr(val_key);
+    let merge_key_expr: syn::Expr = merge_key_expr();
+    let abi_key_doc_str = abi_key_doc_str(val_key);
+    let merge_doc_str = format!(
+        "The given key will be encoded as words and merged into the full key `{abi_key_doc_str}`."
+    );
+    syn::parse_quote! {
+        /// Add a mutation for the entry at the given key.
+        ///
+        #[doc = #merge_doc_str]
+        pub fn entry(mut self, key: #key_ty, val: #val_ty) -> Self {
+            use pint_abi::types::essential::{solution::Mutation, Key, Value};
+            // Add the map key to the stack.
+            let key: Key = pint_abi::encode(&key);
+            self.keys.push(key);
+
+            // Merge the key stack with the ABI key.
+            let abi_key = #abi_key_expr;
+            let key: Key = #merge_key_expr;
+            let value: Value = pint_abi::encode(&val);
+
+            // Add the mutation to the set.
+            self.set.retain(|m: &Mutation| &m.key != &key);
+            let mutation = Mutation { key, value };
+            self.set.push(mutation);
+
+            // Pop the entry key from the stack.
+            self.keys.pop();
+            self
+        }
+    }
+}
+
+/// A map method for inserting mutations for an entry associated with a given key.
+fn map_mutation_method(ty_from: &TypeABI, ty_to: &KeyedTypeABI) -> syn::ImplItemFn {
+    let (val_ty, key) = match ty_to {
+        KeyedTypeABI::Bool(key) => (SingleKeyTy::Bool, key),
+        KeyedTypeABI::Int(key) => (SingleKeyTy::Int, key),
+        KeyedTypeABI::Real(key) => (SingleKeyTy::Real, key),
+        KeyedTypeABI::Array { ty, size: _ } => {
+            let _key = abi_key_from_keyed_type(ty);
+            todo!()
+        }
+        KeyedTypeABI::String(key) => (SingleKeyTy::String, key),
+        KeyedTypeABI::B256(key) => (SingleKeyTy::B256, key),
+        KeyedTypeABI::Tuple(fields) => {
+            let key = abi_key_from_keyed_type(&fields[0].ty);
+            return mutation_method_for_tuple(ty_from, key);
+        }
+        KeyedTypeABI::Map { key, .. } => {
+            return mutation_method_for_map(ty_from, key);
+        }
+    };
+    mutation_method_for_single_key(ty_from, &val_ty, key)
+}
+
+/// The implementation for the map mutations builder of the given name.
+fn mutations_impl(struct_name: &str, ty_from: &TypeABI, ty_to: &KeyedTypeABI) -> syn::ItemImpl {
+    let struct_ident = syn::Ident::new(struct_name, Span::call_site());
+    let method = map_mutation_method(ty_from, ty_to);
+    syn::parse_quote! {
+        impl<'a> #struct_ident<'a> {
+            #method
+        }
+    }
+}
+
+/// Map builder types and impls for a given keyed map type.
+pub(crate) fn builder_items(
+    ty_from: &TypeABI,
+    ty_to: &KeyedTypeABI,
+    key: &pint_abi_types::Key,
+) -> Vec<syn::Item> {
+    let struct_name = mutations_struct_name(key);
+    let mut items = vec![];
+    items.push(mutations_struct(&struct_name, key).into());
+    items.push(mutations_impl(&struct_name, ty_from, ty_to).into());
+    items.extend(
+        mutation_impl_deref(&struct_name)
+            .into_iter()
+            .map(syn::Item::from),
+    );
+    items
+}

--- a/pint-abi-gen/src/mutation.rs
+++ b/pint-abi-gen/src/mutation.rs
@@ -1,0 +1,226 @@
+//! Items for the `Mutations` type generated for `storage` and `pub vars`,
+//! aimed at making it easier to build a set of
+//! [`Mutation`][essential_types::solution::Mutation]s for a solution.
+
+use crate::{map, tuple, SingleKeyTy};
+use pint_abi_types::{KeyedTypeABI, KeyedVarABI};
+use pint_abi_visit::{KeyedVarTree, Nesting, NodeIx};
+use proc_macro2::Span;
+
+/// Recursively traverse the given keyed var and create a builder struct and
+/// associated impl for each tuple, map and array.
+fn nested_builder_items_from_node(tree: &KeyedVarTree, n: NodeIx) -> Vec<syn::Item> {
+    let mut items = vec![];
+    match tree[n].ty {
+        KeyedTypeABI::Map {
+            ty_from,
+            ty_to,
+            key: _,
+        } => {
+            items.extend(map::builder_items(tree, n, ty_from, ty_to));
+        }
+        KeyedTypeABI::Tuple(_fields) => {
+            items.extend(tuple::builder_items(tree, n));
+        }
+        _ => (),
+    }
+    items
+}
+
+/// Recursively traverse the given keyed vars and create a builder structs and
+/// impls for each tuple, map and array.
+fn nested_builder_items_from_keyed_vars(vars: &[KeyedVarABI]) -> Vec<syn::Item> {
+    let mut items = vec![];
+    let tree = KeyedVarTree::from_keyed_vars(vars);
+    tree.dfs(|n| {
+        items.extend(nested_builder_items_from_node(&tree, n));
+    });
+    items
+}
+
+/// The `From<Mutations>` implementation for `Vec<Mutation>`.
+fn impl_from_mutations_for_vec() -> syn::ItemImpl {
+    syn::parse_quote! {
+        impl From<Mutations> for Vec<pint_abi::types::essential::solution::Mutation> {
+            fn from(m: Mutations) -> Self {
+                m.set
+            }
+        }
+    }
+}
+
+/// The docstring for a `Mutations` method.
+fn method_doc_str(name: &str) -> String {
+    format!(
+        "Add a mutation for the `{name}` field into the set.\n\n\
+        Relaces any existing mutation for the given key.",
+    )
+}
+
+/// A `Mutations` builder method for a map field.
+fn method_for_map(name: &str, map_nesting: &[Nesting]) -> syn::ImplItemFn {
+    let struct_name = map::mutations_struct_name(map_nesting);
+    let method_ident = syn::Ident::new(name, Span::call_site());
+    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
+    let doc_str = method_doc_str(name);
+    syn::parse_quote! {
+        #[doc = #doc_str]
+        pub fn #method_ident(mut self, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
+            f(#struct_ident { mutations: &mut self });
+            self
+        }
+    }
+}
+
+/// A `Mutations` builder method for a tuple field.
+fn method_for_tuple(name: &str, nesting: &[Nesting]) -> syn::ImplItemFn {
+    let struct_name = tuple::mutations_struct_name(nesting);
+    let method_ident = syn::Ident::new(name, Span::call_site());
+    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
+    let doc_str = method_doc_str(name);
+    syn::parse_quote! {
+        #[doc = #doc_str]
+        pub fn #method_ident(mut self, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
+            f(#struct_ident { mutations: &mut self });
+            self
+        }
+    }
+}
+
+/// A `Mutations` builder method for a single-key mutation.
+fn method_for_single_key(name: &str, arg_ty: &SingleKeyTy, nesting: &[Nesting]) -> syn::ImplItemFn {
+    let method_ident = syn::Ident::new(name, Span::call_site());
+    let nesting_key_doc_str = crate::nesting_key_doc_str(nesting);
+    let doc_str = format!("{}\n\nKey: `{nesting_key_doc_str}`", method_doc_str(name));
+    let arg_ty = arg_ty.syn_ty();
+    let nesting_expr: syn::ExprArray = crate::nesting_expr(nesting);
+    let construct_key_expr: syn::Expr = crate::construct_key_expr();
+    syn::parse_quote! {
+        #[doc = #doc_str]
+        pub fn #method_ident(mut self, val: #arg_ty) -> Self {
+            use pint_abi::types::essential::{Key, Value, solution::Mutation};
+            let nesting = #nesting_expr;
+            let key: Key = #construct_key_expr;
+            let value: Value = pint_abi::encode(&val);
+            self.set.retain(|m: &Mutation| &m.key != &key);
+            let mutation = Mutation { key, value };
+            self.set.push(mutation);
+            self
+        }
+    }
+}
+
+/// A builder method that takes an argument of the keyed type at the given index
+/// within the tree.
+///
+/// This is shared between both the `Mutations` and `Tuple_*` implementations.
+pub(crate) fn method_from_node(tree: &KeyedVarTree, n: NodeIx, name: &str) -> syn::ImplItemFn {
+    let nesting = tree.nesting(n);
+    let arg_ty = match &tree[n].ty {
+        KeyedTypeABI::Bool(_key) => SingleKeyTy::Bool,
+        KeyedTypeABI::Int(_key) => SingleKeyTy::Int,
+        KeyedTypeABI::Real(_key) => SingleKeyTy::Real,
+        KeyedTypeABI::String(_key) => SingleKeyTy::String,
+        KeyedTypeABI::B256(_key) => SingleKeyTy::B256,
+        KeyedTypeABI::Array { ty: _, size: _ } => todo!(),
+        KeyedTypeABI::Tuple(_) => {
+            return method_for_tuple(name, &nesting);
+        }
+        KeyedTypeABI::Map { .. } => {
+            return method_for_map(name, &nesting);
+        }
+    };
+    // A mutation builder method for a single mutation.
+    method_for_single_key(name, &arg_ty, &nesting)
+}
+
+/// All builder methods for the `Mutations` builder type.
+fn impl_mutations_methods(vars: &[KeyedVarABI]) -> Vec<syn::ImplItemFn> {
+    let tree = KeyedVarTree::from_keyed_vars(vars);
+    tree.roots()
+        .iter()
+        .map(|&n| {
+            let name = crate::field_name_from_var_name(tree[n].name.unwrap());
+            method_from_node(&tree, n, &name)
+        })
+        .collect()
+}
+
+/// The implementation for the `Mutations` builder type.
+fn impl_mutations(vars: &[KeyedVarABI]) -> syn::ItemImpl {
+    let methods = impl_mutations_methods(vars);
+    syn::parse_quote! {
+        impl Mutations {
+            #(
+                #methods
+            )*
+        }
+    }
+}
+
+/// Shorthand constructor for the `Mutations` builder.
+fn mutations_fn() -> syn::ItemFn {
+    syn::parse_quote! {
+        /// Begin building a set of [`Mutations`].
+        pub fn mutations() -> Mutations {
+            Mutations::default()
+        }
+    }
+}
+
+/// The builder struct for mutations.
+fn mutations_struct() -> syn::ItemStruct {
+    syn::parse_quote! {
+        /// A builder for a set of mutations.
+        ///
+        /// Can be constructed via the [`mutations`] function.
+        #[derive(Debug, Default)]
+        pub struct Mutations {
+            /// The set of mutations being built.
+            set: Vec<pint_abi::types::essential::solution::Mutation>,
+            /// The stack of key elements that need to be merged with the
+            /// `&[Nesting]` derived by the `KeyedTypeABI` traversal.
+            ///
+            /// For example, when a map's `entry` method is called, the provided
+            /// key is pushed to this stack. Upon completion of the `entry`
+            /// method, the key is popped.
+            key_elems: Vec<pint_abi::key::Elem>,
+        }
+    }
+}
+
+/// A `DerefMut<Target = Mutations>` impl for a nested builder struct.
+///
+/// This allows for easily accessing the `Mutations` type's `key_elems` and
+/// `set` fields within impls for the nested tuple, map and array builder types.
+pub(crate) fn impl_deref_for_nested(struct_name: &str) -> Vec<syn::ItemImpl> {
+    let struct_ident = syn::Ident::new(struct_name, Span::call_site());
+    let deref_impl = syn::parse_quote! {
+        impl<'a> core::ops::Deref for #struct_ident<'a> {
+            type Target = Mutations;
+            fn deref(&self) -> &Self::Target {
+                &*self.mutations
+            }
+        }
+    };
+    let deref_mut_impl = syn::parse_quote! {
+        impl<'a> core::ops::DerefMut for #struct_ident<'a> {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut *self.mutations
+            }
+        }
+    };
+    vec![deref_impl, deref_mut_impl]
+}
+
+/// All items for the `Mutations` type, nested mutations builder types and their impls.
+pub(crate) fn items(vars: &[KeyedVarABI]) -> Vec<syn::Item> {
+    let mut items = vec![
+        mutations_struct().into(),
+        mutations_fn().into(),
+        impl_mutations(vars).into(),
+        impl_from_mutations_for_vec().into(),
+    ];
+    items.extend(nested_builder_items_from_keyed_vars(vars));
+    items
+}

--- a/pint-abi-gen/src/tuple.rs
+++ b/pint-abi-gen/src/tuple.rs
@@ -1,0 +1,72 @@
+//! Items related to generating the `Map` mutations and keys builders.
+
+use crate::{abi_key_doc_str, key_str, mutation_impl_deref, mutation_method_from_keyed_var};
+use pint_abi_types::KeyedTupleField;
+use proc_macro2::Span;
+
+/// The name for the a tuple builder struct.
+pub(crate) fn mutations_struct_name(key: &pint_abi_types::Key) -> String {
+    format!("Tuple_{}", key_str(key))
+}
+
+/// A builder struct for a tuple field.
+fn mutations_struct(struct_name: &str, key: &pint_abi_types::Key) -> syn::ItemStruct {
+    let struct_ident = syn::Ident::new(struct_name, Span::call_site());
+    let abi_key_doc_str = abi_key_doc_str(key);
+    let doc_str = format!(
+        "A mutations builder struct for the tuple at key `{abi_key_doc_str}`.\n\n\
+        Generated solely for use within the `Mutations` builder pattern.",
+    );
+    syn::parse_quote! {
+        #[doc = #doc_str]
+        #[allow(non_camel_case_types)]
+        pub struct #struct_ident<'a> {
+            mutations: &'a mut Mutations,
+        }
+    }
+}
+
+/// A mutation buidler method for a tuple struct.
+fn mutation_method(ix: usize, field: &KeyedTupleField) -> syn::ImplItemFn {
+    let name = field.name.clone().unwrap_or_else(|| format!("_{ix}"));
+    mutation_method_from_keyed_var(&name, &field.ty)
+}
+
+/// The mutation builder methods for a tuple struct.
+fn mutations_methods(fields: &[KeyedTupleField]) -> Vec<syn::ImplItemFn> {
+    fields
+        .iter()
+        .enumerate()
+        .map(|(ix, field)| mutation_method(ix, field))
+        .collect()
+}
+
+/// The implementation for the tuple mutations builder of the given name.
+fn mutations_impl(struct_name: &str, fields: &[KeyedTupleField]) -> syn::ItemImpl {
+    let struct_ident = syn::Ident::new(struct_name, Span::call_site());
+    let methods = mutations_methods(fields);
+    syn::parse_quote! {
+        impl<'a> #struct_ident<'a> {
+            #(
+                #methods
+            )*
+        }
+    }
+}
+
+/// Tuple builder types and impls for a given keyed tuple type.
+pub(crate) fn builder_items(
+    fields: &[KeyedTupleField],
+    key: &pint_abi_types::Key,
+) -> Vec<syn::Item> {
+    let struct_name = mutations_struct_name(key);
+    let mut items = vec![];
+    items.push(mutations_struct(&struct_name, key).into());
+    items.push(mutations_impl(&struct_name, fields).into());
+    items.extend(
+        mutation_impl_deref(&struct_name)
+            .into_iter()
+            .map(syn::Item::from),
+    );
+    items
+}

--- a/pint-abi-gen/src/tuple.rs
+++ b/pint-abi-gen/src/tuple.rs
@@ -1,6 +1,6 @@
 //! Items related to generating the `Map` mutations and keys builders.
 
-use crate::{mutation_impl_deref, mutation_method_from_node, nesting_key_doc_str, nesting_ty_str};
+use crate::{mutation, nesting_key_doc_str, nesting_ty_str};
 use pint_abi_visit::{KeyedVarTree, Nesting, NodeIx};
 use proc_macro2::Span;
 
@@ -36,7 +36,7 @@ fn mutation_method(tree: &KeyedVarTree, field: NodeIx) -> syn::ImplItemFn {
         };
         format!("_{ix}")
     });
-    mutation_method_from_node(tree, field, &name)
+    mutation::method_from_node(tree, field, &name)
 }
 
 /// The mutation builder methods for a tuple struct.
@@ -69,7 +69,7 @@ pub(crate) fn builder_items(tree: &KeyedVarTree, tuple: NodeIx) -> Vec<syn::Item
     items.push(mutations_struct(&nesting, &struct_name).into());
     items.push(mutations_impl(tree, tuple, &struct_name).into());
     items.extend(
-        mutation_impl_deref(&struct_name)
+        mutation::impl_deref_for_nested(&struct_name)
             .into_iter()
             .map(syn::Item::from),
     );

--- a/pint-abi-gen/src/vars.rs
+++ b/pint-abi-gen/src/vars.rs
@@ -1,0 +1,79 @@
+//! Struct and impls for the decision variables `Vars` type.
+
+use crate::{field_name_from_var_name, ty_from_pint_ty};
+use pint_abi_types::VarABI;
+use proc_macro2::Span;
+
+/// A named field for each of the decision variables.
+fn fields(vars: &[VarABI]) -> Vec<syn::Field> {
+    vars.iter()
+        .map(|var| {
+            let name = field_name_from_var_name(&var.name);
+            let ident = syn::Ident::new(&name, Span::call_site());
+            let ty = ty_from_pint_ty(&var.ty);
+            syn::parse_quote! {
+                pub #ident: #ty
+            }
+        })
+        .collect()
+}
+
+/// Generate a struct for an predicate's decision variables.
+fn struct_decl(vars: &[VarABI]) -> syn::ItemStruct {
+    let fields = fields(vars);
+    syn::parse_quote! {
+        /// The predicate's decision variables.
+        #[derive(Clone, Debug)]
+        pub struct Vars {
+            #(
+                #fields
+            ),*
+        }
+    }
+}
+
+/// Generate a `Encode` implementation for a `Vars` type.
+fn impl_encode(vars: &[VarABI]) -> syn::ItemImpl {
+    let field_idents = vars
+        .iter()
+        .map(|var| field_name_from_var_name(&var.name))
+        .map(|name| syn::Ident::new(&name, Span::call_site()));
+    syn::parse_quote! {
+        impl pint_abi::Encode for Vars {
+            fn encode<W: pint_abi::Write>(&self, w: &mut W) -> Result<(), W::Error> {
+                #(
+                    pint_abi::Encode::encode(&self.#field_idents, w).expect("cannot fail");
+                )*
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Generate a `From<Vars>` implementation for converting `Vars` to `Vec<Value>`.
+fn impl_(vars: &[VarABI]) -> syn::ItemImpl {
+    let field_idents = vars
+        .iter()
+        .map(|var| field_name_from_var_name(&var.name))
+        .map(|name| syn::Ident::new(&name, Span::call_site()));
+    syn::parse_quote! {
+        impl From<Vars> for Vec<pint_abi::types::essential::Value> {
+            fn from(vars: Vars) -> Self {
+                let mut values: Vec<pint_abi::types::essential::Value> = vec![];
+                #(
+                    values.push(pint_abi::encode(&vars.#field_idents));
+                )*
+                values
+            }
+        }
+    }
+}
+
+/// The struct decl and impls for the decision variables `Vars` type.
+pub(crate) fn items(vars: &[VarABI]) -> Vec<syn::Item> {
+    vec![
+        struct_decl(vars).into(),
+        impl_encode(vars).into(),
+        impl_(vars).into(),
+    ]
+}

--- a/pint-abi-gen/src/visit.rs
+++ b/pint-abi-gen/src/visit.rs
@@ -1,0 +1,123 @@
+//! General visitors for traversing vars, keyed vars.
+
+use essential_types::Word;
+use pint_abi_types::{KeyedTypeABI, KeyedVarABI, TypeABI};
+
+/// Represents how a pub var or storage field's key is constructed.
+pub(crate) enum KeyElem {
+    /// A fixed word element, e.g. for a top-level field or tuple field.
+    Word(Word),
+    /// A key element provided by a map key. If the map key size is fixed, `len
+    MapKey {
+        /// The type of the key.
+        ty: TypeABI,
+    },
+    /// A key element provided by an array index.
+    ArrayIx {
+        /// The total length of the array if it's known.
+        array_len: Option<usize>,
+    },
+}
+
+/// Represents a visited keyed var or nested type alongside it's key.
+pub(crate) struct Keyed<'a> {
+    /// The name of the var if it is named.
+    pub(crate) name: Option<&'a str>,
+    /// The type of the var.
+    pub(crate) ty: &'a KeyedTypeABI,
+    /// A description of the key construction.
+    pub(crate) key: &'a [KeyElem],
+}
+
+/// The number of words used to represent an ABI type in key form.
+fn abi_ty_size(ty: &TypeABI) -> usize {
+    match ty {
+        TypeABI::Bool | TypeABI::Int | TypeABI::Real => 1,
+        TypeABI::B256 => 4,
+        TypeABI::String => panic!("unknown size of type `string`"),
+        TypeABI::Tuple(fields) => fields.iter().map(|f| abi_ty_size(&f.ty)).sum(),
+        TypeABI::Array { ty, size } => {
+            abi_ty_size(ty) * usize::try_from(*size).expect("size out of range")
+        }
+    }
+}
+
+/// Construct an ABI key in the form output by the compiler given a sequence of key elements.
+fn abi_key_from_elems(elems: &[KeyElem]) -> Vec<Option<usize>> {
+    let mut key = vec![];
+    for elem in elems {
+        match elem {
+            KeyElem::Word(w) => key.push(Some(usize::try_from(*w).expect("out of range"))),
+            KeyElem::MapKey { ty } => key.extend(vec![None; abi_ty_size(ty)]),
+            KeyElem::ArrayIx { .. } => key.push(None),
+        }
+    }
+    key
+}
+
+/// Visit all keyed vars in `storage` or `pub_vars` alongside their associated key.
+pub(crate) fn keyed_vars(vars: &[KeyedVarABI], mut visit: impl FnMut(Keyed)) {
+    /// Call `visit` with the given `var` and `key`, then recurse nested vars.
+    fn visit_and_recurse(
+        name: Option<&str>,
+        ty: &KeyedTypeABI,
+        key_elems: &mut Vec<KeyElem>,
+        visit: &mut impl FnMut(Keyed),
+    ) {
+        visit(Keyed {
+            name,
+            ty,
+            key: &key_elems[..],
+        });
+        match ty {
+            KeyedTypeABI::Bool(_key)
+            | KeyedTypeABI::Int(_key)
+            | KeyedTypeABI::Real(_key)
+            | KeyedTypeABI::String(_key)
+            | KeyedTypeABI::B256(_key) => {}
+
+            // Recurse for nested tuple types.
+            KeyedTypeABI::Tuple(fields) => {
+                for (i, field) in fields.iter().enumerate() {
+                    let ix_word = Word::try_from(i).expect("index out of range");
+                    let key_elem = KeyElem::Word(ix_word);
+                    let name = field.name.as_deref();
+                    key_elems.push(key_elem);
+                    visit_and_recurse(name, &field.ty, key_elems, visit);
+                    key_elems.pop();
+                }
+            }
+
+            // Recurse for nested array element types.
+            KeyedTypeABI::Array { ty, size } => {
+                let array_len = Some(usize::try_from(*size).expect("size out of range"));
+                let key_elem = KeyElem::ArrayIx { array_len };
+                key_elems.push(key_elem);
+                visit_and_recurse(None, &ty, key_elems, visit);
+                key_elems.pop();
+            }
+
+            // Recurse for nested map element types.
+            KeyedTypeABI::Map {
+                ty_from,
+                ty_to,
+                key: _,
+            } => {
+                let ty = ty_from.clone();
+                let key_elem = KeyElem::MapKey { ty };
+                key_elems.push(key_elem);
+                visit_and_recurse(None, &ty_to, key_elems, visit);
+                key_elems.pop();
+            }
+        }
+    }
+
+    let mut key = vec![];
+    for (i, var) in vars.iter().enumerate() {
+        let ix_word = Word::try_from(i).expect("index out of range");
+        let key_elem = KeyElem::Word(ix_word);
+        key.push(key_elem);
+        visit_and_recurse(Some(var.name.as_str()), &var.ty, &mut key, &mut visit);
+        key.pop();
+    }
+}

--- a/pint-abi-visit/Cargo.toml
+++ b/pint-abi-visit/Cargo.toml
@@ -10,4 +10,5 @@ repository.workspace = true
 
 [dependencies]
 essential-types = { workspace = true }
+petgraph = { workspace = true }
 pint-abi-types = { workspace = true }

--- a/pint-abi-visit/Cargo.toml
+++ b/pint-abi-visit/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "pint-abi-visit"
+version = "0.0.1"
+description = "Items to assist in traversing the Pint ABI types."
+edition.workspace = true
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+essential-types = { workspace = true }
+pint-abi-types = { workspace = true }

--- a/pint-abi-visit/src/lib.rs
+++ b/pint-abi-visit/src/lib.rs
@@ -2,9 +2,50 @@
 //!
 //! This assists in traversal of the `storage` and `pub_vars` sections of the Pint ABI.
 
+use essential_types::Word;
+use petgraph::visit::EdgeRef;
 use pint_abi_types::{KeyedTupleField, KeyedTypeABI, KeyedVarABI, TypeABI};
 
-/// A stack of `Nesting` describes how a [`Keyed`] var type is nested.
+/// The [`KeyedTypeABI`] rose tree represented as a graph.
+///
+/// By constructing the tree as an indexable type, it allows more flexibility
+/// around inspecting both parent and child nodes during traversal.
+///
+/// This is particularly useful for generating both types and implementations
+/// (that may refer to child nodes) when visiting a single node.
+pub struct KeyedVarTree<'a> {
+    graph: KeyedVarGraph<'a>,
+    /// The root keyed var variables.
+    roots: Vec<NodeIx>,
+}
+
+/// The graph structure used to represent the [`KeyedVarTree`] internally.
+///
+/// The edge `a -> b` implies that `b` is nested within `a`.
+pub type KeyedVarGraph<'a> = petgraph::Graph<Keyed<'a>, (), petgraph::Directed, TreeIx>;
+
+/// Index size used for the graph.
+type TreeIx = usize;
+/// An index into a `KeyedVarGraph` edge.
+pub type EdgeIx = petgraph::graph::EdgeIndex<TreeIx>;
+/// An index into a `KeyedVarGraph` node.
+pub type NodeIx = petgraph::graph::NodeIndex<TreeIx>;
+
+/// Represents a visited keyed var along with the context in which its nested.
+pub struct Keyed<'a> {
+    /// The name of the var if it is named.
+    pub name: Option<&'a str>,
+    /// The type of the var.
+    pub ty: &'a KeyedTypeABI,
+    /// Describes how the keyed var is nested within `storage` or `pub vars`.
+    ///
+    /// The first element is always a `Var` representing the keyed var's
+    /// top-level index within `storage` or pub vars.
+    pub nesting: Nesting,
+}
+
+/// Describes how a [`KeyedTypeABI`] is nested within the tree.
+#[derive(Clone, Debug)]
 pub enum Nesting {
     /// A top-level storage field of pub var.
     ///
@@ -25,8 +66,8 @@ pub enum Nesting {
     },
     /// An entry within a map.
     MapEntry {
-        /// The type of the key.
-        key_ty: TypeABI,
+        /// The number of words used to represent the key.
+        key_size: usize,
     },
     /// An element within an array.
     ArrayElem {
@@ -35,63 +76,70 @@ pub enum Nesting {
     },
 }
 
-/// Represents a visited keyed var or nested type alongside it's key.
-pub struct Keyed<'a> {
-    /// The name of the var if it is named.
-    pub name: Option<&'a str>,
-    /// The type of the var.
-    pub ty: &'a KeyedTypeABI,
-    /// Describes how the keyed var is nested within `storage` or `pub vars`.
-    ///
-    /// The first element is always a `Var` representing the keyed var's
-    /// top-level index within `storage` or pub vars.
-    pub nesting: &'a [Nesting],
+impl<'a> core::ops::Deref for KeyedVarTree<'a> {
+    type Target = KeyedVarGraph<'a>;
+    fn deref(&self) -> &Self::Target {
+        &self.graph
+    }
 }
 
-/// Visit all keyed vars in `storage` or `pub_vars` alongside their associated key.
-pub fn keyed_vars(vars: &[KeyedVarABI], mut visit: impl FnMut(Keyed)) {
-    /// Call `visit` with the given `var` and `key`, then recurse nested vars.
-    fn visit_and_recurse(
-        name: Option<&str>,
-        ty: &KeyedTypeABI,
-        nesting: &mut Vec<Nesting>,
-        visit: &mut impl FnMut(Keyed),
-    ) {
-        visit(Keyed {
-            name,
-            ty,
-            nesting: &nesting[..],
-        });
+/// Construct a [`KeyedVarTree`] from a `storage` or `puv_vars` ABI representation.
+pub fn tree_from_keyed_vars(vars: &[KeyedVarABI]) -> KeyedVarTree {
+    /// Add the child nodes of the given node `a` with type `ty`, by traversing
+    /// the `KeyedTypeABI`.
+    fn add_children<'a>(graph: &mut KeyedVarGraph<'a>, a: NodeIx, ty: &'a KeyedTypeABI) {
         match ty {
             KeyedTypeABI::Bool(_key)
             | KeyedTypeABI::Int(_key)
             | KeyedTypeABI::Real(_key)
             | KeyedTypeABI::String(_key)
-            | KeyedTypeABI::B256(_key) => {}
+            | KeyedTypeABI::B256(_key) => {
+                // TODO: Remove this whole block once keys have been removed.
+                // This is just a sanity check to make sure that this traversal
+                // is deriving the same keys as the compiler is generating.
+                let nesting = nesting(graph, a);
+                let partial_key: Vec<_> = partial_key_from_nesting(&nesting)
+                    .into_iter()
+                    .map(|opt| opt.map(|w| usize::try_from(w).unwrap()))
+                    .collect();
+                assert_eq!(
+                    &partial_key[..],
+                    _key,
+                    "Key mismatch between `pint-abi-visit` and compiler generated ABI key. \
+                    Please report this to the pint repo as it indicates a key construction \
+                    discrepency between the compiler and the Pint ABI gen code.",
+                );
+            }
 
             // Recurse for nested tuple types.
             KeyedTypeABI::Tuple(fields) => {
                 for (ix, field) in fields.iter().enumerate() {
                     let flat_ix = {
-                        let start_flat_ix = match nesting.last() {
-                            Some(Nesting::TupleField { flat_ix, .. }) => *flat_ix,
+                        let start_flat_ix = match &graph[a].nesting {
+                            Nesting::TupleField { flat_ix, .. } => *flat_ix,
                             _ => 0,
                         };
                         flattened_ix(fields, ix, start_flat_ix)
                     };
                     let name = field.name.as_deref();
-                    nesting.push(Nesting::TupleField { ix, flat_ix });
-                    visit_and_recurse(name, &field.ty, nesting, visit);
-                    nesting.pop();
+                    let ty = &field.ty;
+                    let nesting = Nesting::TupleField { ix, flat_ix };
+                    let node = Keyed { ty, name, nesting };
+                    let b = graph.add_node(node);
+                    graph.add_edge(a, b, ());
+                    add_children(graph, b, &field.ty);
                 }
             }
 
             // Recurse for nested array element types.
             KeyedTypeABI::Array { ty, size } => {
                 let array_len = usize::try_from(*size).expect("size out of range");
-                nesting.push(Nesting::ArrayElem { array_len });
-                visit_and_recurse(None, &ty, nesting, visit);
-                nesting.pop();
+                let nesting = Nesting::ArrayElem { array_len };
+                let name = None;
+                let node = Keyed { ty, name, nesting };
+                let b = graph.add_node(node);
+                graph.add_edge(a, b, ());
+                add_children(graph, b, ty);
             }
 
             // Recurse for nested map element types.
@@ -100,21 +148,98 @@ pub fn keyed_vars(vars: &[KeyedVarABI], mut visit: impl FnMut(Keyed)) {
                 ty_to,
                 key: _,
             } => {
-                let key_ty = ty_from.clone();
-                nesting.push(Nesting::MapEntry { key_ty });
-                visit_and_recurse(None, &ty_to, nesting, visit);
-                nesting.pop();
+                let key_size = ty_size(ty_from);
+                let nesting = Nesting::MapEntry { key_size };
+                let name = None;
+                let ty = ty_to;
+                let node = Keyed { ty, name, nesting };
+                let b = graph.add_node(node);
+                graph.add_edge(a, b, ());
+                add_children(graph, b, ty_to);
             }
         }
     }
 
-    let mut key = vec![];
+    // Construct the graph.
+    let mut graph = KeyedVarGraph::default();
+
+    // Add each root and its children.
+    let mut roots = vec![];
     for (ix, var) in vars.iter().enumerate() {
-        let key_elem = Nesting::Var { ix };
-        key.push(key_elem);
-        visit_and_recurse(Some(var.name.as_str()), &var.ty, &mut key, &mut visit);
-        key.pop();
+        let ty = &var.ty;
+        let name = Some(var.name.as_str());
+        let nesting = Nesting::Var { ix };
+        let node = Keyed { ty, name, nesting };
+        let n = graph.add_node(node);
+        add_children(&mut graph, n, &var.ty);
+        roots.push(n);
     }
+
+    KeyedVarTree { graph, roots }
+}
+
+impl<'a> KeyedVarTree<'a> {
+    /// Visit all keyed types within the tree in depth-first order.
+    pub fn dfs(&self, mut visit: impl FnMut(NodeIx)) {
+        for &root in &self.roots {
+            let mut dfs = petgraph::visit::Dfs::new(&self.graph, root);
+            while let Some(n) = dfs.next(&self.graph) {
+                visit(n);
+            }
+        }
+    }
+
+    /// Return the node index of the parent node within the tree.
+    pub fn parent(&self, n: NodeIx) -> Option<NodeIx> {
+        parent(&self.graph, n)
+    }
+
+    /// An iterator yielding the immediate children of this node.
+    pub fn children(&self, n: NodeIx) -> Vec<NodeIx> {
+        let mut children: Vec<_> = self
+            .graph
+            .edges_directed(n, petgraph::Direction::Outgoing)
+            .map(|e| e.target())
+            .collect();
+        // The graph edges iterator yields edges in the reverse order of which they were added.
+        // Reverse the order here to ensure children are yielded in the more intuitive order.
+        children.reverse();
+        children
+    }
+
+    /// Returns a description of how the node at `n` is nested from the root.
+    pub fn nesting(&self, n: NodeIx) -> Vec<Nesting> {
+        nesting(&self.graph, n)
+    }
+
+    /// The root nodes, representing the top-level storage or pub vars.
+    pub fn roots(&self) -> &[NodeIx] {
+        &self.roots
+    }
+}
+
+/// Return the node index of the parent node within the graph.
+fn parent(graph: &KeyedVarGraph, n: NodeIx) -> Option<NodeIx> {
+    graph
+        .edges_directed(n, petgraph::Direction::Incoming)
+        .next()
+        .map(|e| e.source())
+}
+
+/// Return the full nesting of the node at the given index.
+fn nesting(graph: &KeyedVarGraph, mut n: NodeIx) -> Vec<Nesting> {
+    // First, collect the path to the root.
+    let mut path = vec![n];
+    while let Some(p) = parent(graph, n) {
+        path.push(p);
+        n = p;
+    }
+    // Collect the nestings starting from the root.
+    let mut nestings = vec![];
+    while let Some(n) = path.pop() {
+        nestings.push(graph[n].nesting.clone());
+    }
+    nestings
 }
 
 /// Determine the flattened index of the tuple field at the given field index
@@ -134,6 +259,42 @@ fn flattened_ix(fields: &[KeyedTupleField], field_ix: usize, start_flat_ix: usiz
             .sum()
     }
     start_flat_ix + count_flattened_leaf_fields(&fields[0..field_ix])
+}
+
+/// Given a type nesting, returns a partial key to the nested value.
+///
+/// Words that are provided dynamically (via map key or array index) are
+/// represented with `None`.
+pub fn partial_key_from_nesting(nesting: &[Nesting]) -> Vec<Option<Word>> {
+    let mut opts = vec![];
+    let mut iter = nesting.iter().peekable();
+    while let Some(nesting) = iter.next() {
+        match nesting {
+            Nesting::Var { ix } => {
+                let word = Word::try_from(*ix).expect("out of Word range");
+                opts.push(Some(word));
+            }
+            Nesting::TupleField { ix: _, flat_ix } => {
+                let mut deepest_flat_ix = *flat_ix;
+                while let Some(Nesting::TupleField { ix: _, flat_ix }) = iter.peek() {
+                    deepest_flat_ix = *flat_ix;
+                    iter.next();
+                }
+                let word = Word::try_from(deepest_flat_ix).expect("out of Word range");
+                opts.push(Some(word));
+            }
+            Nesting::MapEntry { key_size } => {
+                opts.resize(opts.len() + key_size, None);
+            }
+            Nesting::ArrayElem { array_len: _ } => {
+                while let Some(Nesting::ArrayElem { array_len: _ }) = iter.peek() {
+                    iter.next();
+                }
+                opts.push(None);
+            }
+        }
+    }
+    opts
 }
 
 /// The number of words used to represent an ABI type in key form.

--- a/pint-abi/Cargo.toml
+++ b/pint-abi/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 essential-types = { workspace = true }
 pint-abi-gen = { workspace = true, optional = true }
 pint-abi-types = { workspace = true }
+pint-abi-visit = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 

--- a/pint-abi/src/key.rs
+++ b/pint-abi/src/key.rs
@@ -1,5 +1,7 @@
 //! Items related to key construction.
 
+#[doc(inline)]
+pub use crate::visit::partial_key_from_nesting as partial_from_nesting;
 use crate::{
     types::essential::{Key, Word},
     visit::Nesting,

--- a/pint-abi/src/key.rs
+++ b/pint-abi/src/key.rs
@@ -1,0 +1,88 @@
+//! Items related to key construction.
+
+use crate::{
+    types::essential::{Key, Word},
+    visit::Nesting,
+};
+
+/// Represents a dynamically provided key element (e.g. map key or array index).
+///
+/// ABI-generated `Mutations` builders maintain a stack of key `Elem`s as users
+/// enter nested map/array entries.
+#[derive(Debug)]
+pub enum Elem {
+    /// A key element is provided by a map key.
+    MapKey(Key),
+    /// A key element is provided by an array index.
+    ArrayIx(usize),
+}
+
+/// Construct a full key for a given nested type and the associated stack of
+/// dynamically provided key elements.
+pub fn construct(nesting: &[Nesting], key_elems: &[Elem]) -> Key {
+    let mut words = vec![];
+    let mut nesting_iter = nesting.iter().peekable();
+    let mut key_elems_iter = key_elems.iter();
+    while let Some(nesting) = nesting_iter.next() {
+        match nesting {
+            // Push the storage/pub-var index directly. This is always the first nesting.
+            Nesting::Var { ix } => {
+                let word = Word::try_from(*ix).expect("out of Word range");
+                words.push(word);
+            }
+
+            // If we've encountered a tuple field, flatten any further tuple
+            // nestings and use the deepest `flat_ix` which represents the
+            // flattened index of the tuple field.
+            Nesting::TupleField { ix: _, flat_ix } => {
+                let mut deepest_flat_ix = *flat_ix;
+                while let Some(Nesting::TupleField { ix: _, flat_ix }) = nesting_iter.peek() {
+                    deepest_flat_ix = *flat_ix;
+                    nesting_iter.next();
+                }
+                let word = Word::try_from(deepest_flat_ix).expect("out of Word range");
+                words.push(word);
+            }
+
+            // If this is a map entry, take the map key from the key elements.
+            Nesting::MapEntry { .. } => {
+                let key = expect_map_key(key_elems_iter.next());
+                words.extend(key);
+            }
+
+            // If this is an array element, determine the key from the array
+            // index. For directly nested arrays, detemine the flattened index
+            // by multiplying the index by the inner array lenghts.
+            Nesting::ArrayElem { array_len: _ } => {
+                let mut ix = expect_array_ix(key_elems_iter.next());
+                while let Some(Nesting::ArrayElem { array_len }) = nesting_iter.peek() {
+                    ix = ix * array_len + expect_array_ix(key_elems_iter.next());
+                    nesting_iter.next();
+                }
+                let word = Word::try_from(ix).expect("out of Word range");
+                words.push(word);
+            }
+        }
+    }
+    words
+}
+
+fn expect_array_ix(elem: Option<&Elem>) -> usize {
+    match elem {
+        Some(Elem::ArrayIx(ix)) => *ix,
+        elem => unreachable!(
+            "invalid key `Elem` provided by ABI-generated code: \
+            expected array index, found {elem:?}",
+        ),
+    }
+}
+
+fn expect_map_key(elem: Option<&Elem>) -> Key {
+    match elem {
+        Some(Elem::MapKey(key)) => key.clone(),
+        elem => unreachable!(
+            "invalid key `Elem` provided by ABI-generated code: \
+            expected map key, found {elem:?}",
+        ),
+    }
+}

--- a/pint-abi/src/lib.rs
+++ b/pint-abi/src/lib.rs
@@ -25,6 +25,7 @@ use types::{
 };
 
 mod encode;
+pub mod key;
 mod write;
 
 /// Both Pint ABI and Essential protocol types.

--- a/pint-abi/src/lib.rs
+++ b/pint-abi/src/lib.rs
@@ -115,30 +115,3 @@ pub fn find_predicate<'a>(
 fn predicate_name_matches(abi_pred_name: &str, pred_name: &str) -> bool {
     abi_pred_name == pred_name || abi_pred_name.split("::").nth(1) == Some(pred_name)
 }
-
-/// This function is used by `pint-abi-gen`-generated mutation builder methods in
-/// order to merge a stack of map entry keys into a the full ABI-compatible key.
-///
-/// ## Example
-///
-/// Given the following:
-///
-/// - `abi_key`: `[Some(1), None, Some(3), None, None, Some(6)]`
-/// - `key_stack`: `[[2], [4, 5]]`
-///
-/// Produces an expression with the value `[1, 2, 3, 4, 5, 6]`.
-#[doc(hidden)]
-pub fn __merge_key(
-    abi_key: &[Option<types::essential::Word>],
-    key_stack: &[types::essential::Key],
-) -> types::essential::Key {
-    let mut key_stack_words = key_stack.iter().flatten().copied();
-    abi_key
-        .iter()
-        .copied()
-        .map(|opt: Option<types::essential::Word>| {
-            opt.or_else(|| key_stack_words.next())
-                .expect("failed to merge key: missing words for key")
-        })
-        .collect()
-}

--- a/pint-abi/src/lib.rs
+++ b/pint-abi/src/lib.rs
@@ -9,6 +9,8 @@ pub use pint_abi_gen::from_file as gen_from_file;
 #[cfg(feature = "pint-abi-gen")]
 #[doc(inline)]
 pub use pint_abi_gen::from_str as gen_from_str;
+#[doc(inline)]
+pub use pint_abi_visit as visit;
 
 #[doc(inline)]
 pub use encode::Encode;


### PR DESCRIPTION
This is a pretty major refactor of the `pint-abi-gen` crate ahead of landing support for arrays, `keys()` builders, and more.

## `pint-abi-visit`

The major addition is the `pint-abi-visit` crate which provides some helpers for traversing the `[KeyedVarABI]`s of `storage` and `pub vars`. For context, `pint-abi-gen` does a traversal of the nested ABI types in order to generate types and impls for array, map and tuple types that allow for building mutations in a type-safe manner.

When visiting each `KeyedTypeABI`, `struct` and `impl` generation require a lot more context than just the current type being visited. E.g. in order to be able to produce a unique struct name, provide docstrings, and produce a key construction expression, we need to know the full "`Nesting`" of the type. In order to be able to produce and `impl` with builder methods for nested types, we also need to be able to iterate over the nested "child" nodes within the currently visited type.

To assist with all of this, we now first flatten the `[KeyedVarABI]`s into an indexable tree structure. Then rather than recursively traversing through the `KeyedTypeABI`s, we instead traverse the tree using indices. The indexed approach gives us the freedom to traverse the parent or child nodes as necessary when generating items, which wasn't really possible with the recursive `KeyedTypeABI` traversal.

## Key Construction

This PR also changes the way that keys are constructed for mutations. **We no longer use the keys specified in the ABI JSON**, and instead use the current context of the `[KeyedVarABI]` traversal to determine the keys programmatically. cc @mohammadfawaz 

Currently, we just use the keys from the leaf types (e.g. `Bool`, `Int`, etc) to verify that the key construction matches the compiler's key construction, but this can probably be removed along with the keys from the ABI in general. This does increase the risk of running into a discrepancy between the ABI-gen key construction and the `pintc` key construction slightly, but hopefully these cases should be caught by the `pint-abi-gen-tests` before they can be released.

Ideally we would share the approach to key construction between `pintc` and `pint-abi-gen` somehow, but I haven't dug into the compiler enough to know how feasible this is.

Closes #762.
Related #752.
Dependency of #761.