### PR TITLE
fix: handle macro declared vars

### DIFF
--- a/pint-abi-gen-tests/test-pkgs/simple/src/contract.pnt
+++ b/pint-abi-gen-tests/test-pkgs/simple/src/contract.pnt
@@ -23,6 +23,8 @@ predicate Foo {
     pub var t1: int;
     pub var t2: b256;
 
+    @bar();
+
     // Here we write a bunch of arbitrary constraints to check encoding/decoding
     // of the different types etc.
 
@@ -64,5 +66,12 @@ predicate Foo {
 
 macro @foo() {
     var v5: int;
+    var v6: { int, int };
     constraint v5 == 42;
+    constraint v6.0 == 43 && v6.1 == 44;
+}
+
+macro @bar() {
+    pub var t3: int;
+    constraint t3 == 45;
 }

--- a/pint-abi-gen-tests/test-pkgs/simple/src/contract.pnt
+++ b/pint-abi-gen-tests/test-pkgs/simple/src/contract.pnt
@@ -17,6 +17,8 @@ predicate Foo {
     var v3: { int, int };
     var v4: { int, int, { int, int } };
 
+    @foo();
+
     pub var t0: bool;
     pub var t1: int;
     pub var t2: b256;
@@ -58,4 +60,9 @@ predicate Foo {
     constraint my_map1_key1' == { 1111, { 0x2222222222222222222222222222222222222222222222222222222222222222, 3333 } };
     constraint my_nested_map0_key1_2' == 1234;
     constraint my_nested_map1_key2_3' == { 69, { 0x1111111100000000111111110000000011111111000000001111111100000000, 96 } };
+}
+
+macro @foo() {
+    var v5: int;
+    constraint v5 == 42;
 }

--- a/pint-abi-gen-tests/tests/simple.rs
+++ b/pint-abi-gen-tests/tests/simple.rs
@@ -43,6 +43,7 @@ async fn test_solution_foo() {
         v3: [30, 31].into(),
         v4: (40, 41, (420, 421)),
         anon_0_v5: 42,
+        anon_0_v6: (43, 44),
     };
 
     // Public decision variables (i.e. transient data).
@@ -50,6 +51,7 @@ async fn test_solution_foo() {
         .t0(false)
         .t1(11)
         .t2([0x2222222222222222; 4])
+        .anon_1_t3(45)
         .into();
 
     // State mutations.

--- a/pint-abi-gen-tests/tests/simple.rs
+++ b/pint-abi-gen-tests/tests/simple.rs
@@ -42,6 +42,7 @@ async fn test_solution_foo() {
         v2: [0x1111111100000000; 4],
         v3: [30, 31].into(),
         v4: (40, 41, (420, 421)),
+        anon_0_v5: 42,
     };
 
     // Public decision variables (i.e. transient data).

--- a/pint-abi-gen/src/lib.rs
+++ b/pint-abi-gen/src/lib.rs
@@ -710,8 +710,8 @@ fn mutation_method_from_keyed_var(name: &str, ty: &KeyedTypeABI) -> syn::ImplIte
 fn mutations_methods_from_keyed_vars(vars: &[KeyedVarABI]) -> Vec<syn::ImplItemFn> {
     vars.iter()
         .map(|var| {
-            let name = strip_colons_prefix(&var.name);
-            mutation_method_from_keyed_var(name, &var.ty)
+            let name = field_name_from_var_name(&var.name);
+            mutation_method_from_keyed_var(&name, &var.ty)
         })
         .collect()
 }

--- a/pint-abi-gen/src/lib.rs
+++ b/pint-abi-gen/src/lib.rs
@@ -73,16 +73,16 @@ fn ty_from_pint_ty(ty: &TypeABI) -> syn::Type {
 /// Names for fields are emitted by pint with a `::` prefix.
 /// This function checks for the `::` prefix and strips it if it exists.
 fn strip_colons_prefix(name: &str) -> &str {
-    let mut split = name.split("::");
-    let first = split.next();
-    split.next().or(first).expect("name had unexpected format")
+    name.trim_start_matches("::")
 }
 
-/// Var names have the `::` prefix, and sometimes have `.` separators for
-/// flattened tuple fields. We strip the `::` prefix, and replace all `.`
+/// Var names have the `::` prefix, and sometimes have `.` or `@` or `::` separators for
+/// flattened tuple fields. We strip the `::` prefix, and replace all `.` or `@` or `::`
 /// occurrences with `_`.
 fn field_name_from_var_name(name: &str) -> String {
-    strip_colons_prefix(name).replace('.', "_")
+    strip_colons_prefix(name)
+        .replace(['.', '@'], "_")
+        .replace("::", "_")
 }
 
 /// A named field for each of the decision variables.


### PR DESCRIPTION
If you declare a var inside a macro it gets a name like `::anon@0::v5`. This handles that by also replacing `@` and non-prefix `::` with `_`.

Maybe don't merge until @mitchmindtree has checked this