### PR TITLE
Move `exprs` from `Predicate` into `Contract`.

### DIFF
--- a/pintc/src/expr/evaluate.rs
+++ b/pintc/src/expr/evaluate.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{CompileError, Error, ErrorEmitted, Handler},
     expr::{BinaryOp as BinOp, Expr, Immediate as Imm, TupleAccess, UnaryOp},
-    predicate::{ExprKey, Predicate},
+    predicate::{Contract, ExprKey, Predicate},
     span::{empty_span, Spanned},
     types::{EnumDecl, Path},
 };
@@ -27,7 +27,7 @@ impl Evaluator {
         }
     }
 
-    pub(crate) fn contains_path(&mut self, path: &Path) -> bool {
+    pub(crate) fn contains_path(&self, path: &Path) -> bool {
         self.scope_values.contains_key(path)
     }
 
@@ -60,16 +60,18 @@ impl Evaluator {
         &self,
         expr_key: &ExprKey,
         handler: &Handler,
-        pred: &Predicate,
+        contract: &Contract,
+        pred_name: &str,
     ) -> Result<Imm, ErrorEmitted> {
-        self.evaluate(expr_key.get(pred), handler, pred)
+        self.evaluate(expr_key.get(contract), handler, contract, pred_name)
     }
 
     pub(crate) fn evaluate(
         &self,
         expr: &Expr,
         handler: &Handler,
-        pred: &Predicate,
+        contract: &Contract,
+        pred_name: &str,
     ) -> Result<Imm, ErrorEmitted> {
         match expr {
             Expr::Immediate { value, .. } => Ok(value.clone()),
@@ -77,7 +79,7 @@ impl Evaluator {
             Expr::Array { elements, .. } => {
                 let imm_elements = elements
                     .iter()
-                    .map(|el_key| self.evaluate_key(el_key, handler, pred))
+                    .map(|el_key| self.evaluate_key(el_key, handler, contract, pred_name))
                     .collect::<Result<_, _>>()?;
 
                 Ok(Imm::Array(imm_elements))
@@ -87,7 +89,7 @@ impl Evaluator {
                 let imm_fields = fields
                     .iter()
                     .map(|(name, fld_key)| {
-                        self.evaluate_key(fld_key, handler, pred)
+                        self.evaluate_key(fld_key, handler, contract, pred_name)
                             .map(|fld_imm| (name.clone(), fld_imm))
                     })
                     .collect::<Result<_, _>>()?;
@@ -111,7 +113,7 @@ impl Evaluator {
                 }),
 
             Expr::UnaryOp { op, expr, .. } => {
-                let expr = self.evaluate_key(expr, handler, pred)?;
+                let expr = self.evaluate_key(expr, handler, contract, pred_name)?;
 
                 match (expr, op) {
                     (Imm::Real(expr), UnaryOp::Neg) => Ok(Imm::Real(-expr)),
@@ -127,8 +129,8 @@ impl Evaluator {
             }
 
             Expr::BinaryOp { op, lhs, rhs, .. } => {
-                let lhs = self.evaluate_key(lhs, handler, pred)?;
-                let rhs = self.evaluate_key(rhs, handler, pred)?;
+                let lhs = self.evaluate_key(lhs, handler, contract, pred_name)?;
+                let rhs = self.evaluate_key(rhs, handler, contract, pred_name)?;
 
                 match (lhs, rhs) {
                     (Imm::Real(lhs), Imm::Real(rhs)) => match op {
@@ -228,10 +230,10 @@ impl Evaluator {
 
             Expr::Index { expr, index, span } => {
                 // If the expr is an array...
-                let ary = self.evaluate_key(expr, handler, pred)?;
+                let ary = self.evaluate_key(expr, handler, contract, pred_name)?;
                 if let Imm::Array(elements) = ary {
                     // And the index is an int...
-                    let idx = self.evaluate_key(index, handler, pred)?;
+                    let idx = self.evaluate_key(index, handler, contract, pred_name)?;
                     if let Imm::Int(n) = idx {
                         // And it's not out of bounds...
                         elements.get(n as usize).cloned().ok_or_else(|| {
@@ -247,7 +249,7 @@ impl Evaluator {
                 } else {
                     Err(handler.emit_err(Error::Compile {
                         error: CompileError::CannotIndexIntoValue {
-                            span: expr.get(pred).span().clone(),
+                            span: expr.get(contract).span().clone(),
                             index_span: span.clone(),
                         },
                     }))
@@ -256,7 +258,9 @@ impl Evaluator {
 
             Expr::TupleFieldAccess { tuple, field, span } => {
                 // If the expr is a tuple...
-                let tup = self.evaluate_key(tuple, handler, pred)?;
+                let pred = contract.preds.get(pred_name).unwrap();
+
+                let tup = self.evaluate_key(tuple, handler, contract, pred_name)?;
                 if let Imm::Tuple(fields) = tup {
                     // And the field can be found...
                     match field {
@@ -271,14 +275,14 @@ impl Evaluator {
                     }
                     .cloned()
                     .ok_or_else(|| {
-                        let mut tuple_ty = tuple.get_ty(pred).clone();
+                        let mut tuple_ty = tuple.get_ty(contract).clone();
                         if tuple_ty.is_unknown() {
                             tuple_ty = Imm::Tuple(fields).get_ty(Some(span));
                         }
                         handler.emit_err(Error::Compile {
                             error: CompileError::InvalidTupleAccessor {
                                 accessor: field.to_string(),
-                                tuple_type: pred.with_pred(tuple_ty).to_string(),
+                                tuple_type: pred.with_pred(contract, tuple_ty).to_string(),
                                 span: span.clone(),
                             },
                         })
@@ -286,7 +290,9 @@ impl Evaluator {
                 } else {
                     Err(handler.emit_err(Error::Compile {
                         error: CompileError::TupleAccessNonTuple {
-                            non_tuple_type: pred.with_pred(tuple.get_ty(pred)).to_string(),
+                            non_tuple_type: pred
+                                .with_pred(contract, tuple.get_ty(contract))
+                                .to_string(),
                             span: span.clone(),
                         },
                     }))
@@ -299,20 +305,27 @@ impl Evaluator {
                 else_expr,
                 span,
             } => {
-                let cond = self.evaluate_key(condition, handler, pred)?;
+                let cond = self.evaluate_key(condition, handler, contract, pred_name)?;
                 if let Imm::Bool(b) = cond {
-                    self.evaluate_key(if b { then_expr } else { else_expr }, handler, pred)
+                    self.evaluate_key(
+                        if b { then_expr } else { else_expr },
+                        handler,
+                        contract,
+                        pred_name,
+                    )
                 } else {
-                    let mut cond_ty = condition.get_ty(pred).clone();
+                    let mut cond_ty = condition.get_ty(contract).clone();
                     if cond_ty.is_unknown() {
-                        if let Expr::Immediate { value, .. } = condition.get(pred) {
+                        if let Expr::Immediate { value, .. } = condition.get(contract) {
                             cond_ty = value.get_ty(Some(span));
                         }
                     }
 
+                    let pred = contract.preds.get(pred_name).unwrap();
+
                     Err(handler.emit_err(Error::Compile {
                         error: CompileError::NonBoolConditional {
-                            ty: pred.with_pred(cond_ty).to_string(),
+                            ty: pred.with_pred(contract, cond_ty).to_string(),
                             conditional: "select expression".to_owned(),
                             span: span.clone(),
                         },
@@ -322,14 +335,16 @@ impl Evaluator {
 
             Expr::Cast { value, ty, span } => {
                 let cast_error = |imm: Imm| -> Result<Imm, ErrorEmitted> {
-                    let mut value_ty = value.get_ty(pred).clone();
+                    let mut value_ty = value.get_ty(contract).clone();
                     if value_ty.is_unknown() {
                         value_ty = imm.get_ty(Some(span));
                     }
 
+                    let pred = contract.preds.get(pred_name).unwrap();
+
                     Err(handler.emit_err(Error::Compile {
                         error: CompileError::BadCastFrom {
-                            ty: pred.with_pred(value_ty).to_string(),
+                            ty: pred.with_pred(contract, value_ty).to_string(),
                             span: span.clone(),
                         },
                     }))
@@ -337,7 +352,7 @@ impl Evaluator {
 
                 // All casts are either redundant (e.g., bool as bool) or are to ints, except int
                 // as real.  They'll be rejected by the type checker if not.
-                let imm = self.evaluate_key(value, handler, pred)?;
+                let imm = self.evaluate_key(value, handler, contract, pred_name)?;
                 match imm {
                     Imm::Real(_) => {
                         if ty.is_real() {
@@ -420,10 +435,11 @@ impl ExprKey {
     /// and inserts it (and its sub-expressions) into `pred.exprs`.
     pub(crate) fn plug_in(
         self,
-        pred: &mut Predicate,
+        contract: &mut Contract,
+        pred_name: &str,
         values_map: &FxHashMap<Path, Imm>,
     ) -> ExprKey {
-        let expr = self.get(pred).clone();
+        let expr = self.get(contract).clone();
 
         let plugged = match expr {
             Expr::Immediate { .. } => expr,
@@ -435,9 +451,9 @@ impl ExprKey {
             } => {
                 let elements = elements
                     .iter()
-                    .map(|element| element.plug_in(pred, values_map))
+                    .map(|element| element.plug_in(contract, pred_name, values_map))
                     .collect::<Vec<_>>();
-                let range_expr = range_expr.plug_in(pred, values_map);
+                let range_expr = range_expr.plug_in(contract, pred_name, values_map);
 
                 Expr::Array {
                     elements,
@@ -449,7 +465,9 @@ impl ExprKey {
             Expr::Tuple { fields, span } => {
                 let fields = fields
                     .iter()
-                    .map(|(name, value)| (name.clone(), value.plug_in(pred, values_map)))
+                    .map(|(name, value)| {
+                        (name.clone(), value.plug_in(contract, pred_name, values_map))
+                    })
                     .collect::<Vec<_>>();
 
                 Expr::Tuple {
@@ -472,27 +490,27 @@ impl ExprKey {
             Expr::PathByKey(key, ref span) => {
                 let span = span.clone();
                 values_map
-                    .get(&key.get(pred).name)
+                    .get(&key.get(contract.preds.get(pred_name).unwrap()).name)
                     .map_or(expr, |value| Expr::Immediate {
                         value: value.clone(),
                         span,
                     })
             }
             Expr::UnaryOp { op, expr, span } => {
-                let expr = expr.plug_in(pred, values_map);
+                let expr = expr.plug_in(contract, pred_name, values_map);
 
                 Expr::UnaryOp { op, expr, span }
             }
             Expr::BinaryOp { op, lhs, rhs, span } => {
-                let lhs = lhs.plug_in(pred, values_map);
-                let rhs = rhs.plug_in(pred, values_map);
+                let lhs = lhs.plug_in(contract, pred_name, values_map);
+                let rhs = rhs.plug_in(contract, pred_name, values_map);
 
                 Expr::BinaryOp { op, lhs, rhs, span }
             }
             Expr::IntrinsicCall { name, args, span } => {
                 let args = args
                     .iter()
-                    .map(|arg| arg.plug_in(pred, values_map))
+                    .map(|arg| arg.plug_in(contract, pred_name, values_map))
                     .collect::<Vec<_>>();
 
                 Expr::IntrinsicCall { name, args, span }
@@ -503,9 +521,9 @@ impl ExprKey {
                 else_expr,
                 span,
             } => {
-                let condition = condition.plug_in(pred, values_map);
-                let then_expr = then_expr.plug_in(pred, values_map);
-                let else_expr = else_expr.plug_in(pred, values_map);
+                let condition = condition.plug_in(contract, pred_name, values_map);
+                let then_expr = then_expr.plug_in(contract, pred_name, values_map);
+                let else_expr = else_expr.plug_in(contract, pred_name, values_map);
 
                 Expr::Select {
                     condition,
@@ -515,18 +533,18 @@ impl ExprKey {
                 }
             }
             Expr::Index { expr, index, span } => {
-                let expr = expr.plug_in(pred, values_map);
-                let index = index.plug_in(pred, values_map);
+                let expr = expr.plug_in(contract, pred_name, values_map);
+                let index = index.plug_in(contract, pred_name, values_map);
 
                 Expr::Index { expr, index, span }
             }
             Expr::TupleFieldAccess { tuple, field, span } => {
-                let tuple = tuple.plug_in(pred, values_map);
+                let tuple = tuple.plug_in(contract, pred_name, values_map);
 
                 Expr::TupleFieldAccess { tuple, field, span }
             }
             Expr::Cast { value, ty, span } => {
-                let value = value.plug_in(pred, values_map);
+                let value = value.plug_in(contract, pred_name, values_map);
 
                 Expr::Cast { value, ty, span }
             }
@@ -535,8 +553,8 @@ impl ExprKey {
                 collection,
                 span,
             } => {
-                let value = value.plug_in(pred, values_map);
-                let collection = collection.plug_in(pred, values_map);
+                let value = value.plug_in(contract, pred_name, values_map);
+                let collection = collection.plug_in(contract, pred_name, values_map);
 
                 Expr::In {
                     value,
@@ -545,8 +563,8 @@ impl ExprKey {
                 }
             }
             Expr::Range { lb, ub, span } => {
-                let lb = lb.plug_in(pred, values_map);
-                let ub = ub.plug_in(pred, values_map);
+                let lb = lb.plug_in(contract, pred_name, values_map);
+                let ub = ub.plug_in(contract, pred_name, values_map);
 
                 Expr::Range { lb, ub, span }
             }
@@ -559,13 +577,18 @@ impl ExprKey {
             } => {
                 let gen_ranges = gen_ranges
                     .iter()
-                    .map(|(index, range)| (index.clone(), range.plug_in(pred, values_map)))
+                    .map(|(index, range)| {
+                        (
+                            index.clone(),
+                            range.plug_in(contract, pred_name, values_map),
+                        )
+                    })
                     .collect::<Vec<_>>();
                 let conditions = conditions
                     .iter()
-                    .map(|condition| condition.plug_in(pred, values_map))
+                    .map(|condition| condition.plug_in(contract, pred_name, values_map))
                     .collect::<Vec<_>>();
-                let body = body.plug_in(pred, values_map);
+                let body = body.plug_in(contract, pred_name, values_map);
 
                 Expr::Generator {
                     kind,
@@ -578,6 +601,8 @@ impl ExprKey {
         };
 
         // Insert the new plugged expression and its type.
-        pred.exprs.insert(plugged, self.get_ty(pred).clone())
+        contract
+            .exprs
+            .insert(plugged, self.get_ty(contract).clone())
     }
 }

--- a/pintc/src/parser/use_path.rs
+++ b/pintc/src/parser/use_path.rs
@@ -102,7 +102,7 @@ lalrpop_mod!(#[allow(unused)] pub pint_parser);
 fn gather_use_paths() {
     use crate::{
         error::Handler,
-        predicate::{Contract, Predicate},
+        predicate::{Contract, Exprs, Predicate},
     };
     use std::collections::BTreeMap;
     let parser = pint_parser::TestDelegateParser::new();
@@ -121,17 +121,19 @@ fn gather_use_paths() {
                             Contract::ROOT_PRED_NAME.to_string(),
                             Predicate::default(),
                         )]),
+                        exprs: Exprs::default(),
                         consts: fxhash::FxHashMap::default(),
+                        removed_macro_calls: slotmap::SecondaryMap::default(),
                     },
                     current_pred: &mut current_pred,
-                    macros: &mut Vec::new(),
+                    macros: &mut Vec::default(),
                     macro_calls: &mut BTreeMap::from([(
                         Contract::ROOT_PRED_NAME.to_string(),
-                        slotmap::SecondaryMap::new(),
+                        slotmap::SecondaryMap::default(),
                     )]),
                     span_from: &|_, _| span::empty_span(),
-                    use_paths: &mut Vec::new(),
-                    next_paths: &mut Vec::new(),
+                    use_paths: &mut Vec::default(),
+                    next_paths: &mut Vec::default(),
                 },
                 &Handler::default(),
                 crate::lexer::Lexer::new(src, &filepath, &[]),

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -477,7 +477,7 @@ Expr: ExprKey = {
 SelectExpr: ExprKey = {
     <l:@L> <condition:LogicalOrOp> "?" <then_expr:SelectExpr> ":" <else_expr:SelectExpr> <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::Select {
                 condition,
                 then_expr,
@@ -493,7 +493,7 @@ SelectExpr: ExprKey = {
 LogicalOrOp: ExprKey = {
     <l:@L> <lhs:LogicalOrOp> "||" <rhs:LogicalAndOp> <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::BinaryOp {
                 op: BinaryOp::LogicalOr,
                 lhs,
@@ -509,7 +509,7 @@ LogicalOrOp: ExprKey = {
 LogicalAndOp: ExprKey = {
     <l:@L> <lhs:LogicalAndOp> "&&" <rhs:Comparison> <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::BinaryOp {
                 op: BinaryOp::LogicalAnd,
                 lhs,
@@ -525,7 +525,7 @@ LogicalAndOp: ExprKey = {
 Comparison: ExprKey = {
     <l:@L> <lhs:Comparison> <op:RelOpOp> <rhs:InOp> <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::BinaryOp {
                 op,
                 lhs,
@@ -550,7 +550,7 @@ RelOpOp: BinaryOp = {
 InOp: ExprKey = {
      <l:@L> <value:InOp> "in" <collection:Additive> <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::In {
                 value,
                 collection,
@@ -561,7 +561,7 @@ InOp: ExprKey = {
      },
      <l:@L> <value:InOp> "in" <collection:Range> <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::In {
                 value,
                 collection,
@@ -576,7 +576,7 @@ InOp: ExprKey = {
 Additive: ExprKey = {
     <l:@L> <lhs:Additive> <op:AddOpOp> <rhs:Multiplicative> <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::BinaryOp {
                 op,
                 lhs,
@@ -597,7 +597,7 @@ AddOpOp: BinaryOp = {
 Multiplicative: ExprKey = {
     <l:@L> <lhs:Multiplicative> <op:MultOpOp> <rhs:AsOp> <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::BinaryOp {
                 op,
                 lhs,
@@ -619,7 +619,7 @@ MultOpOp: BinaryOp = {
 AsOp: ExprKey = {
      <l:@L> <value:AsOp> "as" <ty:Type> <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::Cast {
                 value,
                 ty: Box::new(ty),
@@ -647,7 +647,7 @@ UnaryOpOp: UnaryOp = {
 UnaryOp: ExprKey = {
     <l:@L> <op:UnaryOpOp> <expr:UnaryOp> <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::UnaryOp {
                 op,
                 expr,
@@ -662,7 +662,7 @@ UnaryOp: ExprKey = {
 PostfixOp: ExprKey = {
     <l:@L> <expr:PostfixOp> "[" <index:Expr> "]" <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::Index {
                 expr,
                 index,
@@ -679,7 +679,7 @@ PostfixOp: ExprKey = {
 
         // Recover with a malformed expression
         context
-            .current_pred()
+            .contract
             .exprs
             .insert(Expr::Error(span.clone()), Type::Unknown(span))
     },
@@ -694,7 +694,7 @@ PostfixOp: ExprKey = {
     },
     <l:@L> <expr:PostfixOp> "'" <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::UnaryOp {
                 op: UnaryOp::NextState,
                 expr,
@@ -709,7 +709,7 @@ PostfixOp: ExprKey = {
 Term: ExprKey = {
     <e:TermInner> => {
         let span = e.span().clone();
-        context.current_pred().exprs.insert(e, Type::Unknown(span))
+        context.contract.exprs.insert(e, Type::Unknown(span))
     },
     <MacroCallExpr>,
     <CondExpr>,
@@ -792,7 +792,7 @@ CondExpr: ExprKey = {
             .rev()
             .fold(else_branch, |acc, (condition, result)| {
                 let span = (context.span_from)(l, r);
-                context.current_pred().exprs.insert(
+                context.contract.exprs.insert(
                     Expr::Select {
                         condition: *condition,
                         then_expr: *result,
@@ -816,7 +816,7 @@ MacroCallExpr: ExprKey = {
             span: span.clone(),
             parent_tag: tag.flatten(),
         };
-        let call_expr_key = context.current_pred().exprs.insert(
+        let call_expr_key = context.contract.exprs.insert(
             Expr::MacroCall {
                 call: call_key,
                 span: span.clone(),
@@ -845,7 +845,7 @@ IntrinsicCallExpr: Expr = {
 ArrayExpr: Expr = {
     <l:@L> "[" <il:@L> <elements:SepList<Expr, ",">> <ir:@R> "]" <r:@R> => {
         let span = (context.span_from)(il, ir);
-        let range_expr = context.current_pred().exprs.insert(
+        let range_expr = context.contract.exprs.insert(
             Expr::Immediate {
                 value: Immediate::Int(elements.len() as i64),
                 span: span.clone(),
@@ -898,7 +898,7 @@ TupleExprField: (Option<Ident>, ExprKey) = {
 Range: ExprKey = {
     <l:@L> <lb:Additive> ".." <ub:Additive> <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::Range {
                 lb,
                 ub,
@@ -982,7 +982,7 @@ StateInit: ExprKey = {
     <call:IntrinsicCallExpr> => {
         let span = call.span().clone();
         context
-            .current_pred()
+            .contract
             .exprs
             .insert(call, Type::Unknown(span))
     },
@@ -1006,7 +1006,7 @@ StorageIndexOp: ExprKey = {
     // into a map of maps.
     <l:@L> <expr:StorageIndexOp> "[" <index:Expr> "]" <r:@R> => {
         let span = (context.span_from)(l, r);
-        context.current_pred().exprs.insert(
+        context.contract.exprs.insert(
             Expr::Index {
                 expr,
                 index,
@@ -1023,7 +1023,7 @@ StorageIndexOp: ExprKey = {
 
         // Recover with a malformed expression
         context
-            .current_pred()
+            .contract
             .exprs
             .insert(Expr::Error(span.clone()), Type::Unknown(span))
     },

--- a/pintc/src/predicate/analyse/array_check.rs
+++ b/pintc/src/predicate/analyse/array_check.rs
@@ -1,4 +1,4 @@
-use super::{Evaluator, ExprKey, Predicate};
+use super::{Contract, Evaluator, ExprKey, Predicate};
 use crate::{
     error::{CompileError, Error, ErrorEmitted, Handler},
     expr::{BinaryOp, Expr, Immediate},
@@ -7,6 +7,7 @@ use crate::{
 };
 
 fn get_array_size_from_type(
+    contract: &Contract,
     pred: &Predicate,
     handler: &Handler,
     array_ty: &Type,
@@ -14,17 +15,17 @@ fn get_array_size_from_type(
     if let Some(n) = array_ty.get_array_size() {
         Ok(n)
     } else if let Some(range_expr_key) = array_ty.get_array_range_expr() {
-        Type::get_array_size_from_range_expr(handler, range_expr_key.get(pred), pred)
+        Type::get_array_size_from_range_expr(handler, range_expr_key.get(contract), contract, pred)
     } else {
         unreachable!("array_ty MUST be an array type for this call")
     }
 }
 
 impl Predicate {
-    pub(crate) fn check_array_lengths(&self, handler: &Handler) {
-        fn check_array_type(pred: &Predicate, handler: &Handler, ty: &Type) {
+    pub(crate) fn check_array_lengths(&self, contract: &Contract, handler: &Handler) {
+        fn check_array_type(contract: &Contract, pred: &Predicate, handler: &Handler, ty: &Type) {
             if ty.is_array() {
-                if let Ok(n) = get_array_size_from_type(pred, handler, ty) {
+                if let Ok(n) = get_array_size_from_type(contract, pred, handler, ty) {
                     if n < 1 {
                         handler.emit_err(Error::Compile {
                             error: CompileError::InvalidConstArrayLength {
@@ -37,22 +38,22 @@ impl Predicate {
         }
 
         for var_key in self.vars().map(|(k, _)| k) {
-            check_array_type(self, handler, var_key.get_ty(self));
+            check_array_type(contract, self, handler, var_key.get_ty(self));
         }
 
-        for expr_key in self.exprs() {
-            check_array_type(self, handler, expr_key.get_ty(self));
+        for expr_key in contract.exprs(self) {
+            check_array_type(contract, self, handler, expr_key.get_ty(contract));
         }
     }
 
-    pub(crate) fn check_array_indexing(&self, handler: &Handler) {
+    pub(crate) fn check_array_indexing(&self, contract: &Contract, handler: &Handler) {
         // Gather all accesses into *arrays*.  `Expr::Index` is also used for maps.
-        let accesses: Vec<(Type, ExprKey)> = self
-            .exprs()
+        let accesses: Vec<(Type, ExprKey)> = contract
+            .exprs(self)
             .filter_map(|expr_key| {
-                expr_key.try_get(self).and_then(|expr| {
+                expr_key.try_get(contract).and_then(|expr| {
                     if let Expr::Index { expr, index, .. } = expr {
-                        let indexed_ty = expr.get_ty(self);
+                        let indexed_ty = expr.get_ty(contract);
                         indexed_ty.is_array().then(|| (indexed_ty.clone(), *index))
                     } else {
                         None
@@ -65,17 +66,21 @@ impl Predicate {
         for (array_ty, index_key) in accesses {
             // First, try evaluating the index value, since it must be an immediate int (or enum
             // variant, which evaluates to int).
-            let index_expr = index_key.get(self);
+            let index_expr = index_key.get(contract);
             let index_span = index_expr.span().clone();
-            if let Ok(index_value) = evaluator.evaluate(index_expr, handler, self).map_err(|_| {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::NonConstArrayIndex {
-                        span: index_span.clone(),
-                    },
+            if let Ok(index_value) = evaluator
+                .evaluate(index_expr, handler, contract, &self.name)
+                .map_err(|_| {
+                    handler.emit_err(Error::Compile {
+                        error: CompileError::NonConstArrayIndex {
+                            span: index_span.clone(),
+                        },
+                    })
                 })
-            }) {
+            {
                 // Get the size of the accessed array.
-                if let Ok(array_size) = get_array_size_from_type(self, handler, &array_ty) {
+                if let Ok(array_size) = get_array_size_from_type(contract, self, handler, &array_ty)
+                {
                     // Check for OOB.
                     if let Immediate::Int(imm_val) = index_value {
                         if imm_val < 0 || imm_val >= array_size {
@@ -93,18 +98,18 @@ impl Predicate {
         }
     }
 
-    pub(crate) fn check_array_compares(&self, handler: &Handler) {
+    pub(crate) fn check_array_compares(&self, contract: &Contract, handler: &Handler) {
         // Analyse all comparisons between arrays.  The only valid operators are Eq and NotEq.
-        for expr_key in self.exprs() {
-            if let Expr::BinaryOp { op, lhs, rhs, span } = expr_key.get(self) {
+        for expr_key in contract.exprs(self) {
+            if let Expr::BinaryOp { op, lhs, rhs, span } = expr_key.get(contract) {
                 if *op == BinaryOp::Equal || *op == BinaryOp::NotEqual {
-                    let lhs_ty = lhs.get_ty(self);
-                    let rhs_ty = rhs.get_ty(self);
+                    let lhs_ty = lhs.get_ty(contract);
+                    let rhs_ty = rhs.get_ty(contract);
 
                     if lhs_ty.is_array() && rhs_ty.is_array() {
                         // We're comparing arrays.  Now compare their sizes.
-                        let lhs_size = get_array_size_from_type(self, handler, lhs_ty);
-                        let rhs_size = get_array_size_from_type(self, handler, rhs_ty);
+                        let lhs_size = get_array_size_from_type(contract, self, handler, lhs_ty);
+                        let rhs_size = get_array_size_from_type(contract, self, handler, rhs_ty);
 
                         if let (Ok(lhs_size), Ok(rhs_size)) = (lhs_size, rhs_size) {
                             if lhs_size != rhs_size {

--- a/pintc/src/predicate/analyse/type_check.rs
+++ b/pintc/src/predicate/analyse/type_check.rs
@@ -1,5 +1,5 @@
 use super::{
-    BlockStatement, Const, ConstraintDecl, Expr, ExprKey, Ident, IfDecl, Inference,
+    BlockStatement, Const, ConstraintDecl, Contract, Expr, ExprKey, Ident, IfDecl, Inference,
     InterfaceInstance, Predicate, PredicateInstance, VarKey,
 };
 use crate::{
@@ -11,7 +11,7 @@ use crate::{
 };
 use fxhash::{FxHashMap, FxHashSet};
 
-impl Predicate {
+impl Contract {
     pub(super) fn lower_newtypes(&mut self, handler: &Handler) -> Result<(), ErrorEmitted> {
         self.check_recursive_newtypes(handler)?;
         self.lower_newtypes_in_newtypes(handler)?;
@@ -79,10 +79,13 @@ impl Predicate {
             }
         }
 
-        for NewTypeDecl { name, ty, span } in &self.new_types {
-            let mut seen_names = FxHashMap::from_iter(std::iter::once((name.name.as_str(), span)));
+        for pred in self.preds.values() {
+            for NewTypeDecl { name, ty, span } in &pred.new_types {
+                let mut seen_names =
+                    FxHashMap::from_iter(std::iter::once((name.name.as_str(), span)));
 
-            let _ = inspect_type_names(handler, &self.new_types, &mut seen_names, ty);
+                let _ = inspect_type_names(handler, &pred.new_types, &mut seen_names, ty);
+            }
         }
 
         if handler.has_errors() {
@@ -122,39 +125,41 @@ impl Predicate {
         //   type B = { A, A };
         //   // B will have `Type::Custom("A")` which need to be `Type::Alias("A", int)`
 
-        for new_type_idx in 0..self.new_types.len() {
-            // We're replacing only a single new type at a time, if found in other new-types.
-            let new_type = self.new_types[new_type_idx].clone();
+        for pred in self.preds.values_mut() {
+            for new_type_idx in 0..pred.new_types.len() {
+                // We're replacing only a single new type at a time, if found in other new-types.
+                let new_type = pred.new_types[new_type_idx].clone();
 
-            // Replace the next found custom type which needs to be replaced with a an alias.
-            // There may be multiple replacements required per iteration, so we'll visit every
-            // current new-type decl per iteration until none are updated.
-            for loop_check in 0.. {
-                let mut modified = false;
+                // Replace the next found custom type which needs to be replaced with a an alias.
+                // There may be multiple replacements required per iteration, so we'll visit every
+                // current new-type decl per iteration until none are updated.
+                for loop_check in 0.. {
+                    let mut modified = false;
 
-                for NewTypeDecl { ref mut ty, .. } in &mut self.new_types {
-                    if let Some(custom_ty) = get_custom_type_mut_ref(&new_type.name.name, ty) {
-                        *custom_ty = Type::Alias {
-                            path: new_type.name.name.clone(),
-                            ty: Box::new(new_type.ty.clone()),
-                            span: new_type.span.clone(),
-                        };
+                    for NewTypeDecl { ref mut ty, .. } in &mut pred.new_types {
+                        if let Some(custom_ty) = get_custom_type_mut_ref(&new_type.name.name, ty) {
+                            *custom_ty = Type::Alias {
+                                path: new_type.name.name.clone(),
+                                ty: Box::new(new_type.ty.clone()),
+                                span: new_type.span.clone(),
+                            };
 
-                        modified = true;
+                            modified = true;
+                        }
                     }
-                }
 
-                if !modified {
-                    break;
-                }
+                    if !modified {
+                        break;
+                    }
 
-                if loop_check > 10_000 {
-                    return Err(handler.emit_err(Error::Compile {
-                        error: CompileError::Internal {
-                            msg: "infinite loop in lower_newtypes_in_newtypes()",
-                            span: empty_span(),
-                        },
-                    }));
+                    if loop_check > 10_000 {
+                        return Err(handler.emit_err(Error::Compile {
+                            error: CompileError::Internal {
+                                msg: "infinite loop in lower_newtypes_in_newtypes()",
+                                span: empty_span(),
+                            },
+                        }));
+                    }
                 }
             }
         }
@@ -202,68 +207,40 @@ impl Predicate {
             }
         }
 
-        // Then, loop for every known var or state type, or any `as` cast expr, or any storage
-        // type, and replace any custom types which match with the type alias.
-        self.vars
-            .update_types(|_, ty| replace_custom_type(&self.new_types, ty));
+        for pred in self.preds.values_mut() {
+            // Then, loop for every known var or state type, or any `as` cast expr, or any storage
+            // type, and replace any custom types which match with the type alias.
+            pred.vars
+                .update_types(|_, ty| replace_custom_type(&pred.new_types, ty));
 
-        self.states
-            .update_types(|_, ty| replace_custom_type(&self.new_types, ty));
+            pred.states
+                .update_types(|_, ty| replace_custom_type(&pred.new_types, ty));
 
-        self.exprs.update_exprs(|_, expr| {
-            if let Expr::Cast { ty, .. } = expr {
-                replace_custom_type(&self.new_types, ty.borrow_mut());
-            }
-        });
+            self.exprs.update_exprs(|_, expr| {
+                if let Expr::Cast { ty, .. } = expr {
+                    replace_custom_type(&pred.new_types, ty.borrow_mut());
+                }
+            });
 
-        if let Some((storage_vars, _)) = &mut self.storage {
-            for StorageVar { ty, .. } in storage_vars {
-                replace_custom_type(&self.new_types, ty);
+            if let Some((storage_vars, _)) = &mut pred.storage {
+                for StorageVar { ty, .. } in storage_vars {
+                    replace_custom_type(&pred.new_types, ty);
+                }
             }
         }
     }
 
     pub(super) fn check_undefined_types(&mut self, handler: &Handler) {
-        let valid_custom_tys: FxHashSet<&String> = FxHashSet::from_iter(
-            self.enums
-                .iter()
-                .map(|ed| &ed.name.name)
-                .chain(self.new_types.iter().map(|ntd| &ntd.name.name)),
-        );
+        for pred in self.preds.values() {
+            let valid_custom_tys: FxHashSet<&String> = FxHashSet::from_iter(
+                pred.enums
+                    .iter()
+                    .map(|ed| &ed.name.name)
+                    .chain(pred.new_types.iter().map(|ntd| &ntd.name.name)),
+            );
 
-        for (state_key, _) in self.states() {
-            if let Type::Custom { path, span, .. } = state_key.get_ty(self) {
-                if !valid_custom_tys.contains(path) {
-                    handler.emit_err(Error::Compile {
-                        error: CompileError::UndefinedType { span: span.clone() },
-                    });
-                }
-            }
-        }
-
-        for (var_key, _) in self.vars() {
-            if let Type::Custom { path, span, .. } = var_key.get_ty(self) {
-                if !valid_custom_tys.contains(path) {
-                    handler.emit_err(Error::Compile {
-                        error: CompileError::UndefinedType { span: span.clone() },
-                    });
-                }
-            }
-        }
-
-        for expr in self.exprs() {
-            if let Type::Custom { path, span, .. } = expr.get_ty(self) {
-                if !valid_custom_tys.contains(path) {
-                    handler.emit_err(Error::Compile {
-                        error: CompileError::UndefinedType { span: span.clone() },
-                    });
-                }
-            }
-        }
-
-        for expr_key in self.exprs() {
-            if let Some(Expr::Cast { ty, .. }) = expr_key.try_get(self) {
-                if let Type::Custom { path, span, .. } = ty.as_ref() {
+            for (state_key, _) in pred.states() {
+                if let Type::Custom { path, span, .. } = state_key.get_ty(pred) {
                     if !valid_custom_tys.contains(path) {
                         handler.emit_err(Error::Compile {
                             error: CompileError::UndefinedType { span: span.clone() },
@@ -271,40 +248,70 @@ impl Predicate {
                     }
                 }
             }
+
+            for (var_key, _) in pred.vars() {
+                if let Type::Custom { path, span, .. } = var_key.get_ty(pred) {
+                    if !valid_custom_tys.contains(path) {
+                        handler.emit_err(Error::Compile {
+                            error: CompileError::UndefinedType { span: span.clone() },
+                        });
+                    }
+                }
+            }
+
+            for expr_key in self.exprs(pred) {
+                if let Type::Custom { path, span, .. } = expr_key.get_ty(self) {
+                    if !valid_custom_tys.contains(path) {
+                        handler.emit_err(Error::Compile {
+                            error: CompileError::UndefinedType { span: span.clone() },
+                        });
+                    }
+                }
+
+                if let Some(Expr::Cast { ty, .. }) = expr_key.try_get(self) {
+                    if let Type::Custom { path, span, .. } = ty.as_ref() {
+                        if !valid_custom_tys.contains(path) {
+                            handler.emit_err(Error::Compile {
+                                error: CompileError::UndefinedType { span: span.clone() },
+                            });
+                        }
+                    }
+                }
+            }
         }
     }
 
-    pub(super) fn check_constraint_types(&mut self, handler: &Handler) {
-        // After all expression types are inferred, then all constraint expressions must be of type bool
-        self.constraints.iter().for_each(|constraint_decl| {
-            let expr_type = constraint_decl.expr.get_ty(self);
-            if !expr_type.is_bool() {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::ConstraintExpressionTypeError {
-                        large_err: Box::new(LargeTypeError::ConstraintExpressionTypeError {
-                            expected_ty: self
-                                .with_pred(Type::Primitive {
-                                    kind: PrimitiveKind::Bool,
-                                    span: empty_span(),
-                                })
-                                .to_string(),
-                            found_ty: self.with_pred(expr_type).to_string(),
-                            span: constraint_decl.span.clone(),
-                            expected_span: Some(constraint_decl.span.clone()),
-                        }),
-                    },
-                });
-            }
-        })
+    pub(super) fn check_constraint_types(&self, handler: &Handler) {
+        for pred in self.preds.values() {
+            // After all expression types are inferred, then all constraint expressions must be of type bool
+            pred.constraints.iter().for_each(|constraint_decl| {
+                let expr_type = constraint_decl.expr.get_ty(self);
+                if !expr_type.is_bool() {
+                    handler.emit_err(Error::Compile {
+                        error: CompileError::ConstraintExpressionTypeError {
+                            large_err: Box::new(LargeTypeError::ConstraintExpressionTypeError {
+                                expected_ty: pred
+                                    .with_pred(
+                                        self,
+                                        Type::Primitive {
+                                            kind: PrimitiveKind::Bool,
+                                            span: empty_span(),
+                                        },
+                                    )
+                                    .to_string(),
+                                found_ty: pred.with_pred(self, expr_type).to_string(),
+                                span: constraint_decl.span.clone(),
+                                expected_span: Some(constraint_decl.span.clone()),
+                            }),
+                        },
+                    });
+                }
+            })
+        }
     }
 
     pub(super) fn check_storage_types(&self, handler: &Handler) {
-        if !self.is_root() {
-            // Only self check when we're the root predicate.
-            return;
-        }
-
-        if let Some((storage_vars, _)) = &self.storage {
+        if let Some((storage_vars, _)) = &self.root_pred().storage {
             for StorageVar { ty, span, .. } in storage_vars {
                 if !(ty.is_bool() || ty.is_int() || ty.is_b256() || ty.is_tuple() || ty.is_array())
                 {
@@ -346,300 +353,337 @@ impl Predicate {
         }
     }
 
-    pub(super) fn type_check_all_exprs(
-        &mut self,
-        handler: &Handler,
-        consts: &FxHashMap<String, Const>,
-    ) {
-        self.check_iface_inst_addrs(handler, consts);
-        self.check_pred_inst_addrs(handler, consts);
+    pub(super) fn type_check_all_exprs(&mut self, handler: &Handler) {
+        self.check_iface_inst_addrs(handler);
+        self.check_pred_inst_addrs(handler);
 
-        // Check all the 'root' exprs (constraints, state init exprs, and var init exprs) one at a
-        // time, gathering errors as we go. Copying the keys out first to avoid borrowing conflict.
-        let mut all_expr_keys = self
-            .constraints
-            .iter()
-            .map(|ConstraintDecl { expr: key, .. }| *key)
-            .chain(self.states().map(|(_, state)| state.expr))
-            .chain(self.var_inits.iter().map(|(_, expr)| *expr))
-            .collect::<Vec<_>>();
+        let pred_names = self.preds.keys().cloned().collect::<Vec<_>>();
+        for pred_name in &pred_names {
+            // Check all the 'root' exprs (constraints, state init exprs, and var init exprs) one at a
+            // time, gathering errors as we go. Copying the keys out first to avoid borrowing conflict.
+            let mut all_expr_keys = self.preds[pred_name]
+                .constraints
+                .iter()
+                .map(|ConstraintDecl { expr: key, .. }| *key)
+                .chain(self.preds[pred_name].states().map(|(_, state)| state.expr))
+                .chain(
+                    self.preds[pred_name]
+                        .var_inits
+                        .iter()
+                        .map(|(_, expr)| *expr),
+                )
+                .collect::<Vec<_>>();
 
-        // When we're checking the root predicate we check all the consts too.
-        if self.is_root() {
-            all_expr_keys.extend(consts.iter().map(|(_, Const { expr, .. })| *expr));
-        }
-
-        for expr_key in all_expr_keys {
-            if let Err(err) = self.type_check_single_expr(consts, expr_key) {
-                handler.emit_err(err);
+            // When we're checking the root predicate we check all the consts too.
+            if pred_name == Contract::ROOT_PRED_NAME {
+                all_expr_keys.extend(self.consts.iter().map(|(_, Const { expr, .. })| *expr));
             }
-        }
 
-        // Now check all if declarations
-        self.if_decls
-            .clone()
-            .iter()
-            .for_each(|if_decl| self.type_check_if_decl(consts, if_decl, handler));
+            for expr_key in all_expr_keys {
+                if let Err(err) = self.type_check_single_expr(pred_name, expr_key) {
+                    handler.emit_err(err);
+                }
+            }
 
-        // Confirm now that all decision variables are typed.
-        let mut var_key_to_new_type = FxHashMap::default();
-        for (var_key, var) in self.vars() {
-            let ty = var_key.get_ty(self);
-            if ty.is_unknown() {
-                if let Some(init_expr_key) = self.var_inits.get(var_key) {
-                    let ty = init_expr_key.get_ty(self);
-                    if !ty.is_unknown() {
-                        if var.is_pub
-                            && !(ty.is_bool()
-                                || ty.is_b256()
-                                || ty.is_int()
-                                || ty.is_tuple()
-                                || ty.is_array())
-                        {
-                            handler.emit_err(Error::Compile {
-                                error: CompileError::Internal {
-                                    msg: "only `bool`, b256`, `int`, tuple, and array pub vars \
+            // Now check all if declarations
+            self.preds[pred_name]
+                .if_decls
+                .clone()
+                .iter()
+                .for_each(|if_decl| self.type_check_if_decl(handler, pred_name, if_decl));
+
+            // Confirm now that all decision variables are typed.
+            let mut var_key_to_new_type = FxHashMap::default();
+            for (var_key, var) in self.preds[pred_name].vars() {
+                let ty = var_key.get_ty(&self.preds[pred_name]);
+                if ty.is_unknown() {
+                    if let Some(init_expr_key) = self.preds[pred_name].var_inits.get(var_key) {
+                        let ty = init_expr_key.get_ty(self);
+                        if !ty.is_unknown() {
+                            if var.is_pub
+                                && !(ty.is_bool()
+                                    || ty.is_b256()
+                                    || ty.is_int()
+                                    || ty.is_tuple()
+                                    || ty.is_array())
+                            {
+                                handler.emit_err(Error::Compile {
+                                    error: CompileError::Internal {
+                                        msg:
+                                            "only `bool`, b256`, `int`, tuple, and array pub vars \
                                           are currently supported",
+                                        span: var.span.clone(),
+                                    },
+                                });
+                            } else {
+                                var_key_to_new_type.insert(var_key, ty.clone());
+                            }
+                        } else {
+                            handler.emit_err(Error::Compile {
+                                error: CompileError::UnknownType {
                                     span: var.span.clone(),
                                 },
                             });
-                        } else {
-                            var_key_to_new_type.insert(var_key, ty.clone());
                         }
                     } else {
                         handler.emit_err(Error::Compile {
-                            error: CompileError::UnknownType {
+                            error: CompileError::Internal {
+                                msg: "untyped variable has no initialiser",
                                 span: var.span.clone(),
                             },
                         });
                     }
-                } else {
+                } else if var.is_pub
+                    && !(ty.is_bool()
+                        || ty.is_b256()
+                        || ty.is_int()
+                        || ty.is_tuple()
+                        || ty.is_array())
+                {
                     handler.emit_err(Error::Compile {
                         error: CompileError::Internal {
-                            msg: "untyped variable has no initialiser",
+                            msg: "only `bool`, b256`, `int`, tuple, and array pub vars \
+                            are currently supported",
                             span: var.span.clone(),
                         },
                     });
                 }
-            } else if var.is_pub
-                && !(ty.is_bool() || ty.is_b256() || ty.is_int() || ty.is_tuple() || ty.is_array())
-            {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "only `bool`, b256`, `int`, tuple, and array pub vars \
-                            are currently supported",
-                        span: var.span.clone(),
-                    },
-                });
             }
-        }
 
-        self.vars.update_types(|var_key, ty| {
-            if let Some(new_ty) = var_key_to_new_type.get(&var_key) {
-                *ty = new_ty.clone()
-            }
-        });
-
-        // Confirm now that all state variables are typed.
-        let mut state_key_to_new_type = FxHashMap::default();
-        for (state_key, state) in self.states() {
-            let state_ty = state_key.get_ty(self);
-            if !state_ty.is_unknown() {
-                let expr_ty = state.expr.get_ty(self);
-                if !expr_ty.is_unknown() {
-                    if !state_ty.eq(self, expr_ty) {
-                        handler.emit_err(Error::Compile {
-                            error: CompileError::StateVarInitTypeError {
-                                large_err: Box::new(LargeTypeError::StateVarInitTypeError {
-                                    expected_ty: self.with_pred(state_ty).to_string(),
-                                    found_ty: self.with_pred(expr_ty).to_string(),
-                                    span: self.expr_key_to_span(state.expr),
-                                    expected_span: Some(state_ty.span().clone()),
-                                }),
-                            },
-                        });
+            self.preds
+                .get_mut(pred_name)
+                .unwrap()
+                .vars
+                .update_types(|var_key, ty| {
+                    if let Some(new_ty) = var_key_to_new_type.get(&var_key) {
+                        *ty = new_ty.clone()
                     }
-                    // State variables of type `Map` are not allowed
-                    if state_ty.is_map() {
-                        handler.emit_err(Error::Compile {
-                            error: CompileError::StateVarTypeIsMap {
-                                span: state.span.clone(),
-                            },
-                        });
-                    }
-                } else {
-                    handler.emit_err(Error::Compile {
-                        error: CompileError::UnknownType {
-                            span: state.span.clone(),
-                        },
-                    });
-                }
-            } else {
-                let expr_ty = state.expr.get_ty(self).clone();
-                if !expr_ty.is_unknown() {
-                    state_key_to_new_type.insert(state_key, expr_ty.clone());
-                    // State variables of type `Map` are not allowed
-                    if expr_ty.is_map() {
-                        handler.emit_err(Error::Compile {
-                            error: CompileError::StateVarTypeIsMap {
-                                span: state.span.clone(),
-                            },
-                        });
-                    }
-                } else {
-                    handler.emit_err(Error::Compile {
-                        error: CompileError::UnknownType {
-                            span: state.span.clone(),
-                        },
-                    });
-                }
-            }
-        }
-        self.states.update_types(|state_key, ty| {
-            if let Some(new_ty) = state_key_to_new_type.get(&state_key) {
-                *ty = new_ty.clone()
-            }
-        });
-
-        // Last thing we have to do is to type check all the range expressions in array types and
-        // make sure they are integers or enums
-        let mut checked_range_exprs = FxHashSet::default();
-        for range_expr in self
-            .vars()
-            .filter_map(|(var_key, _)| var_key.get_ty(self).get_array_range_expr())
-            .chain(
-                self.states()
-                    .filter_map(|(state_key, _)| state_key.get_ty(self).get_array_range_expr()),
-            )
-            .chain(
-                self.exprs()
-                    .filter_map(|expr_key| expr_key.get_ty(self).get_array_range_expr()),
-            )
-            .collect::<Vec<_>>()
-            .iter()
-        {
-            if let Err(err) = self.type_check_single_expr(consts, *range_expr) {
-                handler.emit_err(err);
-            } else if !(range_expr.get_ty(self).is_int()
-                || range_expr.get_ty(self).is_enum(self)
-                || checked_range_exprs.contains(range_expr))
-            {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::InvalidArrayRangeType {
-                        found_ty: self.with_pred(range_expr.get_ty(self)).to_string(),
-                        span: self.expr_key_to_span(*range_expr),
-                    },
                 });
-                // Make sure to not collect too many duplicate errors
-                checked_range_exprs.insert(range_expr);
-            }
-        }
-    }
 
-    fn check_iface_inst_addrs(&mut self, handler: &Handler, consts: &FxHashMap<String, Const>) {
-        // Type check all interface instance declarations.
-        let mut addr_keys = Vec::default();
-        for InterfaceInstance {
-            interface,
-            address,
-            span,
-            ..
-        } in &self.interface_instances
-        {
-            if self
-                .interfaces
-                .iter()
-                .any(|e| e.name.to_string() == *interface)
-            {
-                // OK. Type check this address below.
-                addr_keys.push(*address);
-            } else {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::MissingInterface {
-                        name: interface.clone(),
-                        span: span.clone(),
-                    },
-                });
-            }
-        }
-
-        self.check_instance_addresses(handler, consts, &addr_keys);
-    }
-
-    fn check_pred_inst_addrs(&mut self, handler: &Handler, consts: &FxHashMap<String, Const>) {
-        // Type check all predicate instance declarations.
-        let mut addr_keys = Vec::default();
-        for PredicateInstance {
-            interface_instance,
-            predicate,
-            address,
-            span,
-            ..
-        } in &self.predicate_instances
-        {
-            // Make sure that an appropriate interface instance exists and an appropriate
-            // predicate interface exists.
-            if let Some(interface_instance) = self
-                .interface_instances
-                .iter()
-                .find(|e| e.name.to_string() == *interface_instance)
-            {
-                if let Some(interface) = self
-                    .interfaces
-                    .iter()
-                    .find(|e| e.name.to_string() == *interface_instance.interface)
-                {
-                    if interface
-                        .predicate_interfaces
-                        .iter()
-                        .any(|e| e.name.to_string() == *predicate.to_string())
-                    {
-                        // OK. Type check this address below.
-                        addr_keys.push(*address);
+            // Confirm now that all state variables are typed.
+            let mut state_key_to_new_type = FxHashMap::default();
+            for (state_key, state) in self.preds[pred_name].states() {
+                let state_ty = state_key.get_ty(&self.preds[pred_name]);
+                if !state_ty.is_unknown() {
+                    let expr_ty = state.expr.get_ty(self);
+                    if !expr_ty.is_unknown() {
+                        if !state_ty.eq(&self.preds[pred_name], expr_ty) {
+                            handler.emit_err(Error::Compile {
+                                error: CompileError::StateVarInitTypeError {
+                                    large_err: Box::new(LargeTypeError::StateVarInitTypeError {
+                                        expected_ty: self.preds[pred_name]
+                                            .with_pred(self, state_ty)
+                                            .to_string(),
+                                        found_ty: self.preds[pred_name]
+                                            .with_pred(self, expr_ty)
+                                            .to_string(),
+                                        span: self.expr_key_to_span(state.expr),
+                                        expected_span: Some(state_ty.span().clone()),
+                                    }),
+                                },
+                            });
+                        }
+                        // State variables of type `Map` are not allowed
+                        if state_ty.is_map() {
+                            handler.emit_err(Error::Compile {
+                                error: CompileError::StateVarTypeIsMap {
+                                    span: state.span.clone(),
+                                },
+                            });
+                        }
                     } else {
                         handler.emit_err(Error::Compile {
-                            error: CompileError::MissingPredicateInterface {
-                                pred_name: predicate.name.to_string(),
-                                interface_name: interface.name.to_string(),
-                                span: span.clone(),
+                            error: CompileError::UnknownType {
+                                span: state.span.clone(),
+                            },
+                        });
+                    }
+                } else {
+                    let expr_ty = state.expr.get_ty(self).clone();
+                    if !expr_ty.is_unknown() {
+                        state_key_to_new_type.insert(state_key, expr_ty.clone());
+                        // State variables of type `Map` are not allowed
+                        if expr_ty.is_map() {
+                            handler.emit_err(Error::Compile {
+                                error: CompileError::StateVarTypeIsMap {
+                                    span: state.span.clone(),
+                                },
+                            });
+                        }
+                    } else {
+                        handler.emit_err(Error::Compile {
+                            error: CompileError::UnknownType {
+                                span: state.span.clone(),
                             },
                         });
                     }
                 }
-            } else {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::MissingInterfaceInstance {
-                        name: interface_instance.clone(),
-                        span: span.clone(),
-                    },
+            }
+
+            self.preds
+                .get_mut(pred_name)
+                .unwrap()
+                .states
+                .update_types(|state_key, ty| {
+                    if let Some(new_ty) = state_key_to_new_type.get(&state_key) {
+                        *ty = new_ty.clone()
+                    }
                 });
+
+            // Last thing we have to do is to type check all the range expressions in array types and
+            // make sure they are integers or enums
+            let mut checked_range_exprs = FxHashSet::default();
+            for range_expr in self.preds[pred_name]
+                .vars()
+                .filter_map(|(var_key, _)| {
+                    var_key
+                        .get_ty(&self.preds[pred_name])
+                        .get_array_range_expr()
+                })
+                .chain(self.preds[pred_name].states().filter_map(|(state_key, _)| {
+                    state_key
+                        .get_ty(&self.preds[pred_name])
+                        .get_array_range_expr()
+                }))
+                .chain(
+                    self.exprs(&self.preds[pred_name])
+                        .filter_map(|expr_key| expr_key.get_ty(self).get_array_range_expr()),
+                )
+                .collect::<Vec<_>>()
+                .iter()
+            {
+                if let Err(err) = self.type_check_single_expr(pred_name, *range_expr) {
+                    handler.emit_err(err);
+                } else if !(range_expr.get_ty(self).is_int()
+                    || range_expr.get_ty(self).is_enum(&self.preds[pred_name])
+                    || checked_range_exprs.contains(range_expr))
+                {
+                    handler.emit_err(Error::Compile {
+                        error: CompileError::InvalidArrayRangeType {
+                            found_ty: self.preds[pred_name]
+                                .with_pred(self, range_expr.get_ty(self))
+                                .to_string(),
+                            span: self.expr_key_to_span(*range_expr),
+                        },
+                    });
+                    // Make sure to not collect too many duplicate errors
+                    checked_range_exprs.insert(range_expr);
+                }
             }
         }
+    }
 
-        self.check_instance_addresses(handler, consts, &addr_keys);
+    fn check_iface_inst_addrs(&mut self, handler: &Handler) {
+        for pred_name in self.preds.keys().cloned().collect::<Vec<_>>().iter() {
+            // Type check all interface instance declarations.
+            let mut addr_keys = Vec::default();
+            for InterfaceInstance {
+                interface,
+                address,
+                span,
+                ..
+            } in &self.preds[pred_name].interface_instances
+            {
+                if self.preds[pred_name]
+                    .interfaces
+                    .iter()
+                    .any(|e| e.name.to_string() == *interface)
+                {
+                    // OK. Type check this address below.
+                    addr_keys.push(*address);
+                } else {
+                    handler.emit_err(Error::Compile {
+                        error: CompileError::MissingInterface {
+                            name: interface.clone(),
+                            span: span.clone(),
+                        },
+                    });
+                }
+            }
+
+            self.check_instance_addresses(handler, pred_name, &addr_keys);
+        }
+    }
+
+    fn check_pred_inst_addrs(&mut self, handler: &Handler) {
+        for pred_name in self.preds.keys().cloned().collect::<Vec<_>>().iter() {
+            // Type check all predicate instance declarations.
+            let mut addr_keys = Vec::default();
+            for PredicateInstance {
+                interface_instance,
+                predicate,
+                address,
+                span,
+                ..
+            } in &self.preds[pred_name].predicate_instances
+            {
+                // Make sure that an appropriate interface instance exists and an appropriate
+                // predicate interface exists.
+                if let Some(interface_instance) = self.preds[pred_name]
+                    .interface_instances
+                    .iter()
+                    .find(|e| e.name.to_string() == *interface_instance)
+                {
+                    if let Some(interface) = self.preds[pred_name]
+                        .interfaces
+                        .iter()
+                        .find(|e| e.name.to_string() == *interface_instance.interface)
+                    {
+                        if interface
+                            .predicate_interfaces
+                            .iter()
+                            .any(|e| e.name.to_string() == *predicate.to_string())
+                        {
+                            // OK. Type check this address below.
+                            addr_keys.push(*address);
+                        } else {
+                            handler.emit_err(Error::Compile {
+                                error: CompileError::MissingPredicateInterface {
+                                    pred_name: predicate.name.to_string(),
+                                    interface_name: interface.name.to_string(),
+                                    span: span.clone(),
+                                },
+                            });
+                        }
+                    }
+                } else {
+                    handler.emit_err(Error::Compile {
+                        error: CompileError::MissingInterfaceInstance {
+                            name: interface_instance.clone(),
+                            span: span.clone(),
+                        },
+                    });
+                }
+            }
+
+            self.check_instance_addresses(handler, pred_name, &addr_keys);
+        }
     }
 
     fn check_instance_addresses(
         &mut self,
         handler: &Handler,
-        consts: &FxHashMap<String, Const>,
+        pred_name: &str,
         addr_keys: &[ExprKey],
     ) {
         for address in addr_keys {
-            match self.type_check_single_expr(consts, *address) {
+            match self.type_check_single_expr(pred_name, *address) {
                 Ok(()) => {
                     let ty = address.get_ty(self);
                     if !ty.is_b256() {
                         handler.emit_err(Error::Compile {
                             error: CompileError::AddressExpressionTypeError {
                                 large_err: Box::new(LargeTypeError::AddressExpressionTypeError {
-                                    expected_ty: self
-                                        .with_pred(Type::Primitive {
-                                            kind: PrimitiveKind::B256,
-                                            span: empty_span(),
-                                        })
+                                    expected_ty: self.preds[pred_name]
+                                        .with_pred(
+                                            self,
+                                            Type::Primitive {
+                                                kind: PrimitiveKind::B256,
+                                                span: empty_span(),
+                                            },
+                                        )
                                         .to_string(),
-                                    found_ty: self.with_pred(ty).to_string(),
+                                    found_ty: self.preds[pred_name].with_pred(self, ty).to_string(),
                                     span: self.expr_key_to_span(*address),
                                     expected_span: Some(self.expr_key_to_span(*address)),
                                 }),
@@ -657,12 +701,7 @@ impl Predicate {
 
     // Type check an if statement and all of its sub-statements including other ifs. This is a
     // recursive function.
-    fn type_check_if_decl(
-        &mut self,
-        consts: &FxHashMap<String, Const>,
-        if_decl: &IfDecl,
-        handler: &Handler,
-    ) {
+    fn type_check_if_decl(&mut self, handler: &Handler, pred_name: &str, if_decl: &IfDecl) {
         let IfDecl {
             condition,
             then_block,
@@ -671,14 +710,14 @@ impl Predicate {
         } = if_decl;
 
         // Make sure the condition is a `bool`
-        if let Err(err) = self.type_check_single_expr(consts, *condition) {
+        if let Err(err) = self.type_check_single_expr(pred_name, *condition) {
             handler.emit_err(err);
         } else {
             let cond_ty = condition.get_ty(self);
             if !cond_ty.is_bool() {
                 handler.emit_err(Error::Compile {
                     error: CompileError::NonBoolConditional {
-                        ty: self.with_pred(cond_ty).to_string(),
+                        ty: self.preds[pred_name].with_pred(self, cond_ty).to_string(),
                         conditional: "`if` statement".to_string(),
                         span: self.expr_key_to_span(*condition),
                     },
@@ -688,36 +727,32 @@ impl Predicate {
 
         // Type check each block statement in the "then" block
         then_block.iter().for_each(|block_statement| {
-            self.type_check_block_statement(consts, block_statement, handler);
+            self.type_check_block_statement(handler, pred_name, block_statement);
         });
 
         // Type check each block statement in the "else" block, if available
         else_block.iter().flatten().for_each(|block_statement| {
-            self.type_check_block_statement(consts, block_statement, handler);
+            self.type_check_block_statement(handler, pred_name, block_statement);
         });
     }
 
     fn type_check_block_statement(
         &mut self,
-        consts: &FxHashMap<String, Const>,
-        block_statement: &BlockStatement,
         handler: &Handler,
+        pred_name: &str,
+        block_statement: &BlockStatement,
     ) {
         match block_statement {
             BlockStatement::Constraint(ConstraintDecl { expr, .. }) => {
-                if let Err(err) = self.type_check_single_expr(consts, *expr) {
+                if let Err(err) = self.type_check_single_expr(pred_name, *expr) {
                     handler.emit_err(err);
                 }
             }
-            BlockStatement::If(if_decl) => self.type_check_if_decl(consts, if_decl, handler),
+            BlockStatement::If(if_decl) => self.type_check_if_decl(handler, pred_name, if_decl),
         }
     }
 
-    fn type_check_single_expr(
-        &mut self,
-        consts: &FxHashMap<String, Const>,
-        expr_key: ExprKey,
-    ) -> Result<(), Error> {
+    fn type_check_single_expr(&mut self, pred_name: &str, expr_key: ExprKey) -> Result<(), Error> {
         // Attempt to infer all the types of each expr.
         let mut queue = Vec::new();
 
@@ -748,7 +783,7 @@ impl Predicate {
             if !next_key.get_ty(self).is_unknown() {
                 queue.pop();
             } else {
-                match self.infer_expr_key_type(consts, next_key)? {
+                match self.infer_expr_key_type(&self.preds[pred_name], next_key)? {
                     // Successfully inferred its type.  Save it and pop it from the queue.
                     Inference::Type(ty) => {
                         next_key.set_ty(ty, self);
@@ -775,11 +810,7 @@ impl Predicate {
         Ok(())
     }
 
-    fn infer_expr_key_type(
-        &self,
-        consts: &FxHashMap<String, Const>,
-        expr_key: ExprKey,
-    ) -> Result<Inference, Error> {
+    fn infer_expr_key_type(&self, pred: &Predicate, expr_key: ExprKey) -> Result<Inference, Error> {
         let expr: &Expr = expr_key.try_get(self).ok_or_else(|| Error::Compile {
             error: CompileError::Internal {
                 msg: "orphaned expr key when type checking",
@@ -795,41 +826,43 @@ impl Predicate {
                 },
             }),
 
-            Expr::Immediate { value, span } => self.infer_immediate(value, span),
+            Expr::Immediate { value, span } => self.infer_immediate(pred, value, span),
 
             Expr::Array {
                 elements,
                 range_expr,
                 span,
-            } => self.infer_array_expr(*range_expr, elements, span),
+            } => self.infer_array_expr(pred, *range_expr, elements, span),
 
             Expr::Tuple { fields, span } => self.infer_tuple_expr(fields, span),
 
-            Expr::PathByKey(var_key, span) => self.infer_path_by_key(*var_key, span),
+            Expr::PathByKey(var_key, span) => self.infer_path_by_key(pred, *var_key, span),
 
-            Expr::PathByName(path, span) => self.infer_path_by_name(consts, path, span),
+            Expr::PathByName(path, span) => self.infer_path_by_name(pred, path, span),
 
-            Expr::StorageAccess(name, span) => self.infer_storage_access(name, span),
+            Expr::StorageAccess(name, span) => self.infer_storage_access(pred, name, span),
 
             Expr::ExternalStorageAccess {
                 interface_instance,
                 name,
                 span,
                 ..
-            } => self.infer_external_storage_access(interface_instance, name, span),
+            } => self.infer_external_storage_access(pred, interface_instance, name, span),
 
             Expr::UnaryOp {
                 op,
                 expr: op_expr_key,
                 span,
-            } => self.infer_unary_op(*op, *op_expr_key, span),
+            } => self.infer_unary_op(pred, *op, *op_expr_key, span),
 
-            Expr::BinaryOp { op, lhs, rhs, span } => self.infer_binary_op(*op, *lhs, *rhs, span),
+            Expr::BinaryOp { op, lhs, rhs, span } => {
+                self.infer_binary_op(pred, *op, *lhs, *rhs, span)
+            }
 
             Expr::MacroCall { .. } => Ok(Inference::Ignored),
 
             Expr::IntrinsicCall { name, args, span } => {
-                self.infer_intrinsic_call_expr(name, args, span)
+                self.infer_intrinsic_call_expr(pred, name, args, span)
             }
 
             Expr::Select {
@@ -837,23 +870,23 @@ impl Predicate {
                 then_expr,
                 else_expr,
                 span,
-            } => self.infer_select_expr(*condition, *then_expr, *else_expr, span),
+            } => self.infer_select_expr(pred, *condition, *then_expr, *else_expr, span),
 
-            Expr::Index { expr, index, span } => self.infer_index_expr(*expr, *index, span),
+            Expr::Index { expr, index, span } => self.infer_index_expr(pred, *expr, *index, span),
 
             Expr::TupleFieldAccess { tuple, field, span } => {
-                self.infer_tuple_access_expr(*tuple, field, span)
+                self.infer_tuple_access_expr(pred, *tuple, field, span)
             }
 
-            Expr::Cast { value, ty, span } => self.infer_cast_expr(*value, ty, span),
+            Expr::Cast { value, ty, span } => self.infer_cast_expr(pred, *value, ty, span),
 
             Expr::In {
                 value,
                 collection,
                 span,
-            } => self.infer_in_expr(*value, *collection, span),
+            } => self.infer_in_expr(pred, *value, *collection, span),
 
-            Expr::Range { lb, ub, span } => self.infer_range_expr(*lb, *ub, span),
+            Expr::Range { lb, ub, span } => self.infer_range_expr(pred, *lb, *ub, span),
 
             Expr::Generator {
                 kind,
@@ -861,11 +894,16 @@ impl Predicate {
                 conditions,
                 body,
                 span,
-            } => self.infer_generator_expr(kind, gen_ranges, conditions, *body, span),
+            } => self.infer_generator_expr(pred, kind, gen_ranges, conditions, *body, span),
         }
     }
 
-    pub(super) fn infer_immediate(&self, imm: &Immediate, span: &Span) -> Result<Inference, Error> {
+    pub(super) fn infer_immediate(
+        &self,
+        pred: &Predicate,
+        imm: &Immediate,
+        span: &Span,
+    ) -> Result<Inference, Error> {
         if let Immediate::Array(el_imms) = imm {
             // Immediate::get_ty() assumes the array is well formed.  We need to
             // confirm here.
@@ -888,11 +926,11 @@ impl Predicate {
 
             el_imms.iter().try_for_each(|el_imm| {
                 let el_ty = el_imm.get_ty(None);
-                if !el_ty.eq(self, el0_ty.as_ref()) {
+                if !el_ty.eq(pred, el0_ty.as_ref()) {
                     Err(Error::Compile {
                         error: CompileError::NonHomogeneousArrayElement {
-                            expected_ty: self.with_pred(el0_ty.as_ref()).to_string(),
-                            ty: self.with_pred(el_ty).to_string(),
+                            expected_ty: pred.with_pred(self, el0_ty.as_ref()).to_string(),
+                            ty: pred.with_pred(self, el_ty).to_string(),
                             span: span.clone(),
                         },
                     })
@@ -907,11 +945,16 @@ impl Predicate {
         }
     }
 
-    fn infer_path_by_key(&self, var_key: VarKey, span: &Span) -> Result<Inference, Error> {
-        let ty = var_key.get_ty(self);
+    fn infer_path_by_key(
+        &self,
+        pred: &Predicate,
+        var_key: VarKey,
+        span: &Span,
+    ) -> Result<Inference, Error> {
+        let ty = var_key.get_ty(pred);
         if !ty.is_unknown() {
             Ok(Inference::Type(ty.clone()))
-        } else if let Some(init_expr_key) = self.var_inits.get(var_key) {
+        } else if let Some(init_expr_key) = pred.var_inits.get(var_key) {
             let init_expr_ty = init_expr_key.get_ty(self);
             if !init_expr_ty.is_unknown() {
                 Ok(Inference::Type(init_expr_ty.clone()))
@@ -932,22 +975,22 @@ impl Predicate {
 
     fn infer_path_by_name(
         &self,
-        consts: &FxHashMap<String, Const>,
+        pred: &Predicate,
         path: &Path,
         span: &Span,
     ) -> Result<Inference, Error> {
-        if let Some(var_key) = self
+        if let Some(var_key) = pred
             .vars()
             .find_map(|(var_key, var)| (&var.name == path).then_some(var_key))
         {
             // It's a var.
-            self.infer_path_by_key(var_key, span)
+            self.infer_path_by_key(pred, var_key, span)
         } else if let Some((state_key, state)) =
-            self.states().find(|(_, state)| (&state.name == path))
+            pred.states().find(|(_, state)| (&state.name == path))
         {
             // It's state.
             let state_expr_ty = state.expr.get_ty(self);
-            let state_type = state_key.get_ty(self);
+            let state_type = state_key.get_ty(pred);
             Ok(if !state_type.is_unknown() {
                 Inference::Type(state_type.clone())
             } else if !state_expr_ty.is_unknown() {
@@ -955,7 +998,7 @@ impl Predicate {
             } else {
                 Inference::Dependant(state.expr)
             })
-        } else if let Some(Const { decl_ty, .. }) = consts.get(path) {
+        } else if let Some(Const { decl_ty, .. }) = self.consts.get(path) {
             if !decl_ty.is_unknown() {
                 Ok(Inference::Type(decl_ty.clone()))
             } else {
@@ -966,31 +1009,36 @@ impl Predicate {
                     },
                 })
             }
-        } else if let Some(EphemeralDecl { ty, .. }) = self
+        } else if let Some(EphemeralDecl { ty, .. }) = pred
             .ephemerals
             .iter()
             .find(|eph_decl| &eph_decl.name == path)
         {
             // It's an ephemeral value.
             Ok(Inference::Type(ty.clone()))
-        } else if let Some(ty) = self
+        } else if let Some(ty) = pred
             .new_types
             .iter()
             .find_map(|NewTypeDecl { name, ty, .. }| (&name.name == path).then_some(ty))
         {
             // It's a fully matched newtype.
             Ok(Inference::Type(ty.clone()))
-        } else if let Some(ty) = self.infer_extern_var(path) {
+        } else if let Some(ty) = self.infer_extern_var(pred, path) {
             // It's an external var
             Ok(ty)
         } else {
             // None of the above. That leaves enums.
-            self.infer_enum_variant_by_name(path, span)
+            Self::infer_enum_variant_by_name(pred, path, span)
         }
     }
 
-    fn infer_storage_access(&self, name: &String, span: &Span) -> Result<Inference, Error> {
-        match self.storage.as_ref() {
+    fn infer_storage_access(
+        &self,
+        pred: &Predicate,
+        name: &String,
+        span: &Span,
+    ) -> Result<Inference, Error> {
+        match pred.storage.as_ref() {
             Some(storage) => match storage.0.iter().find(|s_var| s_var.name.name == *name) {
                 Some(s_var) => Ok(Inference::Type(s_var.ty.clone())),
                 None => Err(Error::Compile {
@@ -1011,12 +1059,13 @@ impl Predicate {
 
     fn infer_external_storage_access(
         &self,
+        pred: &Predicate,
         interface_instance: &Path,
         name: &String,
         span: &Span,
     ) -> Result<Inference, Error> {
         // Find the interface instance or emit an error
-        let Some(interface_instance) = self
+        let Some(interface_instance) = pred
             .interface_instances
             .iter()
             .find(|e| e.name.to_string() == *interface_instance)
@@ -1030,7 +1079,7 @@ impl Predicate {
         };
 
         // Find the interface declaration corresponding to the interface instance
-        let Some(interface) = self
+        let Some(interface) = pred
             .interfaces
             .iter()
             .find(|e| e.name.to_string() == *interface_instance.interface)
@@ -1061,7 +1110,7 @@ impl Predicate {
         }
     }
 
-    fn infer_extern_var(&self, path: &Path) -> Option<Inference> {
+    fn infer_extern_var(&self, pred: &Predicate, path: &Path) -> Option<Inference> {
         // Look through all available predicate instances and their corresponding interfaces for a var
         // with the same path as `path`
         for PredicateInstance {
@@ -1069,14 +1118,14 @@ impl Predicate {
             interface_instance,
             predicate,
             ..
-        } in &self.predicate_instances
+        } in &pred.predicate_instances
         {
-            if let Some(interface_instance) = self
+            if let Some(interface_instance) = pred
                 .interface_instances
                 .iter()
                 .find(|e| e.name.to_string() == *interface_instance)
             {
-                if let Some(interface) = self
+                if let Some(interface) = pred
                     .interfaces
                     .iter()
                     .find(|e| e.name.to_string() == *interface_instance.interface)
@@ -1101,12 +1150,12 @@ impl Predicate {
     }
 
     pub(super) fn infer_enum_variant_by_name(
-        &self,
+        pred: &Predicate,
         path: &Path,
         span: &Span,
     ) -> Result<Inference, Error> {
         // Check first if the path prefix matches a new type.
-        for NewTypeDecl { name, ty, .. } in &self.new_types {
+        for NewTypeDecl { name, ty, .. } in &pred.new_types {
             if let Type::Custom {
                 path: enum_path,
                 span,
@@ -1119,7 +1168,8 @@ impl Predicate {
                     if path.chars().nth(new_type_len) == Some(':') {
                         // Definitely worth trying.  Recurse.
                         let new_path = enum_path.clone() + &path[new_type_len..];
-                        if let ty @ Ok(_) = self.infer_enum_variant_by_name(&new_path, span) {
+                        if let ty @ Ok(_) = Self::infer_enum_variant_by_name(pred, &new_path, span)
+                        {
                             // We found an enum variant.
                             return ty;
                         }
@@ -1132,7 +1182,7 @@ impl Predicate {
         // report some hints.
         let mut err_potential_enums = Vec::new();
 
-        if let Some(ty) = self.enums.iter().find_map(
+        if let Some(ty) = pred.enums.iter().find_map(
             |EnumDecl {
                  name: enum_name,
                  variants,
@@ -1172,16 +1222,18 @@ impl Predicate {
 
     fn infer_unary_op(
         &self,
+        pred: &Predicate,
         op: UnaryOp,
         rhs_expr_key: ExprKey,
         span: &Span,
     ) -> Result<Inference, Error> {
         fn drill_down_to_path(
+            contract: &Contract,
             pred: &Predicate,
             expr_key: &ExprKey,
             span: &Span,
         ) -> Result<(), Error> {
-            match expr_key.try_get(pred) {
+            match expr_key.try_get(contract) {
                 Some(Expr::PathByName(name, span)) => {
                     if !pred.states().any(|(_, state)| state.name == *name) {
                         Err(Error::Compile {
@@ -1216,7 +1268,7 @@ impl Predicate {
                 })
                 | Some(Expr::Index { expr, .. })
                 | Some(Expr::TupleFieldAccess { tuple: expr, .. }) => {
-                    drill_down_to_path(pred, expr, span)
+                    drill_down_to_path(contract, pred, expr, span)
                 }
 
                 _ => Err(Error::Compile {
@@ -1236,7 +1288,7 @@ impl Predicate {
             UnaryOp::NextState => {
                 // Next state access must be a path that resolves to a state variable.  It _may_ be
                 // via array indices or tuple fields or even other prime ops.
-                drill_down_to_path(self, &rhs_expr_key, span)?;
+                drill_down_to_path(self, pred, &rhs_expr_key, span)?;
 
                 let ty = rhs_expr_key.get_ty(self);
                 Ok(if !ty.is_unknown() {
@@ -1259,7 +1311,7 @@ impl Predicate {
                                 large_err: Box::new(LargeTypeError::OperatorTypeError {
                                     op: "-",
                                     expected_ty: "numeric".to_string(),
-                                    found_ty: self.with_pred(ty).to_string(),
+                                    found_ty: pred.with_pred(self, ty).to_string(),
                                     span: span.clone(),
                                     expected_span: None,
                                 }),
@@ -1284,7 +1336,7 @@ impl Predicate {
                                 large_err: Box::new(LargeTypeError::OperatorTypeError {
                                     op: "!",
                                     expected_ty: "bool".to_string(),
-                                    found_ty: self.with_pred(ty).to_string(),
+                                    found_ty: pred.with_pred(self, ty).to_string(),
                                     span: span.clone(),
                                     expected_span: None,
                                 }),
@@ -1300,6 +1352,7 @@ impl Predicate {
 
     fn infer_binary_op(
         &self,
+        pred: &Predicate,
         op: BinaryOp,
         lhs_expr_key: ExprKey,
         rhs_expr_key: ExprKey,
@@ -1313,7 +1366,7 @@ impl Predicate {
                         large_err: Box::new(LargeTypeError::OperatorTypeError {
                             op: op.as_str(),
                             expected_ty: ty_str.to_string(),
-                            found_ty: self.with_pred(lhs_ty).to_string(),
+                            found_ty: pred.with_pred(self, lhs_ty).to_string(),
                             span: self.expr_key_to_span(lhs_expr_key),
                             expected_span: None,
                         }),
@@ -1326,21 +1379,21 @@ impl Predicate {
                         large_err: Box::new(LargeTypeError::OperatorTypeError {
                             op: op.as_str(),
                             expected_ty: ty_str.to_string(),
-                            found_ty: self.with_pred(rhs_ty).to_string(),
+                            found_ty: pred.with_pred(self, rhs_ty).to_string(),
                             span: self.expr_key_to_span(rhs_expr_key),
                             expected_span: None,
                         }),
                     },
                 })
-            } else if !lhs_ty.eq(self, rhs_ty) {
+            } else if !lhs_ty.eq(pred, rhs_ty) {
                 // Here we assume the LHS is the 'correct' type.
                 Err(Error::Compile {
                     error: CompileError::OperatorTypeError {
                         arity: "binary",
                         large_err: Box::new(LargeTypeError::OperatorTypeError {
                             op: op.as_str(),
-                            expected_ty: self.with_pred(lhs_ty).to_string(),
-                            found_ty: self.with_pred(rhs_ty).to_string(),
+                            expected_ty: pred.with_pred(self, lhs_ty).to_string(),
+                            found_ty: pred.with_pred(self, rhs_ty).to_string(),
                             span: self.expr_key_to_span(rhs_expr_key),
                             expected_span: Some(self.expr_key_to_span(lhs_expr_key)),
                         }),
@@ -1355,14 +1408,14 @@ impl Predicate {
         // not, emit an error.
         let check_state_var_arg = |arg: ExprKey| match arg.try_get(self) {
             Some(Expr::PathByName(name, _))
-                if self.states().any(|(_, state)| state.name == *name) =>
+                if pred.states().any(|(_, state)| state.name == *name) =>
             {
                 Ok(())
             }
             Some(Expr::PathByKey(var_key, _))
-                if self
+                if pred
                     .states()
-                    .any(|(_, state)| state.name == var_key.get(self).name) =>
+                    .any(|(_, state)| state.name == var_key.get(pred).name) =>
             {
                 Ok(())
             }
@@ -1408,9 +1461,9 @@ impl Predicate {
                         // which we check for type mismatches elsewhere, and emit a much better
                         // error then.
                         let mut is_init_constraint = false;
-                        if !lhs_ty.eq(self, rhs_ty)
+                        if !lhs_ty.eq(pred, rhs_ty)
                             && op == BinaryOp::Equal
-                            && self
+                            && pred
                                 .var_inits
                                 .values()
                                 .any(|init_key| *init_key == rhs_expr_key)
@@ -1420,7 +1473,7 @@ impl Predicate {
 
                         // Both args must be equatable, which at this stage is any type; binary op
                         // type is bool.
-                        if !lhs_ty.eq(self, rhs_ty)
+                        if !lhs_ty.eq(pred, rhs_ty)
                             && !lhs_ty.is_nil()
                             && !rhs_ty.is_nil()
                             && !is_init_constraint
@@ -1430,8 +1483,8 @@ impl Predicate {
                                     arity: "binary",
                                     large_err: Box::new(LargeTypeError::OperatorTypeError {
                                         op: op.as_str(),
-                                        expected_ty: self.with_pred(lhs_ty).to_string(),
-                                        found_ty: self.with_pred(rhs_ty).to_string(),
+                                        expected_ty: pred.with_pred(self, lhs_ty).to_string(),
+                                        found_ty: pred.with_pred(self, rhs_ty).to_string(),
                                         span: self.expr_key_to_span(rhs_expr_key),
                                         expected_span: Some(self.expr_key_to_span(lhs_expr_key)),
                                     }),
@@ -1467,7 +1520,7 @@ impl Predicate {
                                     large_err: Box::new(LargeTypeError::OperatorTypeError {
                                         op: op.as_str(),
                                         expected_ty: "bool".to_string(),
-                                        found_ty: self.with_pred(lhs_ty).to_string(),
+                                        found_ty: pred.with_pred(self, lhs_ty).to_string(),
                                         span: self.expr_key_to_span(lhs_expr_key),
                                         expected_span: Some(span.clone()),
                                     }),
@@ -1480,7 +1533,7 @@ impl Predicate {
                                     large_err: Box::new(LargeTypeError::OperatorTypeError {
                                         op: op.as_str(),
                                         expected_ty: "bool".to_string(),
-                                        found_ty: self.with_pred(rhs_ty).to_string(),
+                                        found_ty: pred.with_pred(self, rhs_ty).to_string(),
                                         span: self.expr_key_to_span(rhs_expr_key),
                                         expected_span: Some(span.clone()),
                                     }),
@@ -1501,6 +1554,7 @@ impl Predicate {
 
     fn infer_select_expr(
         &self,
+        pred: &Predicate,
         cond_expr_key: ExprKey,
         then_expr_key: ExprKey,
         else_expr_key: ExprKey,
@@ -1513,22 +1567,22 @@ impl Predicate {
             if !cond_ty.is_bool() {
                 Err(Error::Compile {
                     error: CompileError::NonBoolConditional {
-                        ty: self.with_pred(cond_ty).to_string(),
+                        ty: pred.with_pred(self, cond_ty).to_string(),
                         conditional: "select expression".to_string(),
                         span: self.expr_key_to_span(cond_expr_key),
                     },
                 })
             } else if !then_ty.is_unknown() {
                 if !else_ty.is_unknown() {
-                    if then_ty.eq(self, else_ty) {
+                    if then_ty.eq(pred, else_ty) {
                         Ok(Inference::Type(then_ty.clone()))
                     } else {
                         Err(Error::Compile {
                             error: CompileError::SelectBranchesTypeMismatch {
                                 large_err: Box::new(LargeTypeError::SelectBranchesTypeMismatch {
-                                    then_type: self.with_pred(then_ty).to_string(),
+                                    then_type: pred.with_pred(self, then_ty).to_string(),
                                     then_span: self.expr_key_to_span(then_expr_key),
-                                    else_type: self.with_pred(else_ty).to_string(),
+                                    else_type: pred.with_pred(self, else_ty).to_string(),
                                     else_span: self.expr_key_to_span(else_expr_key),
                                     span: span.clone(),
                                 }),
@@ -1548,6 +1602,7 @@ impl Predicate {
 
     fn infer_range_expr(
         &self,
+        pred: &Predicate,
         lower_bound_key: ExprKey,
         upper_bound_key: ExprKey,
         span: &Span,
@@ -1556,18 +1611,18 @@ impl Predicate {
         let ub_ty = upper_bound_key.get_ty(self);
         if !lb_ty.is_unknown() {
             if !ub_ty.is_unknown() {
-                if !lb_ty.eq(self, ub_ty) {
+                if !lb_ty.eq(pred, ub_ty) {
                     Err(Error::Compile {
                         error: CompileError::RangeTypesMismatch {
-                            lb_ty: self.with_pred(lb_ty).to_string(),
-                            ub_ty: self.with_pred(ub_ty).to_string(),
+                            lb_ty: pred.with_pred(self, lb_ty).to_string(),
+                            ub_ty: pred.with_pred(self, ub_ty).to_string(),
                             span: ub_ty.span().clone(),
                         },
                     })
                 } else if !lb_ty.is_num() {
                     Err(Error::Compile {
                         error: CompileError::RangeTypesNonNumeric {
-                            ty: self.with_pred(lb_ty).to_string(),
+                            ty: pred.with_pred(self, lb_ty).to_string(),
                             span: span.clone(),
                         },
                     })
@@ -1584,6 +1639,7 @@ impl Predicate {
 
     fn infer_cast_expr(
         &self,
+        pred: &Predicate,
         value_key: ExprKey,
         to_ty: &Type,
         span: &Span,
@@ -1601,20 +1657,20 @@ impl Predicate {
                 // We can only cast to ints or reals.
                 Err(Error::Compile {
                     error: CompileError::BadCastTo {
-                        ty: self.with_pred(to_ty).to_string(),
+                        ty: pred.with_pred(self, to_ty).to_string(),
                         span: span.clone(),
                     },
                 })
             } else if (to_ty.is_int()
                 && !from_ty.is_int()
-                && !from_ty.is_enum(self)
+                && !from_ty.is_enum(pred)
                 && !from_ty.is_bool())
                 || (to_ty.is_real() && !from_ty.is_int() && !from_ty.is_real())
             {
                 // We can only cast to ints from ints, enums or bools and to reals from ints or reals.
                 Err(Error::Compile {
                     error: CompileError::BadCastFrom {
-                        ty: self.with_pred(from_ty).to_string(),
+                        ty: pred.with_pred(self, from_ty).to_string(),
                         span: span.clone(),
                     },
                 })
@@ -1628,6 +1684,7 @@ impl Predicate {
 
     fn infer_in_expr(
         &self,
+        pred: &Predicate,
         value_key: ExprKey,
         collection_key: ExprKey,
         span: &Span,
@@ -1640,11 +1697,11 @@ impl Predicate {
         if !value_ty.is_unknown() {
             if !collection_ty.is_unknown() {
                 if collection_ty.is_num() {
-                    if !value_ty.eq(self, collection_ty) {
+                    if !value_ty.eq(pred, collection_ty) {
                         Err(Error::Compile {
                             error: CompileError::InExprTypesMismatch {
-                                val_ty: self.with_pred(value_ty).to_string(),
-                                range_ty: self.with_pred(collection_ty).to_string(),
+                                val_ty: pred.with_pred(self, value_ty).to_string(),
+                                range_ty: pred.with_pred(self, collection_ty).to_string(),
                                 span: collection_ty.span().clone(),
                             },
                         })
@@ -1655,11 +1712,11 @@ impl Predicate {
                         }))
                     }
                 } else if let Some(el_ty) = collection_ty.get_array_el_type() {
-                    if !value_ty.eq(self, el_ty) {
+                    if !value_ty.eq(pred, el_ty) {
                         Err(Error::Compile {
                             error: CompileError::InExprTypesArrayMismatch {
-                                val_ty: self.with_pred(value_ty).to_string(),
-                                el_ty: self.with_pred(el_ty).to_string(),
+                                val_ty: pred.with_pred(self, value_ty).to_string(),
+                                el_ty: pred.with_pred(self, el_ty).to_string(),
                                 span: el_ty.span().clone(),
                             },
                         })
@@ -1687,6 +1744,7 @@ impl Predicate {
 
     fn infer_array_expr(
         &self,
+        pred: &Predicate,
         range_expr_key: ExprKey,
         element_exprs: &[ExprKey],
         span: &Span,
@@ -1709,11 +1767,11 @@ impl Predicate {
             for el_key in elements {
                 let el_ty = el_key.get_ty(self);
                 if !el_ty.is_unknown() {
-                    if !el_ty.eq(self, el0_ty) {
+                    if !el_ty.eq(pred, el0_ty) {
                         return Err(Error::Compile {
                             error: CompileError::NonHomogeneousArrayElement {
-                                expected_ty: self.with_pred(&el0_ty).to_string(),
-                                ty: self.with_pred(el_ty).to_string(),
+                                expected_ty: pred.with_pred(self, &el0_ty).to_string(),
+                                ty: pred.with_pred(self, el_ty).to_string(),
                                 span: self.expr_key_to_span(*el_key),
                             },
                         });
@@ -1745,6 +1803,7 @@ impl Predicate {
 
     fn infer_index_expr(
         &self,
+        pred: &Predicate,
         array_expr_key: ExprKey,
         index_expr_key: ExprKey,
         span: &Span,
@@ -1766,11 +1825,11 @@ impl Predicate {
                 return Ok(Inference::Dependant(range_expr_key));
             }
 
-            if (!index_ty.is_int() && !index_ty.is_enum(self)) || !index_ty.eq(self, range_ty) {
+            if (!index_ty.is_int() && !index_ty.is_enum(pred)) || !index_ty.eq(pred, range_ty) {
                 Err(Error::Compile {
                     error: CompileError::ArrayAccessWithWrongType {
-                        found_ty: self.with_pred(index_ty).to_string(),
-                        expected_ty: self.with_pred(range_ty).to_string(),
+                        found_ty: pred.with_pred(self, index_ty).to_string(),
+                        expected_ty: pred.with_pred(self, range_ty).to_string(),
                         span: self.expr_key_to_span(index_expr_key),
                     },
                 })
@@ -1790,11 +1849,11 @@ impl Predicate {
             Ok(Inference::Type(ty.clone()))
         } else if let Some(from_ty) = ary_ty.get_map_ty_from() {
             // Is this a storage map?
-            if !from_ty.eq(self, index_ty) {
+            if !from_ty.eq(pred, index_ty) {
                 Err(Error::Compile {
                     error: CompileError::StorageMapAccessWithWrongType {
-                        found_ty: self.with_pred(index_ty).to_string(),
-                        expected_ty: self.with_pred(from_ty).to_string(),
+                        found_ty: pred.with_pred(self, index_ty).to_string(),
+                        expected_ty: pred.with_pred(self, from_ty).to_string(),
                         span: self.expr_key_to_span(index_expr_key),
                     },
                 })
@@ -1812,7 +1871,7 @@ impl Predicate {
         } else {
             Err(Error::Compile {
                 error: CompileError::IndexExprNonIndexable {
-                    non_indexable_type: self.with_pred(ary_ty).to_string(),
+                    non_indexable_type: pred.with_pred(self, ary_ty).to_string(),
                     span: span.clone(),
                 },
             })
@@ -1848,6 +1907,7 @@ impl Predicate {
 
     fn infer_tuple_access_expr(
         &self,
+        pred: &Predicate,
         tuple_expr_key: ExprKey,
         field: &TupleAccess,
         span: &Span,
@@ -1870,7 +1930,7 @@ impl Predicate {
                             Err(Error::Compile {
                                 error: CompileError::InvalidTupleAccessor {
                                     accessor: idx.to_string(),
-                                    tuple_type: self.with_pred(tuple_ty).to_string(),
+                                    tuple_type: pred.with_pred(self, tuple_ty).to_string(),
                                     span: span.clone(),
                                 },
                             })
@@ -1884,7 +1944,7 @@ impl Predicate {
                             Err(Error::Compile {
                                 error: CompileError::InvalidTupleAccessor {
                                     accessor: name.name.clone(),
-                                    tuple_type: self.with_pred(&tuple_ty).to_string(),
+                                    tuple_type: pred.with_pred(self, &tuple_ty).to_string(),
                                     span: span.clone(),
                                 },
                             })
@@ -1894,7 +1954,7 @@ impl Predicate {
             } else {
                 Err(Error::Compile {
                     error: CompileError::TupleAccessNonTuple {
-                        non_tuple_type: self.with_pred(tuple_ty).to_string(),
+                        non_tuple_type: pred.with_pred(self, tuple_ty).to_string(),
                         span: span.clone(),
                     },
                 })
@@ -1906,6 +1966,7 @@ impl Predicate {
 
     fn infer_generator_expr(
         &self,
+        pred: &Predicate,
         kind: &GeneratorKind,
         ranges: &[(Ident, ExprKey)],
         conditions: &[ExprKey],
@@ -1920,7 +1981,7 @@ impl Predicate {
                 if !range_ty.is_int() {
                     return Err(Error::Compile {
                         error: CompileError::NonIntGeneratorRange {
-                            ty: self.with_pred(range_ty).to_string(),
+                            ty: pred.with_pred(self, range_ty).to_string(),
                             gen_kind: kind.to_string(),
                             span: self.expr_key_to_span(*range_expr_key),
                         },
@@ -1937,7 +1998,7 @@ impl Predicate {
                 if !cond_ty.is_bool() {
                     return Err(Error::Compile {
                         error: CompileError::NonBoolGeneratorCondition {
-                            ty: self.with_pred(cond_ty).to_string(),
+                            ty: pred.with_pred(self, cond_ty).to_string(),
                             gen_kind: kind.to_string(),
                             span: self.expr_key_to_span(*cond_expr_key),
                         },
@@ -1953,7 +2014,7 @@ impl Predicate {
             if !body_ty.is_bool() {
                 return Err(Error::Compile {
                     error: CompileError::NonBoolGeneratorBody {
-                        ty: self.with_pred(body_ty).to_string(),
+                        ty: pred.with_pred(self, body_ty).to_string(),
                         gen_kind: kind.to_string(),
                         span: self.expr_key_to_span(body_expr_key),
                     },
@@ -1975,66 +2036,60 @@ impl Predicate {
 
     // Confirm that all var init exprs and const init exprs match their declared type, if they have
     // one.
-    pub(super) fn check_inits(&mut self, handler: &Handler, consts: &FxHashMap<String, Const>) {
-        // Confirm types for all the variable initialisers first.
-        for (var_key, init_expr_key) in &self.var_inits {
-            let var_decl_ty = var_key.get_ty(self);
+    pub(super) fn check_inits(&self, handler: &Handler) {
+        for pred in self.preds.values() {
+            // Confirm types for all the variable initialisers first.
+            for (var_key, init_expr_key) in &pred.var_inits {
+                let var_decl_ty = var_key.get_ty(pred);
 
-            // Reporting an error that we're expecting 'Unknown' is not useful.
-            if !var_decl_ty.is_unknown() {
-                let init_ty = init_expr_key.get_ty(self);
+                // Reporting an error that we're expecting 'Unknown' is not useful.
+                if !var_decl_ty.is_unknown() {
+                    let init_ty = init_expr_key.get_ty(self);
 
-                if !var_decl_ty.eq(self, init_ty) {
-                    handler.emit_err(Error::Compile {
-                        error: CompileError::InitTypeError {
-                            init_kind: "variable",
-                            large_err: Box::new(LargeTypeError::InitTypeError {
+                    if !var_decl_ty.eq(pred, init_ty) {
+                        handler.emit_err(Error::Compile {
+                            error: CompileError::InitTypeError {
                                 init_kind: "variable",
-                                expected_ty: self.with_pred(var_decl_ty).to_string(),
-                                found_ty: self.with_pred(init_ty).to_string(),
-                                expected_ty_span: var_decl_ty.span().clone(),
-                                init_span: self.expr_key_to_span(*init_expr_key),
-                            }),
-                        },
-                    });
+                                large_err: Box::new(LargeTypeError::InitTypeError {
+                                    init_kind: "variable",
+                                    expected_ty: pred.with_pred(self, var_decl_ty).to_string(),
+                                    found_ty: pred.with_pred(self, init_ty).to_string(),
+                                    expected_ty_span: var_decl_ty.span().clone(),
+                                    init_span: self.expr_key_to_span(*init_expr_key),
+                                }),
+                            },
+                        });
+                    }
                 }
             }
         }
 
         // Now confirm that every const initialiser type matches the const decl type.
-        if self.is_root() {
-            for Const {
-                expr: init_expr_key,
-                decl_ty,
-                ..
-            } in consts.values()
-            {
-                let init_ty = init_expr_key.get_ty(self);
+        let root_pred = self.root_pred();
+        for Const {
+            expr: init_expr_key,
+            decl_ty,
+            ..
+        } in self.consts.values()
+        {
+            let init_ty = init_expr_key.get_ty(self);
 
-                // Special case for enum variants -- they'll have an init_ty of `int`.  So we have
-                // an error if the types mismatch and they're _not_ an enum/int combo exception.
-                if !(init_ty.eq(self, decl_ty) || decl_ty.is_enum(self) && init_ty.is_int()) {
-                    handler.emit_err(Error::Compile {
-                        error: CompileError::InitTypeError {
+            // Special case for enum variants -- they'll have an init_ty of `int`.  So we have
+            // an error if the types mismatch and they're _not_ an enum/int combo exception.
+            if !(init_ty.eq(root_pred, decl_ty) || decl_ty.is_enum(root_pred) && init_ty.is_int()) {
+                handler.emit_err(Error::Compile {
+                    error: CompileError::InitTypeError {
+                        init_kind: "const",
+                        large_err: Box::new(LargeTypeError::InitTypeError {
                             init_kind: "const",
-                            large_err: Box::new(LargeTypeError::InitTypeError {
-                                init_kind: "const",
-                                expected_ty: self.with_pred(decl_ty).to_string(),
-                                found_ty: self.with_pred(init_ty).to_string(),
-                                expected_ty_span: decl_ty.span().clone(),
-                                init_span: self.expr_key_to_span(*init_expr_key),
-                            }),
-                        },
-                    });
-                }
+                            expected_ty: root_pred.with_pred(self, decl_ty).to_string(),
+                            found_ty: root_pred.with_pred(self, init_ty).to_string(),
+                            expected_ty_span: decl_ty.span().clone(),
+                            init_span: self.expr_key_to_span(*init_expr_key),
+                        }),
+                    },
+                });
             }
         }
-    }
-
-    pub(super) fn expr_key_to_span(&self, expr_key: ExprKey) -> Span {
-        expr_key
-            .try_get(self)
-            .map(|expr| expr.span().clone())
-            .unwrap_or_else(empty_span)
     }
 }

--- a/pintc/src/predicate/exprs.rs
+++ b/pintc/src/predicate/exprs.rs
@@ -1,4 +1,4 @@
-use super::Predicate;
+use super::{Contract, Predicate};
 use crate::{expr::Expr, types::Type};
 use std::collections::HashSet;
 
@@ -49,97 +49,105 @@ impl Exprs {
 impl ExprKey {
     /// Returns an `Option` containing the `Expr` corresponding to key `self`. Returns `None` if
     /// the key can't be found in the `exprs` map.
-    pub fn try_get<'a>(&'a self, pred: &'a Predicate) -> Option<&Expr> {
-        pred.exprs.exprs.get(*self)
+    pub fn try_get<'a>(&'a self, contract: &'a Contract) -> Option<&Expr> {
+        contract.exprs.exprs.get(*self)
     }
 
     /// Returns the `Expr` corresponding to key `self`. Panics if the key can't be found in the
     /// `exprs` map.
-    pub fn get<'a>(&'a self, pred: &'a Predicate) -> &Expr {
-        pred.exprs.exprs.get(*self).unwrap()
+    pub fn get<'a>(&'a self, contract: &'a Contract) -> &Expr {
+        contract.exprs.exprs.get(*self).unwrap()
     }
 
     /// Returns a mutable reference to the `Expr` corresponding to key `self`. Panics if the key
     /// can't be found in the `exprs` map.
-    pub fn get_mut<'a>(&'a self, pred: &'a mut Predicate) -> &mut Expr {
-        pred.exprs.exprs.get_mut(*self).unwrap()
+    pub fn get_mut<'a>(&'a self, contract: &'a mut Contract) -> &mut Expr {
+        contract.exprs.exprs.get_mut(*self).unwrap()
     }
 
     /// Returns the type of key `self` given an `Predicate`. Panics if the type can't be
     /// found in the `expr_types` map.
-    pub fn get_ty<'a>(&'a self, pred: &'a Predicate) -> &Type {
-        pred.exprs.expr_types.get(*self).unwrap()
+    pub fn get_ty<'a>(&'a self, contract: &'a Contract) -> &Type {
+        contract.exprs.expr_types.get(*self).unwrap()
     }
 
     /// Set the type of key `self` in an `Predicate`. Panics if the type can't be found in
     /// the `expr_types` map.
-    pub fn set_ty<'a>(&'a self, ty: Type, pred: &'a mut Predicate) {
-        pred.exprs.expr_types.insert(*self, ty);
+    pub fn set_ty<'a>(&'a self, ty: Type, contract: &'a mut Contract) {
+        contract.exprs.expr_types.insert(*self, ty);
     }
 
     /// Return whether this expression can panic (typically related to storage).
-    pub fn can_panic(&self, pred: &Predicate) -> bool {
-        pred.exprs
-            .exprs
-            .get(*self)
-            .map_or(false, |expr| match expr {
-                Expr::StorageAccess(_, _) | Expr::ExternalStorageAccess { .. } => true,
+    pub fn can_panic(&self, contract: &Contract, pred: &Predicate) -> bool {
+        contract.exprs.get(*self).map_or(false, |expr| match expr {
+            Expr::StorageAccess(_, _) | Expr::ExternalStorageAccess { .. } => true,
 
-                Expr::PathByName(path, _) => pred.states().any(|(_, state)| &state.name == path),
+            Expr::PathByName(path, _) => pred.states().any(|(_, state)| &state.name == path),
 
-                Expr::Error(_)
-                | Expr::Immediate { .. }
-                | Expr::PathByKey(_, _)
-                | Expr::MacroCall { .. } => false,
+            Expr::Error(_)
+            | Expr::Immediate { .. }
+            | Expr::PathByKey(_, _)
+            | Expr::MacroCall { .. } => false,
 
-                Expr::Array {
-                    elements,
-                    range_expr,
-                    ..
-                } => elements.iter().any(|el| el.can_panic(pred)) || range_expr.can_panic(pred),
+            Expr::Array {
+                elements,
+                range_expr,
+                ..
+            } => {
+                elements.iter().any(|el| el.can_panic(contract, pred))
+                    || range_expr.can_panic(contract, pred)
+            }
 
-                Expr::Tuple { fields, .. } => fields.iter().any(|fld| fld.1.can_panic(pred)),
+            Expr::Tuple { fields, .. } => fields.iter().any(|fld| fld.1.can_panic(contract, pred)),
 
-                Expr::UnaryOp { expr, .. } => expr.can_panic(pred),
+            Expr::UnaryOp { expr, .. } => expr.can_panic(contract, pred),
 
-                Expr::BinaryOp { lhs, rhs, .. } => lhs.can_panic(pred) || rhs.can_panic(pred),
+            Expr::BinaryOp { lhs, rhs, .. } => {
+                lhs.can_panic(contract, pred) || rhs.can_panic(contract, pred)
+            }
 
-                Expr::IntrinsicCall { args, .. } => args.iter().any(|arg| arg.can_panic(pred)),
+            Expr::IntrinsicCall { args, .. } => {
+                args.iter().any(|arg| arg.can_panic(contract, pred))
+            }
 
-                Expr::Select {
-                    condition,
-                    then_expr,
-                    else_expr,
-                    ..
-                } => {
-                    condition.can_panic(pred)
-                        || then_expr.can_panic(pred)
-                        || else_expr.can_panic(pred)
-                }
+            Expr::Select {
+                condition,
+                then_expr,
+                else_expr,
+                ..
+            } => {
+                condition.can_panic(contract, pred)
+                    || then_expr.can_panic(contract, pred)
+                    || else_expr.can_panic(contract, pred)
+            }
 
-                Expr::Index { expr, index, .. } => expr.can_panic(pred) || index.can_panic(pred),
+            Expr::Index { expr, index, .. } => {
+                expr.can_panic(contract, pred) || index.can_panic(contract, pred)
+            }
 
-                Expr::TupleFieldAccess { tuple, .. } => tuple.can_panic(pred),
+            Expr::TupleFieldAccess { tuple, .. } => tuple.can_panic(contract, pred),
 
-                Expr::Cast { value, .. } => value.can_panic(pred),
+            Expr::Cast { value, .. } => value.can_panic(contract, pred),
 
-                Expr::In {
-                    value, collection, ..
-                } => value.can_panic(pred) || collection.can_panic(pred),
+            Expr::In {
+                value, collection, ..
+            } => value.can_panic(contract, pred) || collection.can_panic(contract, pred),
 
-                Expr::Range { lb, ub, .. } => lb.can_panic(pred) || ub.can_panic(pred),
+            Expr::Range { lb, ub, .. } => {
+                lb.can_panic(contract, pred) || ub.can_panic(contract, pred)
+            }
 
-                Expr::Generator {
-                    gen_ranges,
-                    conditions,
-                    body,
-                    ..
-                } => {
-                    gen_ranges.iter().any(|rng| rng.1.can_panic(pred))
-                        || conditions.iter().any(|cond| cond.can_panic(pred))
-                        || body.can_panic(pred)
-                }
-            })
+            Expr::Generator {
+                gen_ranges,
+                conditions,
+                body,
+                ..
+            } => {
+                gen_ranges.iter().any(|rng| rng.1.can_panic(contract, pred))
+                    || conditions.iter().any(|cond| cond.can_panic(contract, pred))
+                    || body.can_panic(contract, pred)
+            }
+        })
     }
 }
 
@@ -154,18 +162,18 @@ impl ExprKey {
 
 #[derive(Debug)]
 pub(crate) struct ExprsIter<'a> {
-    pred: &'a Predicate,
+    contract: &'a Contract,
     queue: Vec<ExprKey>,
     visited: HashSet<ExprKey>,
 }
 
 impl<'a> ExprsIter<'a> {
-    pub(super) fn new(pred: &'a Predicate) -> ExprsIter {
+    pub(super) fn new(contract: &'a Contract, pred: &Predicate) -> ExprsIter<'a> {
         // We start with all the constraint and state exprs.
         let queue = pred.root_set().collect();
 
         ExprsIter {
-            pred,
+            contract,
             queue,
             visited: HashSet::default(),
         }
@@ -194,12 +202,12 @@ impl<'a> Iterator for ExprsIter<'a> {
 
         // Keep macro calls that do not return as expressions but used as expressions. We should
         // error out early when we find these anyways, but we'll do it in type checking.
-        if self.pred.removed_macro_calls.get(next_key).is_some() {
+        if self.contract.removed_macro_calls.get(next_key).is_some() {
             return Some(next_key);
         }
 
         // Push its children to the queue.
-        match next_key.get(self.pred) {
+        match next_key.get(self.contract) {
             Expr::Immediate { .. } => {}
 
             Expr::Array {
@@ -291,7 +299,7 @@ impl<'a> Iterator for ExprsIter<'a> {
 
         // If it has an array type then it also has an associated expr in the range.
         next_key
-            .get_ty(self.pred)
+            .get_ty(self.contract)
             .get_array_range_expr()
             .iter()
             .for_each(|range| queue_if_new!(self, range));

--- a/pintc/src/predicate/states.rs
+++ b/pintc/src/predicate/states.rs
@@ -1,4 +1,4 @@
-use super::{DisplayWithPred, ExprKey, Ident, Predicate};
+use super::{Contract, DisplayWithPred, ExprKey, Ident, Predicate};
 use crate::{
     error::{ErrorEmitted, Handler},
     span::Span,
@@ -99,14 +99,14 @@ impl StateKey {
 }
 
 impl DisplayWithPred for StateKey {
-    fn fmt(&self, f: &mut Formatter, pred: &Predicate) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> fmt::Result {
         let state = &self.get(pred);
         write!(f, "state {}", state.name)?;
         let ty = self.get_ty(pred);
         if !ty.is_unknown() {
-            write!(f, ": {}", pred.with_pred(ty))?;
+            write!(f, ": {}", pred.with_pred(contract, ty))?;
         }
-        write!(f, " = {}", pred.with_pred(&state.expr))
+        write!(f, " = {}", pred.with_pred(contract, &state.expr))
     }
 }
 

--- a/pintc/src/predicate/transform.rs
+++ b/pintc/src/predicate/transform.rs
@@ -2,10 +2,7 @@ mod lower;
 mod unroll;
 mod validate;
 
-use crate::{
-    error::{ErrorEmitted, Handler},
-    predicate::Const,
-};
+use crate::error::{ErrorEmitted, Handler};
 use lower::{
     coalesce_prime_ops, lower_aliases, lower_casts, lower_compares_to_nil, lower_enums, lower_ifs,
     lower_imm_accesses, lower_ins, replace_const_refs,
@@ -15,64 +12,49 @@ use validate::validate;
 
 impl super::Contract {
     pub fn flatten(mut self, handler: &Handler) -> Result<Self, ErrorEmitted> {
-        // Copy the const expressions themselves out of the root Pred.  This is to avoid the need to
-        // borrow them below for replace_const_refs().
-        let const_exprs = self
-            .consts
-            .iter()
-            .map(|(path, Const { expr, decl_ty })| {
-                (
-                    path.clone(),
-                    *expr,
-                    expr.get(self.root_pred()).clone(),
-                    decl_ty.clone(),
-                )
-            })
-            .collect::<Vec<_>>();
+        // Transform each `if` declaration into a collection of constraints. We do this early so
+        // that we don't have to worry about `if` declarations in any of the later passes. All
+        // other passes are safe to assume that `if` declarations and their content have
+        // already been converted to raw constraints.
+        lower_ifs(&mut self);
 
-        for pred in self.preds.values_mut() {
-            // Transform each if declaration into a collection of constraints. We do this early so
-            // that we don't have to worry about `if` declarations in any of the later passes. All
-            // other passes are safe to assume that `if` declarations and their content have
-            // already been converted to raw constraints.
-            lower_ifs(pred);
+        // Plug const decls in everywhere so they maybe lowered below.
+        replace_const_refs(&mut self);
 
-            // Plug const decls in everywhere so they maybe lowered below.
-            replace_const_refs(pred, &const_exprs);
+        // Convert comparisons to `nil` into comparisons between __state_len() and 0.
+        lower_compares_to_nil(&mut self);
 
-            // Convert comparisons to `nil` into comparisons between __state_len() and 0.
-            let _ = lower_compares_to_nil(handler, pred);
+        // Unroll each generator into one large conjuction
+        let _ = handler.scope(|handler| unroll_generators(handler, &mut self));
 
-            // Unroll each generator into one large conjuction
-            let _ = handler.scope(|handler| unroll_generators(handler, pred));
+        // Lower `in` expressions into more explicit comparisons.
+        let _ = lower_ins(handler, &mut self);
 
-            // Lower `in` expressions into more explicit comparisons.
-            let _ = lower_ins(handler, pred);
-
-            // Do some array checks now that generators have been unrolled (and ephemerals aren't
-            // going to cause problems).
-            pred.check_array_lengths(handler);
-            pred.check_array_indexing(handler);
-            pred.check_array_compares(handler);
-
-            // Transform each enum variant into its integer discriminant
-            let _ = lower_enums(handler, pred);
-
-            // Lower indexing or field access into immediates to the actual element or field.
-            let _ = lower_imm_accesses(handler, pred);
-
-            // Coalesce all prime ops back down to the lowest path expression.
-            coalesce_prime_ops(pred);
-
-            // This could be done straight after type checking but any error which prints the
-            // type until now will have the more informative aliased description.  e.g.,
-            // `Height (int)` rather than just `int`.
-            lower_aliases(pred);
-
-            // Lower casts after aliases since we're leaving `int -> real` behind, but it's
-            // much easier if the `real` isn't still an alias.
-            let _ = lower_casts(handler, pred);
+        // Do some array checks now that generators have been unrolled (and ephemerals aren't
+        // going to cause problems).
+        for pred in self.preds.values() {
+            pred.check_array_lengths(&self, handler);
+            pred.check_array_indexing(&self, handler);
+            pred.check_array_compares(&self, handler);
         }
+
+        // Transform each enum variant into its integer discriminant
+        let _ = lower_enums(handler, &mut self);
+
+        // Lower indexing or field access into immediates to the actual element or field.
+        let _ = lower_imm_accesses(handler, &mut self);
+
+        // Coalesce all prime ops back down to the lowest path expression.
+        coalesce_prime_ops(&mut self);
+
+        // This could be done straight after type checking but any error which prints the
+        // type until now will have the more informative aliased description.  e.g.,
+        // `Height (int)` rather than just `int`.
+        lower_aliases(&mut self);
+
+        // Lower casts after aliases since we're leaving `int -> real` behind, but it's
+        // much easier if the `real` isn't still an alias.
+        let _ = lower_casts(handler, &mut self);
 
         // Ensure that the final contract is indeed final
         if !handler.has_errors() {

--- a/pintc/src/predicate/transform/lower.rs
+++ b/pintc/src/predicate/transform/lower.rs
@@ -1,319 +1,355 @@
 use crate::{
     error::{CompileError, Error, ErrorEmitted, Handler},
     expr::{evaluate::Evaluator, BinaryOp, Expr, Ident, Immediate, TupleAccess, UnaryOp},
-    predicate::{BlockStatement, ConstraintDecl, ExprKey, IfDecl, Predicate, StorageVar},
+    predicate::{BlockStatement, Const, ConstraintDecl, Contract, ExprKey, IfDecl, StorageVar},
     span::{empty_span, Spanned},
     types::{EnumDecl, NewTypeDecl, PrimitiveKind, Type},
 };
 
 use fxhash::FxHashMap;
 
-pub(crate) fn lower_enums(handler: &Handler, pred: &mut Predicate) -> Result<(), ErrorEmitted> {
-    // Each enum has its variants indexed from 0.  Gather all the enum declarations and create a
-    // map from path to integer index.
-    let mut variant_map = FxHashMap::default();
-    let mut variant_count_map = FxHashMap::default();
-    let mut add_variants = |e: &EnumDecl, name: &String| {
-        for (i, v) in e.variants.iter().enumerate() {
-            let full_path = name.clone() + "::" + v.name.as_str();
-            variant_map.insert(full_path, i);
-        }
-        variant_count_map.insert(e.name.name.clone(), e.variants.len());
-    };
-    for e in &pred.enums {
-        // Add all variants for the enum.
-        add_variants(e, &e.name.name);
+pub(crate) fn lower_enums(handler: &Handler, contract: &mut Contract) -> Result<(), ErrorEmitted> {
+    for pred_name in contract.preds.keys().cloned().collect::<Vec<_>>() {
+        // Each enum has its variants indexed from 0.  Gather all the enum declarations and create a
+        // map from path to integer index.
+        let mut variant_map = FxHashMap::default();
+        let mut variant_count_map = FxHashMap::default();
 
-        // We need to do exactly the same for any newtypes which are aliasing this enum.
-        if let Some(alias_name) =
-            pred.new_types
-                .iter()
-                .find_map(|NewTypeDecl { name, ty, .. }| {
-                    (ty.get_enum_name(pred) == Some(&e.name.name)).then_some(&name.name)
-                })
-        {
-            add_variants(e, alias_name);
-        }
-    }
+        let mut enum_replacements = Vec::default();
+        let mut variant_replacements = Vec::default();
+        let mut enum_var_keys = Vec::default();
 
-    // Find all the expressions referring to the variants and save them in a list.
-    let mut variant_replacements = Vec::default();
-    let mut enum_replacements = Vec::default();
-    for old_expr_key in pred.exprs() {
-        if let Some(Expr::PathByName(path, _span)) = old_expr_key.try_get(pred) {
-            if let Some(idx) = variant_map.get(path) {
-                variant_replacements.push((old_expr_key, idx));
-            }
-            if let Some(count) = variant_count_map.get(path) {
-                enum_replacements.push((old_expr_key, *count));
-            }
-        }
-    }
-
-    let int_ty = Type::Primitive {
-        kind: PrimitiveKind::Int,
-        span: empty_span(),
-    };
-
-    let bool_ty = Type::Primitive {
-        kind: PrimitiveKind::Bool,
-        span: empty_span(),
-    };
-
-    // Replace the variant expressions with literal int equivalents.
-    for (old_expr_key, idx) in variant_replacements {
-        let new_expr_key = pred.exprs.insert(
-            Expr::Immediate {
-                value: Immediate::Int(*idx as i64),
-                span: empty_span(),
-            },
-            int_ty.clone(),
-        );
-        pred.replace_exprs(old_expr_key, new_expr_key);
-    }
-
-    // Replace any var or state enum type with int.  Also add constraints to disallow vars or state
-    // to have values outside of the enum.
-    for var_key in pred
-        .vars()
-        .map(|(var_key, _)| var_key)
-        .filter(|var_key| var_key.get_ty(pred).is_enum(pred))
-        .collect::<Vec<_>>()
-    {
-        // Add the constraint.  Get the variant max for this enum first.
-        let enum_ty = var_key.get_ty(pred).clone();
-        let variant_max = match variant_count_map.get(enum_ty.get_enum_name(pred).unwrap()) {
-            Some(c) => *c as i64 - 1,
-            None => {
-                return Err(handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "unable to get enum variant count",
-                        span: empty_span(),
-                    },
-                }))
-            }
+        let int_ty = Type::Primitive {
+            kind: PrimitiveKind::Int,
+            span: empty_span(),
         };
 
-        let var_expr_key = pred
-            .exprs
-            .insert(Expr::PathByKey(var_key, empty_span()), int_ty.clone());
-
-        let lower_bound_key = pred.exprs.insert(
-            Expr::Immediate {
-                value: Immediate::Int(0),
-                span: empty_span(),
-            },
-            int_ty.clone(),
-        );
-
-        let upper_bound_key = pred.exprs.insert(
-            Expr::Immediate {
-                value: Immediate::Int(variant_max),
-                span: empty_span(),
-            },
-            int_ty.clone(),
-        );
-
-        let lower_bound_cmp_key = pred.exprs.insert(
-            Expr::BinaryOp {
-                op: BinaryOp::GreaterThanOrEqual,
-                lhs: var_expr_key,
-                rhs: lower_bound_key,
-                span: empty_span(),
-            },
-            bool_ty.clone(),
-        );
-
-        let upper_bound_cmp_key = pred.exprs.insert(
-            Expr::BinaryOp {
-                op: BinaryOp::LessThanOrEqual,
-                lhs: var_expr_key,
-                rhs: upper_bound_key,
-                span: empty_span(),
-            },
-            bool_ty.clone(),
-        );
-
-        pred.constraints.push(ConstraintDecl {
-            expr: lower_bound_cmp_key,
+        let bool_ty = Type::Primitive {
+            kind: PrimitiveKind::Bool,
             span: empty_span(),
-        });
-        pred.constraints.push(ConstraintDecl {
-            expr: upper_bound_cmp_key,
-            span: empty_span(),
-        });
+        };
 
-        // Replace the type.
-        let exprs_with_enum_ty = pred
-            .exprs()
-            .filter(|expr_key| expr_key.get_ty(pred).eq(pred, &enum_ty))
-            .collect::<Vec<_>>();
-        for enum_expr_key in exprs_with_enum_ty {
-            enum_expr_key.set_ty(int_ty.clone(), pred);
-        }
-    }
+        let pred = contract.preds.get(&pred_name).unwrap();
 
-    // Now do the actual type update from enum to int
-    let vars_with_enum_ty = pred
-        .vars()
-        .filter_map(|(var_key, _)| (var_key.get_ty(pred).is_enum(pred)).then_some(var_key))
-        .collect::<Vec<_>>();
-    for enum_var_key in vars_with_enum_ty {
-        enum_var_key.set_ty(int_ty.clone(), pred);
-    }
-
-    // Array types can use enums as the range.  Recursively replace a range known to be an enum
-    // with an immediate integer equivalent.
-    fn replace_array_range(enum_expr_map: &FxHashMap<ExprKey, ExprKey>, ty: &mut Type) {
-        if let Type::Array {
-            ty: el_ty,
-            range: Some(range_key),
-            ..
-        } = ty
-        {
-            // If the range for this array is an enum (i.e., we found it in our map) then replace
-            // it with an immediate int.
-            if let Some(count_expr_key) = enum_expr_map.get(range_key) {
-                *range_key = *count_expr_key;
+        let mut add_variants = |e: &EnumDecl, name: &String| {
+            for (i, v) in e.variants.iter().enumerate() {
+                let full_path = name.clone() + "::" + v.name.as_str();
+                variant_map.insert(full_path, i);
             }
+            variant_count_map.insert(e.name.name.clone(), e.variants.len());
+        };
 
-            // Recurse for multi-dimensional arrays.
-            replace_array_range(enum_expr_map, el_ty);
+        for e in &pred.enums {
+            // Add all variants for the enum.
+            add_variants(e, &e.name.name);
+
+            // We need to do exactly the same for any newtypes which are aliasing this enum.
+            if let Some(alias_name) =
+                pred.new_types
+                    .iter()
+                    .find_map(|NewTypeDecl { name, ty, .. }| {
+                        (ty.get_enum_name(pred) == Some(&e.name.name)).then_some(&name.name)
+                    })
+            {
+                add_variants(e, alias_name);
+            }
         }
-    }
 
-    // Build a map from expr-key-of-path-to-enum to immediate-int-of-variant-count.
-    let enum_count_exprs =
-        FxHashMap::from_iter(enum_replacements.into_iter().map(|(expr_key, count)| {
-            let imm_expr_key = pred.exprs.insert(
+        // Find all the expressions referring to the variants and save them in a list.
+        for old_expr_key in contract.exprs(pred) {
+            if let Some(Expr::PathByName(path, _span)) = old_expr_key.try_get(contract) {
+                if let Some(idx) = variant_map.get(path) {
+                    variant_replacements.push((old_expr_key, idx));
+                }
+                if let Some(count) = variant_count_map.get(path) {
+                    enum_replacements.push((old_expr_key, *count));
+                }
+            }
+        }
+
+        // Gather all vars which have an enum type, along with that enum type and the variant
+        // count.  Clippy says .filter(..).map(..) is cleaner than .filter_map(.. bool.then(..)).
+        enum_var_keys.extend(
+            pred.vars()
+                .filter(|(var_key, _)| var_key.get_ty(pred).is_enum(pred))
+                .map(|(var_key, _)| {
+                    let enum_ty = var_key.get_ty(pred).clone();
+                    let variant_count = variant_count_map.get(enum_ty.get_enum_name(pred).unwrap());
+                    (var_key, enum_ty, variant_count)
+                }),
+        );
+
+        // Not sure at this stage if we'll ever allow state to be an enum.
+        for (state_key, _) in pred.states() {
+            if state_key.get_ty(pred).is_enum(pred) {
+                return Err(handler.emit_err(Error::Compile {
+                    error: CompileError::Internal {
+                        msg: "found state with an enum type",
+                        span: empty_span(),
+                    },
+                }));
+            }
+        }
+
+        // Replace the variant expressions with literal int equivalents.
+        for (old_expr_key, idx) in variant_replacements {
+            let new_expr_key = contract.exprs.insert(
                 Expr::Immediate {
-                    value: Immediate::Int(count as i64),
+                    value: Immediate::Int(*idx as i64),
                     span: empty_span(),
                 },
                 int_ty.clone(),
             );
-            (expr_key, imm_expr_key)
-        }));
+            contract.replace_exprs(&pred_name, old_expr_key, new_expr_key);
+        }
 
-    // Update all the array types.
-    pred.vars
-        .update_types(|_var_key, ty| replace_array_range(&enum_count_exprs, ty));
-    pred.exprs
-        .update_types(|_expr_key, ty| replace_array_range(&enum_count_exprs, ty));
+        // Replace any var or state enum type with int.  Also add constraints to disallow vars or state
+        // to have values outside of the enum.
+        for (var_key, enum_ty, variant_count) in &enum_var_keys {
+            // Add the constraint.  Get the variant max for this enum first.
+            let variant_max = match variant_count {
+                Some(c) => **c as i64 - 1,
+                None => {
+                    return Err(handler.emit_err(Error::Compile {
+                        error: CompileError::Internal {
+                            msg: "unable to get enum variant count",
+                            span: empty_span(),
+                        },
+                    }))
+                }
+            };
 
-    // Not sure at this stage if we'll ever allow state to be an enum.
-    for (state_key, _) in pred.states() {
-        if state_key.get_ty(pred).is_enum(pred) {
-            return Err(handler.emit_err(Error::Compile {
-                error: CompileError::Internal {
-                    msg: "found state with an enum type",
+            let var_expr_key = contract
+                .exprs
+                .insert(Expr::PathByKey(*var_key, empty_span()), int_ty.clone());
+
+            let lower_bound_key = contract.exprs.insert(
+                Expr::Immediate {
+                    value: Immediate::Int(0),
                     span: empty_span(),
                 },
-            }));
-        }
-    }
+                int_ty.clone(),
+            );
 
-    Ok(())
-}
+            let upper_bound_key = contract.exprs.insert(
+                Expr::Immediate {
+                    value: Immediate::Int(variant_max),
+                    span: empty_span(),
+                },
+                int_ty.clone(),
+            );
 
-pub(crate) fn lower_casts(handler: &Handler, pred: &mut Predicate) -> Result<(), ErrorEmitted> {
-    let mut replacements = Vec::new();
+            let lower_bound_cmp_key = contract.exprs.insert(
+                Expr::BinaryOp {
+                    op: BinaryOp::GreaterThanOrEqual,
+                    lhs: var_expr_key,
+                    rhs: lower_bound_key,
+                    span: empty_span(),
+                },
+                bool_ty.clone(),
+            );
 
-    for old_expr_key in pred.exprs() {
-        if let Some(Expr::Cast {
-            value,
-            ty: to_ty,
-            span,
-        }) = old_expr_key.try_get(pred)
-        {
-            let from_ty = value.get_ty(pred);
-            if from_ty.is_unknown() {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "expression type is `Unknown` while lowering casts",
-                        span: span.clone(),
-                    },
+            let upper_bound_cmp_key = contract.exprs.insert(
+                Expr::BinaryOp {
+                    op: BinaryOp::LessThanOrEqual,
+                    lhs: var_expr_key,
+                    rhs: upper_bound_key,
+                    span: empty_span(),
+                },
+                bool_ty.clone(),
+            );
+
+            if let Some(pred) = contract.preds.get_mut(&pred_name) {
+                pred.constraints.push(ConstraintDecl {
+                    expr: lower_bound_cmp_key,
+                    span: empty_span(),
                 });
-            }
+                pred.constraints.push(ConstraintDecl {
+                    expr: upper_bound_cmp_key,
+                    span: empty_span(),
+                });
+            };
 
-            // The type checker will have already rejected bad cast types.
-            if !(from_ty.is_int() && to_ty.is_real()) {
-                replacements.push((old_expr_key, *value));
+            // Replace the type.
+            let exprs_with_enum_ty = contract
+                .exprs_for_pred_name(&pred_name)
+                .filter(|expr_key| {
+                    expr_key
+                        .get_ty(contract)
+                        .eq(contract.preds.get(&pred_name).unwrap(), enum_ty)
+                })
+                .collect::<Vec<_>>();
+
+            for enum_expr_key in exprs_with_enum_ty {
+                enum_expr_key.set_ty(int_ty.clone(), contract);
             }
         }
-    }
 
-    for (old_expr_key, new_expr_key) in replacements {
-        pred.replace_exprs(old_expr_key, new_expr_key);
+        // Now do the actual type update from enum to int
+        for (enum_var_key, _, _) in enum_var_keys {
+            enum_var_key.set_ty(int_ty.clone(), contract.preds.get_mut(&pred_name).unwrap());
+        }
+
+        // Array types can use enums as the range.  Recursively replace a range known to be an enum
+        // with an immediate integer equivalent.
+        fn replace_array_range(enum_expr_map: &FxHashMap<ExprKey, ExprKey>, ty: &mut Type) {
+            if let Type::Array {
+                ty: el_ty,
+                range: Some(range_key),
+                ..
+            } = ty
+            {
+                // If the range for this array is an enum (i.e., we found it in our map) then replace
+                // it with an immediate int.
+                if let Some(count_expr_key) = enum_expr_map.get(range_key) {
+                    *range_key = *count_expr_key;
+                }
+
+                // Recurse for multi-dimensional arrays.
+                replace_array_range(enum_expr_map, el_ty);
+            }
+        }
+
+        // Build a map from expr-key-of-path-to-enum to immediate-int-of-variant-count.
+        let enum_count_exprs =
+            FxHashMap::from_iter(enum_replacements.into_iter().map(|(expr_key, count)| {
+                let imm_expr_key = contract.exprs.insert(
+                    Expr::Immediate {
+                        value: Immediate::Int(count as i64),
+                        span: empty_span(),
+                    },
+                    int_ty.clone(),
+                );
+                (expr_key, imm_expr_key)
+            }));
+
+        // Update all the array types.
+        contract
+            .preds
+            .get_mut(&pred_name)
+            .unwrap()
+            .vars
+            .update_types(|_var_key, ty| replace_array_range(&enum_count_exprs, ty));
+        contract
+            .exprs
+            .update_types(|_expr_key, ty| replace_array_range(&enum_count_exprs, ty));
     }
 
     Ok(())
 }
 
-pub(crate) fn lower_aliases(pred: &mut Predicate) {
-    use std::borrow::BorrowMut;
+pub(crate) fn lower_casts(handler: &Handler, contract: &mut Contract) -> Result<(), ErrorEmitted> {
+    for pred_name in contract.preds.keys().cloned().collect::<Vec<_>>() {
+        let mut replacements = Vec::new();
 
-    let new_types = FxHashMap::from_iter(
-        pred.new_types
-            .iter()
-            .map(|NewTypeDecl { name, ty, .. }| (name.name.clone(), ty.clone())),
-    );
+        for old_expr_key in contract.exprs_for_pred_name(&pred_name) {
+            if let Some(Expr::Cast {
+                value,
+                ty: to_ty,
+                span,
+            }) = old_expr_key.try_get(contract)
+            {
+                let from_ty = value.get_ty(contract);
+                if from_ty.is_unknown() {
+                    handler.emit_err(Error::Compile {
+                        error: CompileError::Internal {
+                            msg: "expression type is `Unknown` while lowering casts",
+                            span: span.clone(),
+                        },
+                    });
+                }
 
-    fn replace_alias(new_types_map: &FxHashMap<String, Type>, old_ty: &mut Type) {
-        match old_ty {
-            Type::Alias { ty, .. } => {
-                *old_ty = *ty.clone();
-            }
-
-            Type::Custom { path, .. } => {
-                if let Some(ty) = new_types_map.get(path) {
-                    *old_ty = ty.clone();
+                // The type checker will have already rejected bad cast types.
+                if !(from_ty.is_int() && to_ty.is_real()) {
+                    replacements.push((old_expr_key, *value));
                 }
             }
+        }
 
-            Type::Array { ty, .. } => replace_alias(new_types_map, ty),
-            Type::Tuple { fields, .. } => fields
-                .iter_mut()
-                .for_each(|(_, ty)| replace_alias(new_types_map, ty)),
-            Type::Map { ty_from, ty_to, .. } => {
-                replace_alias(new_types_map, ty_from);
-                replace_alias(new_types_map, ty_to);
-            }
-
-            Type::Error(_) | Type::Unknown(_) | Type::Primitive { .. } => {}
+        for (old_expr_key, new_expr_key) in replacements {
+            contract.replace_exprs(&pred_name, old_expr_key, new_expr_key);
         }
     }
 
-    // Replace aliases with the actual type.
-    pred.vars
-        .update_types(|_, var_ty| replace_alias(&new_types, var_ty));
-    pred.states
-        .update_types(|_, state_ty| replace_alias(&new_types, state_ty));
-    pred.exprs
-        .update_types(|_, expr_ty| replace_alias(&new_types, expr_ty));
+    Ok(())
+}
 
-    pred.exprs.update_exprs(|_, expr| {
-        if let Expr::Cast { ty, .. } = expr {
-            replace_alias(&new_types, ty.borrow_mut());
-        }
-    });
+pub(crate) fn lower_aliases(contract: &mut Contract) {
+    use std::borrow::BorrowMut;
 
-    if let Some((storage_vars, _)) = &mut pred.storage {
-        for StorageVar { ty, .. } in storage_vars {
-            replace_alias(&new_types, ty);
+    for pred_name in contract.preds.keys().cloned().collect::<Vec<_>>() {
+        let new_types = FxHashMap::from_iter(
+            contract
+                .preds
+                .get(&pred_name)
+                .unwrap()
+                .new_types
+                .iter()
+                .map(|NewTypeDecl { name, ty, .. }| (name.name.clone(), ty.clone())),
+        );
+
+        fn replace_alias(new_types_map: &FxHashMap<String, Type>, old_ty: &mut Type) {
+            match old_ty {
+                Type::Alias { ty, .. } => {
+                    *old_ty = *ty.clone();
+                }
+
+                Type::Custom { path, .. } => {
+                    if let Some(ty) = new_types_map.get(path) {
+                        *old_ty = ty.clone();
+                    }
+                }
+
+                Type::Array { ty, .. } => replace_alias(new_types_map, ty),
+                Type::Tuple { fields, .. } => fields
+                    .iter_mut()
+                    .for_each(|(_, ty)| replace_alias(new_types_map, ty)),
+                Type::Map { ty_from, ty_to, .. } => {
+                    replace_alias(new_types_map, ty_from);
+                    replace_alias(new_types_map, ty_to);
+                }
+
+                Type::Error(_) | Type::Unknown(_) | Type::Primitive { .. } => {}
+            }
         }
+
+        // Replace aliases with the actual type.
+        if let Some(pred) = contract.preds.get_mut(&pred_name) {
+            pred.vars
+                .update_types(|_, var_ty| replace_alias(&new_types, var_ty));
+            pred.states
+                .update_types(|_, state_ty| replace_alias(&new_types, state_ty));
+
+            if let Some((storage_vars, _)) = &mut pred.storage {
+                for StorageVar { ty, .. } in storage_vars {
+                    replace_alias(&new_types, ty);
+                }
+            }
+        };
+
+        contract
+            .exprs
+            .update_types(|_, expr_ty| replace_alias(&new_types, expr_ty));
+
+        contract.exprs.update_exprs(|_, expr| {
+            if let Expr::Cast { ty, .. } = expr {
+                replace_alias(&new_types, ty.borrow_mut());
+            }
+        });
     }
 }
 
 pub(crate) fn lower_imm_accesses(
     handler: &Handler,
-    pred: &mut Predicate,
+    contract: &mut Contract,
 ) -> Result<(), ErrorEmitted> {
-    let mut replace_direct_accesses = || {
-        let candidates = pred
-            .exprs()
-            .filter_map(|expr_key| match expr_key.get(pred) {
-                Expr::Index { expr, index, .. } => expr.try_get(pred).and_then(|array_expr| {
+    let pred_names = contract.preds.keys().cloned().collect::<Vec<_>>();
+
+    let mut replace_direct_accesses = |pred_name: &str| {
+        let candidates = contract
+            .exprs_for_pred_name(pred_name)
+            .filter_map(|expr_key| match expr_key.get(contract) {
+                Expr::Index { expr, index, .. } => expr.try_get(contract).and_then(|array_expr| {
                     let is_array_expr = matches!(array_expr, Expr::Array { .. });
                     let is_array_imm = matches!(
                         array_expr,
@@ -331,7 +367,7 @@ pub(crate) fn lower_imm_accesses(
                 }),
 
                 Expr::TupleFieldAccess { tuple, field, .. } => {
-                    tuple.try_get(pred).and_then(|tuple_expr| {
+                    tuple.try_get(contract).and_then(|tuple_expr| {
                         let is_tuple_expr = matches!(tuple_expr, Expr::Tuple { .. });
                         let is_tuple_imm = matches!(
                             tuple_expr,
@@ -350,7 +386,7 @@ pub(crate) fn lower_imm_accesses(
             })
             .collect::<Vec<_>>();
 
-        let evaluator = Evaluator::new(pred);
+        let evaluator = Evaluator::new(contract.preds.get(pred_name).unwrap());
         let mut replacements = Vec::new();
         for (old_expr_key, array_idx, field_idx) in candidates {
             assert!(
@@ -360,7 +396,7 @@ pub(crate) fn lower_imm_accesses(
 
             if let Some((array_key, array_idx_key)) = array_idx {
                 // We have an array access into an immediate.  Evaluate the index.
-                let Some(idx_expr) = array_idx_key.try_get(pred) else {
+                let Some(idx_expr) = array_idx_key.try_get(contract) else {
                     return Err(handler.emit_err(Error::Compile {
                         error: CompileError::Internal {
                             msg: "missing array index expression in lower_imm_accesses()",
@@ -369,9 +405,9 @@ pub(crate) fn lower_imm_accesses(
                     }));
                 };
 
-                match evaluator.evaluate(idx_expr, handler, pred) {
+                match evaluator.evaluate(idx_expr, handler, contract, pred_name) {
                     Ok(Immediate::Int(idx_val)) if idx_val >= 0 => {
-                        match array_key.try_get(pred) {
+                        match array_key.try_get(contract) {
                             Some(Expr::Array { elements, .. }) => {
                                 // Simply replace the index with the element expr.
                                 replacements.push((old_expr_key, elements[idx_val as usize]));
@@ -393,7 +429,7 @@ pub(crate) fn lower_imm_accesses(
                                 let el_imm = elements[idx_val as usize].clone();
                                 let el_ty = el_imm.get_ty(None);
 
-                                let el_expr = pred.exprs.insert(
+                                let el_expr = contract.exprs.insert(
                                     Expr::Immediate {
                                         value: el_imm,
                                         span: empty_span(),
@@ -428,7 +464,7 @@ pub(crate) fn lower_imm_accesses(
 
             if let Some((tuple_key, tuple_field_key)) = field_idx {
                 // We have a tuple access into an immediate.
-                match tuple_key.try_get(pred) {
+                match tuple_key.try_get(contract) {
                     Some(Expr::Tuple { fields, .. }) => {
                         let new_expr_key = match tuple_field_key {
                             TupleAccess::Index(idx_val) => fields[idx_val].1,
@@ -472,7 +508,7 @@ pub(crate) fn lower_imm_accesses(
                         // Create a new immediate expr and replace the index with it.
                         let fld_ty = fld_imm.get_ty(None);
 
-                        let fld_expr = pred.exprs.insert(
+                        let fld_expr = contract.exprs.insert(
                             Expr::Immediate {
                                 value: fld_imm,
                                 span: empty_span(),
@@ -493,8 +529,8 @@ pub(crate) fn lower_imm_accesses(
         // Iterate for each replacement without borrowing.
         while let Some((old_expr_key, new_expr_key)) = replacements.pop() {
             // Replace the old with the new throughout the Pred.
-            pred.replace_exprs(old_expr_key, new_expr_key);
-            pred.exprs.remove(old_expr_key);
+            contract.replace_exprs(pred_name, old_expr_key, new_expr_key);
+            contract.exprs.remove(old_expr_key);
 
             // But _also_ replace the old within `replacements` in case any of our new keys is now
             // stale.
@@ -510,188 +546,202 @@ pub(crate) fn lower_imm_accesses(
 
     // Replace all the direct array and tuple accesses until there are none left.  This will loop
     // for all the nested aggregates.
-    for loop_check in 0.. {
-        if !replace_direct_accesses()? {
-            break;
-        }
+    for pred_name in &pred_names {
+        for loop_check in 0.. {
+            if !replace_direct_accesses(pred_name)? {
+                break;
+            }
 
-        if loop_check > 10_000 {
-            return Err(handler.emit_err(Error::Compile {
-                error: CompileError::Internal {
-                    msg: "infinite loop in lower_imm_accesses()",
-                    span: empty_span(),
-                },
-            }));
+            if loop_check > 10_000 {
+                return Err(handler.emit_err(Error::Compile {
+                    error: CompileError::Internal {
+                        msg: "infinite loop in lower_imm_accesses()",
+                        span: empty_span(),
+                    },
+                }));
+            }
         }
     }
 
     Ok(())
 }
 
-pub(crate) fn lower_ins(handler: &Handler, pred: &mut Predicate) -> Result<(), ErrorEmitted> {
-    let mut in_range_collections = Vec::new();
-    let mut array_collections = Vec::new();
+pub(crate) fn lower_ins(handler: &Handler, contract: &mut Contract) -> Result<(), ErrorEmitted> {
+    for pred_name in contract.preds.keys().cloned().collect::<Vec<_>>() {
+        let mut in_range_collections = Vec::new();
+        let mut array_collections = Vec::new();
 
-    // Collect all the `in` expressions which need to be replaced.  (Copy them out of the Pred.)
-    for in_expr_key in pred.exprs() {
-        if let Some(Expr::In {
-            value,
-            collection,
-            span,
-        }) = in_expr_key.try_get(pred)
-        {
-            if let Some(collection_expr) = collection.try_get(pred) {
-                match collection_expr {
-                    Expr::Range { lb, ub, span } => {
-                        in_range_collections.push((in_expr_key, *value, *lb, *ub, span.clone()));
-                    }
+        // Collect all the `in` expressions which need to be replaced.  (Copy them out of the Pred.)
+        for in_expr_key in contract.exprs_for_pred_name(&pred_name) {
+            if let Some(Expr::In {
+                value,
+                collection,
+                span,
+            }) = in_expr_key.try_get(contract)
+            {
+                if let Some(collection_expr) = collection.try_get(contract) {
+                    match collection_expr {
+                        Expr::Range { lb, ub, span } => {
+                            in_range_collections.push((
+                                in_expr_key,
+                                *value,
+                                *lb,
+                                *ub,
+                                span.clone(),
+                            ));
+                        }
 
-                    Expr::Immediate {
-                        value: Immediate::Array(elements),
-                        span,
-                    } => {
-                        array_collections.push((
-                            in_expr_key,
-                            *value,
-                            *collection,
-                            elements.len(),
-                            collection
-                                .get_ty(pred)
-                                .get_array_el_type()
-                                .cloned()
-                                .expect("array must have array type"),
-                            span.clone(),
-                        ));
-                    }
+                        Expr::Immediate {
+                            value: Immediate::Array(elements),
+                            span,
+                        } => {
+                            array_collections.push((
+                                in_expr_key,
+                                *value,
+                                *collection,
+                                elements.len(),
+                                collection
+                                    .get_ty(contract)
+                                    .get_array_el_type()
+                                    .cloned()
+                                    .expect("array must have array type"),
+                                span.clone(),
+                            ));
+                        }
 
-                    Expr::Array { elements, span, .. } => {
-                        array_collections.push((
-                            in_expr_key,
-                            *value,
-                            *collection,
-                            elements.len(),
-                            collection
-                                .get_ty(pred)
-                                .get_array_el_type()
-                                .cloned()
-                                .expect("array must have array type"),
-                            span.clone(),
-                        ));
-                    }
+                        Expr::Array { elements, span, .. } => {
+                            array_collections.push((
+                                in_expr_key,
+                                *value,
+                                *collection,
+                                elements.len(),
+                                collection
+                                    .get_ty(contract)
+                                    .get_array_el_type()
+                                    .cloned()
+                                    .expect("array must have array type"),
+                                span.clone(),
+                            ));
+                        }
 
-                    _ => {
-                        handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "invalid collection (not range or array) in `in` expr",
-                                span: span.clone(),
-                            },
-                        });
+                        _ => {
+                            handler.emit_err(Error::Compile {
+                                error: CompileError::Internal {
+                                    msg: "invalid collection (not range or array) in `in` expr",
+                                    span: span.clone(),
+                                },
+                            });
+                        }
                     }
+                } else {
+                    handler.emit_err(Error::Compile {
+                        error: CompileError::Internal {
+                            msg: "missing collection in `in` expr",
+                            span: span.clone(),
+                        },
+                    });
                 }
-            } else {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "missing collection in `in` expr",
-                        span: span.clone(),
-                    },
-                });
             }
         }
-    }
 
-    let bool_ty = Type::Primitive {
-        kind: PrimitiveKind::Bool,
-        span: empty_span(),
-    };
+        let bool_ty = Type::Primitive {
+            kind: PrimitiveKind::Bool,
+            span: empty_span(),
+        };
 
-    // Replace the range expressions first. `x in l..u` becomes `(x >= l) && (x <= u)`.
-    for (in_expr_key, value_key, lower_bounds_key, upper_bounds_key, span) in in_range_collections {
-        let lb_cmp_key = pred.exprs.insert(
-            Expr::BinaryOp {
-                op: BinaryOp::GreaterThanOrEqual,
-                lhs: value_key,
-                rhs: lower_bounds_key,
-                span: span.clone(),
-            },
-            bool_ty.clone(),
-        );
+        // Replace the range expressions first. `x in l..u` becomes `(x >= l) && (x <= u)`.
+        for (in_expr_key, value_key, lower_bounds_key, upper_bounds_key, span) in
+            in_range_collections
+        {
+            let lb_cmp_key = contract.exprs.insert(
+                Expr::BinaryOp {
+                    op: BinaryOp::GreaterThanOrEqual,
+                    lhs: value_key,
+                    rhs: lower_bounds_key,
+                    span: span.clone(),
+                },
+                bool_ty.clone(),
+            );
 
-        let ub_cmp_key = pred.exprs.insert(
-            Expr::BinaryOp {
-                op: BinaryOp::LessThanOrEqual,
-                lhs: value_key,
-                rhs: upper_bounds_key,
-                span: span.clone(),
-            },
-            bool_ty.clone(),
-        );
+            let ub_cmp_key = contract.exprs.insert(
+                Expr::BinaryOp {
+                    op: BinaryOp::LessThanOrEqual,
+                    lhs: value_key,
+                    rhs: upper_bounds_key,
+                    span: span.clone(),
+                },
+                bool_ty.clone(),
+            );
 
-        let and_key = pred.exprs.insert(
-            Expr::BinaryOp {
-                op: BinaryOp::LogicalAnd,
-                lhs: lb_cmp_key,
-                rhs: ub_cmp_key,
-                span: span.clone(),
-            },
-            bool_ty.clone(),
-        );
+            let and_key = contract.exprs.insert(
+                Expr::BinaryOp {
+                    op: BinaryOp::LogicalAnd,
+                    lhs: lb_cmp_key,
+                    rhs: ub_cmp_key,
+                    span: span.clone(),
+                },
+                bool_ty.clone(),
+            );
 
-        pred.replace_exprs(in_expr_key, and_key);
-    }
+            contract.replace_exprs(&pred_name, in_expr_key, and_key);
+        }
 
-    let int_ty = Type::Primitive {
-        kind: PrimitiveKind::Int,
-        span: empty_span(),
-    };
+        let int_ty = Type::Primitive {
+            kind: PrimitiveKind::Int,
+            span: empty_span(),
+        };
 
-    // Replace the array expressions.
-    // `x in ary` becomes `(x == ary[0]) || (x == ary[1]) || (x == ary[2]) || ...`.
-    for (in_expr_key, value_key, array_key, element_count, element_ty, span) in array_collections {
-        let or_key = (0..(element_count as i64))
-            .map(|el_idx| {
-                let el_idx_val_key = pred.exprs.insert(
-                    Expr::Immediate {
-                        value: Immediate::Int(el_idx),
-                        span: empty_span(),
-                    },
-                    int_ty.clone(),
-                );
+        // Replace the array expressions.
+        // `x in ary` becomes `(x == ary[0]) || (x == ary[1]) || (x == ary[2]) || ...`.
+        for (in_expr_key, value_key, array_key, element_count, element_ty, span) in
+            array_collections
+        {
+            let or_key = (0..(element_count as i64))
+                .map(|el_idx| {
+                    let el_idx_val_key = contract.exprs.insert(
+                        Expr::Immediate {
+                            value: Immediate::Int(el_idx),
+                            span: empty_span(),
+                        },
+                        int_ty.clone(),
+                    );
 
-                let el_idx_expr_key = pred.exprs.insert(
-                    Expr::Index {
-                        expr: array_key,
-                        index: el_idx_val_key,
-                        span: empty_span(),
-                    },
-                    element_ty.clone(),
-                );
+                    let el_idx_expr_key = contract.exprs.insert(
+                        Expr::Index {
+                            expr: array_key,
+                            index: el_idx_val_key,
+                            span: empty_span(),
+                        },
+                        element_ty.clone(),
+                    );
 
-                pred.exprs.insert(
-                    Expr::BinaryOp {
-                        op: BinaryOp::Equal,
-                        lhs: value_key,
-                        rhs: el_idx_expr_key,
-                        span: span.clone(),
-                    },
-                    bool_ty.clone(),
-                )
-            })
-            .collect::<Vec<_>>() // Collect into Vec to avoid borrowing pred.exprs conflict.
-            .into_iter()
-            .reduce(|lhs, rhs| {
-                pred.exprs.insert(
-                    Expr::BinaryOp {
-                        op: BinaryOp::LogicalOr,
-                        lhs,
-                        rhs,
-                        span: span.clone(),
-                    },
-                    bool_ty.clone(),
-                )
-            })
-            .expect("can't have empty array expressions");
+                    contract.exprs.insert(
+                        Expr::BinaryOp {
+                            op: BinaryOp::Equal,
+                            lhs: value_key,
+                            rhs: el_idx_expr_key,
+                            span: span.clone(),
+                        },
+                        bool_ty.clone(),
+                    )
+                })
+                .collect::<Vec<_>>() // Collect into Vec to avoid borrowing contract.exprs conflict.
+                .into_iter()
+                .reduce(|lhs, rhs| {
+                    contract.exprs.insert(
+                        Expr::BinaryOp {
+                            op: BinaryOp::LogicalOr,
+                            lhs,
+                            rhs,
+                            span: span.clone(),
+                        },
+                        bool_ty.clone(),
+                    )
+                })
+                .expect("can't have empty array expressions");
 
-        pred.replace_exprs(in_expr_key, or_key);
+            contract.replace_exprs(&pred_name, in_expr_key, or_key);
+        }
     }
 
     if handler.has_errors() {
@@ -716,89 +766,87 @@ pub(crate) fn lower_ins(handler: &Handler, pred: &mut Predicate) -> Result<(), E
 /// constraint __state_len(x) == 0;
 /// constraint __state_len(y) != 0;
 ///
-pub(crate) fn lower_compares_to_nil(
-    _handler: &Handler,
-    pred: &mut Predicate,
-) -> Result<(), ErrorEmitted> {
-    let compares_to_nil = pred
-        .exprs()
-        .filter_map(|expr_key| match expr_key.try_get(pred) {
-            Some(Expr::BinaryOp { op, lhs, rhs, span })
-                if (*op == BinaryOp::Equal || *op == BinaryOp::NotEqual)
-                    && (lhs.get(pred).is_nil() || rhs.get(pred).is_nil()) =>
-            {
-                Some((expr_key, *op, *lhs, *rhs, span.clone()))
-            }
-            _ => None,
-        })
-        .collect::<Vec<_>>();
+pub(crate) fn lower_compares_to_nil(contract: &mut Contract) {
+    for pred_name in contract.preds.keys().cloned().collect::<Vec<_>>() {
+        let compares_to_nil = contract
+            .exprs_for_pred_name(&pred_name)
+            .filter_map(|expr_key| match expr_key.try_get(contract) {
+                Some(Expr::BinaryOp { op, lhs, rhs, span })
+                    if (*op == BinaryOp::Equal || *op == BinaryOp::NotEqual)
+                        && (lhs.get(contract).is_nil() || rhs.get(contract).is_nil()) =>
+                {
+                    Some((expr_key, *op, *lhs, *rhs, span.clone()))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
 
-    let convert_to_state_len_compare =
-        |pred: &mut Predicate, op: &BinaryOp, expr: &ExprKey, span: &crate::span::Span| {
-            let state_len = pred.exprs.insert(
-                Expr::IntrinsicCall {
-                    name: Ident {
-                        name: "__state_len".to_string(),
-                        hygienic: false,
+        let convert_to_state_len_compare =
+            |contract: &mut Contract, op: &BinaryOp, expr: &ExprKey, span: &crate::span::Span| {
+                let state_len = contract.exprs.insert(
+                    Expr::IntrinsicCall {
+                        name: Ident {
+                            name: "__state_len".to_string(),
+                            hygienic: false,
+                            span: span.clone(),
+                        },
+                        args: vec![*expr],
                         span: span.clone(),
                     },
-                    args: vec![*expr],
-                    span: span.clone(),
-                },
-                Type::Primitive {
-                    kind: PrimitiveKind::Int,
-                    span: empty_span(),
-                },
-            );
+                    Type::Primitive {
+                        kind: PrimitiveKind::Int,
+                        span: empty_span(),
+                    },
+                );
 
-            let zero = pred.exprs.insert(
-                Expr::Immediate {
-                    value: Immediate::Int(0),
-                    span: empty_span(),
-                },
-                Type::Primitive {
-                    kind: PrimitiveKind::Bool,
-                    span: empty_span(),
-                },
-            );
+                let zero = contract.exprs.insert(
+                    Expr::Immediate {
+                        value: Immediate::Int(0),
+                        span: empty_span(),
+                    },
+                    Type::Primitive {
+                        kind: PrimitiveKind::Bool,
+                        span: empty_span(),
+                    },
+                );
 
-            // New binary op: `__state_len(expr) == 0`
-            pred.exprs.insert(
-                Expr::BinaryOp {
-                    op: *op,
-                    lhs: state_len,
-                    rhs: zero,
-                    span: span.clone(),
-                },
-                Type::Primitive {
-                    kind: PrimitiveKind::Bool,
-                    span: empty_span(),
-                },
-            )
-        };
+                // New binary op: `__state_len(expr) == 0`
+                contract.exprs.insert(
+                    Expr::BinaryOp {
+                        op: *op,
+                        lhs: state_len,
+                        rhs: zero,
+                        span: span.clone(),
+                    },
+                    Type::Primitive {
+                        kind: PrimitiveKind::Bool,
+                        span: empty_span(),
+                    },
+                )
+            };
 
-    for (old_bin_op, op, lhs, rhs, span) in compares_to_nil.iter() {
-        let new_bin_op = match (lhs.get(pred).is_nil(), rhs.get(pred).is_nil()) {
-            (false, true) => convert_to_state_len_compare(pred, op, lhs, span),
-            (true, false) => convert_to_state_len_compare(pred, op, rhs, span),
-            (true, true) => pred.exprs.insert(
-                // Comparing two `nil`s should always return `false` regardless of whether this is
-                // an `Equal` or a `NotEqual`.
-                Expr::Immediate {
-                    value: Immediate::Bool(false),
-                    span: empty_span(),
-                },
-                Type::Primitive {
-                    kind: PrimitiveKind::Bool,
-                    span: empty_span(),
-                },
-            ),
-            _ => unreachable!("both operands cannot be non-nil simultaneously at this stage"),
-        };
-        pred.replace_exprs(*old_bin_op, new_bin_op);
+        for (old_bin_op, op, lhs, rhs, span) in compares_to_nil.iter() {
+            let new_bin_op = match (lhs.get(contract).is_nil(), rhs.get(contract).is_nil()) {
+                (false, true) => convert_to_state_len_compare(contract, op, lhs, span),
+                (true, false) => convert_to_state_len_compare(contract, op, rhs, span),
+                (true, true) => contract.exprs.insert(
+                    // Comparing two `nil`s should always return `false` regardless of whether this is
+                    // an `Equal` or a `NotEqual`.
+                    Expr::Immediate {
+                        value: Immediate::Bool(false),
+                        span: empty_span(),
+                    },
+                    Type::Primitive {
+                        kind: PrimitiveKind::Bool,
+                        span: empty_span(),
+                    },
+                ),
+                _ => unreachable!("both operands cannot be non-nil simultaneously at this stage"),
+            };
+
+            contract.replace_exprs(&pred_name, *old_bin_op, new_bin_op);
+        }
     }
-
-    Ok(())
 }
 
 /// Convert all `if` declarations into individual constraints that are pushed to `pred.constraints`.
@@ -823,25 +871,34 @@ pub(crate) fn lower_compares_to_nil(
 /// The transformation is recursive and uses the Boolean principle:
 /// `a ==> b` is equivalent to `!a || b`.
 ///
-pub(crate) fn lower_ifs(pred: &mut Predicate) {
-    for if_decl in &pred.if_decls.clone() {
-        let all_exprs = convert_if(pred, if_decl);
+pub(crate) fn lower_ifs(contract: &mut Contract) {
+    for pred_name in contract.preds.keys().cloned().collect::<Vec<_>>() {
+        let mut all_exprs = Vec::default();
+
+        // Ideally we'd refactor this to not require cloning the IfDecl.
+        for if_decl in &contract.preds.get(&pred_name).unwrap().if_decls.clone() {
+            all_exprs.extend(&convert_if(contract, &pred_name, if_decl));
+        }
+
+        let mut_pred = contract.preds.get_mut(&pred_name).unwrap();
+
         for expr in all_exprs {
-            pred.constraints.push(ConstraintDecl {
+            mut_pred.constraints.push(ConstraintDecl {
                 expr,
                 span: empty_span(),
             });
         }
-    }
 
-    // Remove all `if_decls`. We don't need them anymore.
-    pred.if_decls.clear();
+        // Remove all `if_decls`. We don't need them anymore.
+        mut_pred.if_decls.clear();
+    }
 }
 
 // Given an `IfDecl`, convert all of its statements to Boolean expressions and return all of
 // them in a `Vec<ExprKey>`. This follows the principle that `a ==> b` is equivalent to `!a || b`.
 fn convert_if(
-    pred: &mut Predicate,
+    contract: &mut Contract,
+    pred_name: &str,
     IfDecl {
         condition,
         then_block,
@@ -849,7 +906,7 @@ fn convert_if(
         ..
     }: &IfDecl,
 ) -> Vec<ExprKey> {
-    let condition_inverse = pred.exprs.insert(
+    let condition_inverse = contract.exprs.insert(
         Expr::UnaryOp {
             op: UnaryOp::Not,
             expr: *condition,
@@ -866,7 +923,8 @@ fn convert_if(
     for statement in then_block {
         // `condition => statement` i.e. `!condition || statement`
         all_exprs.extend(convert_if_block_statement(
-            pred,
+            contract,
+            pred_name,
             statement,
             condition_inverse,
         ));
@@ -876,7 +934,7 @@ fn convert_if(
         // `!condition => statement` i.e. `!!condition || statement`
         for statement in else_block {
             all_exprs.extend(convert_if_block_statement(
-                pred, statement,
+                contract, pred_name, statement,
                 *condition, // use condition is here since it's the inverse of the inverse,
             ));
         }
@@ -895,7 +953,8 @@ fn convert_if(
 // If `statement` is an `IfDecl`, then recurse by calling `convert_if`.
 //
 fn convert_if_block_statement(
-    pred: &mut Predicate,
+    contract: &mut Contract,
+    pred_name: &str,
     statement: &BlockStatement,
     condition_inverse: ExprKey,
 ) -> Vec<ExprKey> {
@@ -907,7 +966,7 @@ fn convert_if_block_statement(
     let mut converted_exprs = vec![];
     match statement {
         BlockStatement::Constraint(constraint_decl) => {
-            converted_exprs.push(pred.exprs.insert(
+            converted_exprs.push(contract.exprs.insert(
                 Expr::BinaryOp {
                     op: BinaryOp::LogicalOr,
                     lhs: condition_inverse,
@@ -918,8 +977,8 @@ fn convert_if_block_statement(
             ));
         }
         BlockStatement::If(if_decl) => {
-            for inner_expr in convert_if(pred, if_decl) {
-                converted_exprs.push(pred.exprs.insert(
+            for inner_expr in convert_if(contract, pred_name, if_decl) {
+                converted_exprs.push(contract.exprs.insert(
                     Expr::BinaryOp {
                         op: BinaryOp::LogicalOr,
                         lhs: condition_inverse,
@@ -935,197 +994,216 @@ fn convert_if_block_statement(
     converted_exprs
 }
 
-pub(super) fn replace_const_refs(pred: &mut Predicate, consts: &[(String, ExprKey, Expr, Type)]) {
-    // Find all the paths which refer to a const and link them.
-    let const_refs = pred
-        .exprs()
-        .filter_map(|path_expr_key| {
-            if let Expr::PathByName(path, _span) = path_expr_key.get(pred) {
-                consts
-                    .iter()
-                    .find_map(|(const_path, const_expr_key, const_expr, const_ty)| {
-                        (path == const_path).then_some((
-                            path_expr_key,
-                            *const_expr_key,
-                            const_expr,
-                            const_ty,
-                        ))
-                    })
-            } else {
-                None
-            }
+pub(super) fn replace_const_refs(contract: &mut Contract) {
+    let consts = contract
+        .consts
+        .iter()
+        .map(|(path, Const { expr, decl_ty })| {
+            (
+                path.clone(),
+                *expr,
+                expr.get(contract).clone(),
+                decl_ty.clone(),
+            )
         })
         .collect::<Vec<_>>();
 
-    // Replace all paths to consts with the consts themselves.
-    if pred.is_root() {
-        // This is the root Pred, meaning we already have the ExprKeys for the consts available.
-        pred.replace_exprs_by_map(&FxHashMap::from_iter(
-            const_refs.into_iter().map(|refs| (refs.0, refs.1)),
-        ));
-    } else {
-        // This is NOT the root Pred, so we need to inject these const expressions into the Pred before
-        // we can replace the paths.
-        for (path_expr_key, _, const_expr, const_ty) in const_refs {
-            let const_expr_key = pred.exprs.insert(const_expr.clone(), const_ty.clone());
-            pred.replace_exprs(path_expr_key, const_expr_key);
+    for pred_name in contract.preds.keys().cloned().collect::<Vec<_>>() {
+        // Find all the paths which refer to a const and link them.
+        let const_refs = contract
+            .exprs_for_pred_name(&pred_name)
+            .filter_map(|path_expr_key| {
+                if let Expr::PathByName(path, _span) = path_expr_key.get(contract) {
+                    consts
+                        .iter()
+                        .find_map(|(const_path, const_expr_key, const_expr, const_ty)| {
+                            (path == const_path).then_some((
+                                path_expr_key,
+                                *const_expr_key,
+                                const_expr,
+                                const_ty,
+                            ))
+                        })
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // Replace all paths to consts with the consts themselves.
+        if pred_name == Contract::ROOT_PRED_NAME {
+            // This is the root Pred, meaning we already have the ExprKeys for the consts available.
+            contract.replace_exprs_by_map(
+                &pred_name,
+                &FxHashMap::from_iter(const_refs.into_iter().map(|refs| (refs.0, refs.1))),
+            );
+        } else {
+            // This is NOT the root Pred, so we need to inject these const expressions into the
+            // Pred before we can replace the paths.
+            for (path_expr_key, _, const_expr, const_ty) in const_refs {
+                let const_expr_key = contract.exprs.insert(const_expr.clone(), const_ty.clone());
+                contract.replace_exprs(&pred_name, path_expr_key, const_expr_key);
+            }
         }
     }
 }
 
-pub(super) fn coalesce_prime_ops(pred: &mut Predicate) {
-    // Gather up all the keys to any NextState ops in this predicate.
-    let mut work_list: Vec<(ExprKey, ExprKey)> = pred
-        .exprs()
-        .filter_map(|op_key| {
-            if let Expr::UnaryOp {
-                op: UnaryOp::NextState,
-                expr: arg_key,
-                ..
-            } = op_key.get(pred)
-            {
-                Some((op_key, *arg_key))
-            } else {
-                None
-            }
-        })
-        .collect();
+pub(super) fn coalesce_prime_ops(contract: &mut Contract) {
+    for pred_name in contract.preds.keys().cloned().collect::<Vec<_>>() {
+        // Gather up all the keys to any NextState ops in this predicate.
+        let mut work_list: Vec<(ExprKey, ExprKey)> = contract
+            .exprs_for_pred_name(&pred_name)
+            .filter_map(|op_key| {
+                if let Expr::UnaryOp {
+                    op: UnaryOp::NextState,
+                    expr: arg_key,
+                    ..
+                } = op_key.get(contract)
+                {
+                    Some((op_key, *arg_key))
+                } else {
+                    None
+                }
+            })
+            .collect();
 
-    // We want to merge any ops which are applied to other ops.  And we want to push ops on index
-    // or field access expressions up to the array or tuple that they're indexing.  In turn that
-    // could create new prime ops applied to prime ops or indices/accesses.
-    //
-    // Doing this efficiently is non-trivial.  Whenever we replace an expression key in the
-    // predicate we need to update the work list at the same time.
+        // We want to merge any ops which are applied to other ops.  And we want to push ops on index
+        // or field access expressions up to the array or tuple that they're indexing.  In turn that
+        // could create new prime ops applied to prime ops or indices/accesses.
+        //
+        // Doing this efficiently is non-trivial.  Whenever we replace an expression key in the
+        // predicate we need to update the work list at the same time.
 
-    fn replace_exprs(
-        pred: &mut Predicate,
-        work_list: &mut Vec<(ExprKey, ExprKey)>,
-        old_key: ExprKey,
-        new_key: ExprKey,
-    ) {
-        pred.replace_exprs(old_key, new_key);
+        fn replace_exprs(
+            contract: &mut Contract,
+            pred_name: &str,
+            work_list: &mut Vec<(ExprKey, ExprKey)>,
+            old_key: ExprKey,
+            new_key: ExprKey,
+        ) {
+            contract.replace_exprs(pred_name, old_key, new_key);
 
-        for (ref mut op_key, ref mut arg_key) in work_list {
-            if *op_key == old_key {
-                *op_key = new_key;
-            }
-            if *arg_key == old_key {
-                *arg_key = new_key;
+            for (ref mut op_key, ref mut arg_key) in work_list {
+                if *op_key == old_key {
+                    *op_key = new_key;
+                }
+                if *arg_key == old_key {
+                    *arg_key = new_key;
+                }
             }
         }
-    }
 
-    // The different transforms we may perform to coalesce prime ops.  Needed to avoid borrow
-    // violations when we update the expressions in-place.
-    enum Coalescence {
-        None,
-        MergeOps,
-        LowerIndex(ExprKey),
-        LowerAccess(ExprKey),
-    }
+        // The different transforms we may perform to coalesce prime ops.  Needed to avoid borrow
+        // violations when we update the expressions in-place.
+        enum Coalescence {
+            None,
+            MergeOps,
+            LowerIndex(ExprKey),
+            LowerAccess(ExprKey),
+        }
 
-    // Pop the next candidate (prime op key and its argument key) until the list is empty.
-    while let Some((op_key, arg_key)) = work_list.pop() {
-        let coalescence = match arg_key.get(pred) {
-            Expr::UnaryOp {
-                op: UnaryOp::NextState,
-                ..
-            } => Coalescence::MergeOps,
-
-            Expr::Index { expr, .. } => Coalescence::LowerIndex(*expr),
-
-            Expr::TupleFieldAccess { tuple, .. } => Coalescence::LowerAccess(*tuple),
-
-            // The only other valid expressions will be PathByKey and PathByName, and for either
-            // there's nothing to do -- they're popped off the work list.
-            Expr::Error(_)
-            | Expr::Immediate { .. }
-            | Expr::Array { .. }
-            | Expr::Tuple { .. }
-            | Expr::PathByKey(..)
-            | Expr::PathByName(..)
-            | Expr::StorageAccess(..)
-            | Expr::ExternalStorageAccess { .. }
-            | Expr::UnaryOp { .. }
-            | Expr::BinaryOp { .. }
-            | Expr::MacroCall { .. }
-            | Expr::IntrinsicCall { .. }
-            | Expr::Select { .. }
-            | Expr::Cast { .. }
-            | Expr::In { .. }
-            | Expr::Range { .. }
-            | Expr::Generator { .. } => Coalescence::None,
-        };
-
-        match coalescence {
-            Coalescence::None => {}
-
-            Coalescence::MergeOps => {
-                // E.g., a''.
-
-                // Replace any reference to the outer op expression with the inner arg op.
-                replace_exprs(pred, &mut work_list, op_key, arg_key);
-            }
-
-            Coalescence::LowerIndex(indexed_key) => {
-                // E.g., a[i]' -> a'[i].
-
-                // Update any reference the the prime op to instead be to the index expression.
-                replace_exprs(pred, &mut work_list, op_key, arg_key);
-
-                // Update the prime op to refer to the indexed expression and put this 'new' op
-                // back onto the list.
-                let Expr::UnaryOp {
-                    expr: arg_key_ref, ..
-                } = op_key.get_mut(pred)
-                else {
-                    unreachable!("op_key must be to a Unary::NextState")
-                };
-
-                *arg_key_ref = indexed_key;
-                work_list.push((op_key, indexed_key));
-
-                // Update the index expression to refer to the prime op.
-                let Expr::Index {
-                    expr: indexed_key_ref,
+        // Pop the next candidate (prime op key and its argument key) until the list is empty.
+        while let Some((op_key, arg_key)) = work_list.pop() {
+            let coalescence = match arg_key.get(contract) {
+                Expr::UnaryOp {
+                    op: UnaryOp::NextState,
                     ..
-                } = arg_key.get_mut(pred)
-                else {
-                    unreachable!("arg_key must be to an Expr::Index")
-                };
+                } => Coalescence::MergeOps,
 
-                *indexed_key_ref = op_key;
-            }
+                Expr::Index { expr, .. } => Coalescence::LowerIndex(*expr),
 
-            Coalescence::LowerAccess(accessed_key) => {
-                // E.g., a.x' -> a'.x.
+                Expr::TupleFieldAccess { tuple, .. } => Coalescence::LowerAccess(*tuple),
 
-                // Update any reference to the prime op to instead be to the access expression.
-                replace_exprs(pred, &mut work_list, op_key, arg_key);
+                // The only other valid expressions will be PathByKey and PathByName, and for either
+                // there's nothing to do -- they're popped off the work list.
+                Expr::Error(_)
+                | Expr::Immediate { .. }
+                | Expr::Array { .. }
+                | Expr::Tuple { .. }
+                | Expr::PathByKey(..)
+                | Expr::PathByName(..)
+                | Expr::StorageAccess(..)
+                | Expr::ExternalStorageAccess { .. }
+                | Expr::UnaryOp { .. }
+                | Expr::BinaryOp { .. }
+                | Expr::MacroCall { .. }
+                | Expr::IntrinsicCall { .. }
+                | Expr::Select { .. }
+                | Expr::Cast { .. }
+                | Expr::In { .. }
+                | Expr::Range { .. }
+                | Expr::Generator { .. } => Coalescence::None,
+            };
 
-                // Update the prime op to refer to the accessed expression.  Also update the list
-                // to reflect the same.
-                let Expr::UnaryOp {
-                    expr: old_arg_key, ..
-                } = op_key.get_mut(pred)
-                else {
-                    unreachable!("op_key must be to a Unary::NextState")
-                };
+            match coalescence {
+                Coalescence::None => {}
 
-                *old_arg_key = accessed_key;
-                work_list.push((op_key, accessed_key));
+                Coalescence::MergeOps => {
+                    // E.g., a''.
 
-                // Update the access expression to refer to the prime op.
-                let Expr::TupleFieldAccess {
-                    tuple: old_accessed_key,
-                    ..
-                } = arg_key.get_mut(pred)
-                else {
-                    unreachable!("arg_key must be to an Expr::TupleFieldAccess")
-                };
+                    // Replace any reference to the outer op expression with the inner arg op.
+                    replace_exprs(contract, &pred_name, &mut work_list, op_key, arg_key);
+                }
 
-                *old_accessed_key = op_key;
+                Coalescence::LowerIndex(indexed_key) => {
+                    // E.g., a[i]' -> a'[i].
+
+                    // Update any reference the the prime op to instead be to the index expression.
+                    replace_exprs(contract, &pred_name, &mut work_list, op_key, arg_key);
+
+                    // Update the prime op to refer to the indexed expression and put this 'new' op
+                    // back onto the list.
+                    let Expr::UnaryOp {
+                        expr: arg_key_ref, ..
+                    } = op_key.get_mut(contract)
+                    else {
+                        unreachable!("op_key must be to a Unary::NextState")
+                    };
+
+                    *arg_key_ref = indexed_key;
+                    work_list.push((op_key, indexed_key));
+
+                    // Update the index expression to refer to the prime op.
+                    let Expr::Index {
+                        expr: indexed_key_ref,
+                        ..
+                    } = arg_key.get_mut(contract)
+                    else {
+                        unreachable!("arg_key must be to an Expr::Index")
+                    };
+
+                    *indexed_key_ref = op_key;
+                }
+
+                Coalescence::LowerAccess(accessed_key) => {
+                    // E.g., a.x' -> a'.x.
+
+                    // Update any reference to the prime op to instead be to the access expression.
+                    replace_exprs(contract, &pred_name, &mut work_list, op_key, arg_key);
+
+                    // Update the prime op to refer to the accessed expression.  Also update the list
+                    // to reflect the same.
+                    let Expr::UnaryOp {
+                        expr: old_arg_key, ..
+                    } = op_key.get_mut(contract)
+                    else {
+                        unreachable!("op_key must be to a Unary::NextState")
+                    };
+
+                    *old_arg_key = accessed_key;
+                    work_list.push((op_key, accessed_key));
+
+                    // Update the access expression to refer to the prime op.
+                    let Expr::TupleFieldAccess {
+                        tuple: old_accessed_key,
+                        ..
+                    } = arg_key.get_mut(contract)
+                    else {
+                        unreachable!("arg_key must be to an Expr::TupleFieldAccess")
+                    };
+
+                    *old_accessed_key = op_key;
+                }
             }
         }
     }

--- a/pintc/src/predicate/vars.rs
+++ b/pintc/src/predicate/vars.rs
@@ -1,4 +1,4 @@
-use super::{DisplayWithPred, Ident, Predicate};
+use super::{Contract, DisplayWithPred, Ident, Predicate};
 use crate::{
     error::{ErrorEmitted, Handler},
     span::Span,
@@ -100,16 +100,21 @@ impl VarKey {
     }
 
     /// Generate a `VarABI` given a `VarKey` and an `Predicate`
-    pub fn abi(&self, handler: &Handler, pred: &Predicate) -> Result<VarABI, ErrorEmitted> {
+    pub fn abi(
+        &self,
+        handler: &Handler,
+        contract: &Contract,
+        pred: &Predicate,
+    ) -> Result<VarABI, ErrorEmitted> {
         Ok(VarABI {
             name: self.get(pred).name.clone(),
-            ty: self.get_ty(pred).abi(handler, pred)?,
+            ty: self.get_ty(pred).abi(handler, contract, pred)?,
         })
     }
 }
 
 impl DisplayWithPred for VarKey {
-    fn fmt(&self, f: &mut Formatter, pred: &Predicate) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> fmt::Result {
         let var = &self.get(pred);
         if var.is_pub {
             write!(f, "pub ")?;
@@ -117,7 +122,7 @@ impl DisplayWithPred for VarKey {
         write!(f, "var {}", var.name)?;
         let ty = self.get_ty(pred);
         if !ty.is_unknown() {
-            write!(f, ": {}", pred.with_pred(ty))?;
+            write!(f, ": {}", pred.with_pred(contract, ty))?;
         }
         Ok(())
     }

--- a/pintc/src/types/display.rs
+++ b/pintc/src/types/display.rs
@@ -1,14 +1,14 @@
-use crate::predicate::{DisplayWithPred, Predicate};
+use crate::predicate::{Contract, DisplayWithPred, Predicate};
 use std::fmt::{Formatter, Result};
 
 impl DisplayWithPred for super::Path {
-    fn fmt(&self, f: &mut Formatter, _pred: &Predicate) -> Result {
+    fn fmt(&self, f: &mut Formatter, _contract: &Contract, _pred: &Predicate) -> Result {
         write!(f, "{self}")
     }
 }
 
 impl DisplayWithPred for super::Type {
-    fn fmt(&self, f: &mut Formatter, pred: &Predicate) -> Result {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> Result {
         match self {
             super::Type::Error(..) => write!(f, "Error"),
 
@@ -27,33 +27,33 @@ impl DisplayWithPred for super::Type {
                 write!(
                     f,
                     "{}[{}]",
-                    pred.with_pred(ty.as_ref()),
+                    pred.with_pred(contract, ty.as_ref()),
                     range
-                        .map(|range| pred.with_pred(range).to_string())
+                        .map(|range| pred.with_pred(contract, range).to_string())
                         .unwrap_or("_".to_owned())
                 )
             }
 
             super::Type::Tuple { fields, .. } => {
                 macro_rules! write_field {
-                    ($f: expr, $field: expr, $comma: expr, $pred: expr) => {{
+                    ($f: expr, $field: expr, $comma: expr, $contract: ident, $pred: expr) => {{
                         if $comma {
                             write!($f, ", ")?;
                         };
                         if let Some(name) = &$field.0 {
                             write!($f, "{}: ", name.name)?;
                         }
-                        write!($f, "{}", $pred.with_pred(&$field.1))?;
+                        write!($f, "{}", $pred.with_pred($contract, &$field.1))?;
                     }};
                 }
 
                 write!(f, "{{")?;
                 let mut fields = fields.iter();
                 if let Some(first_field) = fields.next() {
-                    write_field!(f, first_field, false, pred);
+                    write_field!(f, first_field, false, contract, pred);
                 }
                 for field in fields {
-                    write_field!(f, field, true, pred);
+                    write_field!(f, field, true, contract, pred);
                 }
                 write!(f, "}}")
             }
@@ -61,15 +61,15 @@ impl DisplayWithPred for super::Type {
             super::Type::Custom { path, .. } => write!(f, "{path}"),
 
             super::Type::Alias { path, ty, .. } => {
-                write!(f, "{path} ({})", pred.with_pred(&**ty))
+                write!(f, "{path} ({})", pred.with_pred(contract, ty.as_ref()))
             }
 
             super::Type::Map { ty_from, ty_to, .. } => {
                 write!(
                     f,
                     "( {} => {} )",
-                    pred.with_pred(&**ty_from),
-                    pred.with_pred(&**ty_to)
+                    pred.with_pred(contract, ty_from.as_ref()),
+                    pred.with_pred(contract, ty_to.as_ref())
                 )
             }
         }
@@ -77,7 +77,7 @@ impl DisplayWithPred for super::Type {
 }
 
 impl DisplayWithPred for super::EnumDecl {
-    fn fmt(&self, f: &mut Formatter, _pred: &Predicate) -> Result {
+    fn fmt(&self, f: &mut Formatter, _contract: &Contract, _pred: &Predicate) -> Result {
         write!(f, "enum {} = ", self.name)?;
         crate::util::write_many!(f, self.variants, " | ");
         Ok(())
@@ -85,7 +85,12 @@ impl DisplayWithPred for super::EnumDecl {
 }
 
 impl DisplayWithPred for super::NewTypeDecl {
-    fn fmt(&self, f: &mut Formatter, pred: &Predicate) -> Result {
-        write!(f, "type {} = {}", self.name, pred.with_pred(&self.ty))
+    fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> Result {
+        write!(
+            f,
+            "type {} = {}",
+            self.name,
+            pred.with_pred(contract, &self.ty)
+        )
     }
 }

--- a/pintc/src/util.rs
+++ b/pintc/src/util.rs
@@ -1,20 +1,20 @@
 /// A place for small utility functions which can use used in various places throughout the crate.
 
 macro_rules! write_many_iter_with_pred {
-    ($f: expr, $i: ident, $sep: literal, $pred: ident) => {
+    ($f: expr, $i: ident, $sep: literal, $contract: ident, $pred: ident) => {
         if let Some(e) = $i.next() {
-            write!($f, "{}", $pred.with_pred(e))?;
+            write!($f, "{}", $pred.with_pred($contract, e))?;
         }
         for e in $i {
-            write!($f, "{}{}", $sep, $pred.with_pred(e))?;
+            write!($f, "{}{}", $sep, $pred.with_pred($contract, e))?;
         }
     };
 }
 
 macro_rules! write_many_with_pred {
-    ($f: expr, $vec: expr, $sep: literal, $pred: ident) => {
+    ($f: expr, $vec: expr, $sep: literal, $contract: ident, $pred: ident) => {
         let mut i = $vec.iter();
-        crate::util::write_many_iter_with_pred!($f, i, $sep, $pred);
+        crate::util::write_many_iter_with_pred!($f, i, $sep, $contract, $pred);
     };
 }
 

--- a/pintc/tests/consts/bad_type.pnt
+++ b/pintc/tests/consts/bad_type.pnt
@@ -4,7 +4,6 @@ const b: int = {11, 22};
 const c = 33;
 
 predicate test {
-    // The type checker currently stops with the const type errors before getting to this constraint.
     var d: b256;
     constraint d == c;
 }
@@ -21,10 +20,16 @@ predicate test {
 // >>>
 
 // typecheck_failure <<<
+// binary operator type error
+// @117..118: operator `==` argument has unexpected type `int`
+// @112..113: expecting type `b256`
 // const initialization type error
 // @37..45: const initializer has unexpected type `{int, int}`
 // @31..34: expecting type `int`
 // const initialization type error
 // @15..20: const initializer has unexpected type `bool`
 // @9..12: expecting type `int`
+// constraint expression type error
+// @101..118: constraint expression has unknown type
+// @101..118: expecting type `bool`
 // >>>

--- a/pintc/tests/root_types/arrays.pnt
+++ b/pintc/tests/root_types/arrays.pnt
@@ -14,14 +14,14 @@ predicate Foo {}
 // type ::myTuple = {x: int};
 // type ::myTupleArray = {x: int[5]};
 // type ::myNestedArrayTuple = {y: {z: int[{4, 1}.0]}};
-// 
+//
 // predicate ::Foo {
 //     type ::myArray = int[2];
 //     type ::myMultiDimArray = int[2][2];
-//     type ::myArrayTuple = int[1.0];
+//     type ::myArrayTuple = int[{3, 1}.0];
 //     type ::myTuple = {x: int};
 //     type ::myTupleArray = {x: int[5]};
-//     type ::myNestedArrayTuple = {y: {z: int[1.0]}};
+//     type ::myNestedArrayTuple = {y: {z: int[{4, 1}.0]}};
 // }
 // >>>
 
@@ -32,13 +32,13 @@ predicate Foo {}
 // type ::myTuple = {x: int};
 // type ::myTupleArray = {x: int[5]};
 // type ::myNestedArrayTuple = {y: {z: int[{4, 1}.0]}};
-// 
+//
 // predicate ::Foo {
 //     type ::myArray = int[2];
 //     type ::myMultiDimArray = int[2][2];
-//     type ::myArrayTuple = int[1.0];
+//     type ::myArrayTuple = int[{3, 1}.0];
 //     type ::myTuple = {x: int};
 //     type ::myTupleArray = {x: int[5]};
-//     type ::myNestedArrayTuple = {y: {z: int[1.0]}};
+//     type ::myNestedArrayTuple = {y: {z: int[{4, 1}.0]}};
 // }
 // >>>

--- a/pintc/tests/root_types/exprs.pnt
+++ b/pintc/tests/root_types/exprs.pnt
@@ -22,12 +22,12 @@ predicate Foo {}
 // predicate ::Foo {
 //     type ::myAliasForCast = int;
 //     type ::myNestedCast = int[4 as ::myAliasForCast];
-//     type ::myNestedUnaryOp = int[-3];
+//     type ::myNestedUnaryOp = int[--3];
 //     type ::myNestedBinaryOp = int[(1 + 2)];
-//     type ::myNestedSelect = int[(0 ? 5 : 6)];
-//     type ::myNestedTuple = int[1.0];
-//     type ::myNestedArray = int[2[1]];
-//     type ::complexType = {::myNestedCast, ::myNestedSelect}[3 as int];
+//     type ::myNestedSelect = int[((1 > 0) ? 5 : 6)];
+//     type ::myNestedTuple = int[{2, 1}.0];
+//     type ::myNestedArray = int[[2, 1][1]];
+//     type ::complexType = {::myNestedCast, ::myNestedSelect}[2 in {1, 2, 3} as int];
 // }
 // >>>
 
@@ -44,11 +44,11 @@ predicate Foo {}
 // predicate ::Foo {
 //     type ::myAliasForCast = int;
 //     type ::myNestedCast = int[4 as int];
-//     type ::myNestedUnaryOp = int[-3];
+//     type ::myNestedUnaryOp = int[--3];
 //     type ::myNestedBinaryOp = int[(1 + 2)];
-//     type ::myNestedSelect = int[(0 ? 5 : 6)];
-//     type ::myNestedTuple = int[1.0];
-//     type ::myNestedArray = int[2[1]];
-//     type ::complexType = {::myNestedCast (int[4 as int]), ::myNestedSelect (int[(0 ? 5 : 6)])}[3 as int];
+//     type ::myNestedSelect = int[((1 > 0) ? 5 : 6)];
+//     type ::myNestedTuple = int[{2, 1}.0];
+//     type ::myNestedArray = int[[2, 1][1]];
+//     type ::complexType = {::myNestedCast (int[4 as int]), ::myNestedSelect (int[((1 > 0) ? 5 : 6)])}[2 in {1, 2, 3} as int];
 // }
 // >>>


### PR DESCRIPTION
This is the first task in #774.  It doesn't add any new functionality, is just a refactor to put `exprs` in `Contract`.

It's a bit of a mess and the rest of the tasks in #774 will clean it up.

The type checker and the transforms are changed the most.  Anywhere we used to need a `Predicate` reference we now pretty much also need a `Contract` reference.  For the type checker, which likes to update types in-place as they're resolved, and for the transforms, which are obviously making wholesale changes to the predicates, this is a bit of a borrowing nightmare.  Consequently a lot of the time instead of passing `pred: &Predicate`s around we're now passing `pred_name: &str`s and the predicate is fetched on demand from the contract by name.

This isn't ideal and so the next task is to put the `Predicate`s into a `slotmap` and refer to them generally by `PredKey` instead of `&Predicate` or by name.

But this PR is a change which touches a lot of the code and rebasing/merging against it is already a pain.  (If #780 is merged first then this will get conflicts, but then vice versa.  It might be easier to merge this one first, as the smaller PR is easier to reason about -- I can fix the conflicts.)