### PR TITLE
feat: Add `pint-abi-gen` `Keys` builder for building sets of keys

### DIFF
--- a/pint-abi-gen/src/array.rs
+++ b/pint-abi-gen/src/array.rs
@@ -1,16 +1,159 @@
 //! Items related to generating the `Array` mutations and keys builders.
 
 use crate::{
-    construct_key_expr, map, mutation, nesting_expr, nesting_key_doc_str, nesting_ty_str, tuple,
-    SingleKeyTy, TypeABI,
+    construct_key_expr, keys, map, mutations, nesting_expr, nesting_key_doc_str, nesting_ty_str,
+    tuple, SingleKeyTy, TypeABI,
 };
 use pint_abi_visit::{KeyedVarTree, Nesting, NodeIx};
 use proc_macro2::Span;
 
 /// The name for the array builder struct.
-pub(crate) fn mutations_struct_name(nesting: &[Nesting]) -> String {
+pub(crate) fn struct_name(nesting: &[Nesting]) -> String {
     format!("Array_{}", nesting_ty_str(nesting))
 }
+
+// ------------------------------------
+// Keys
+// ------------------------------------
+
+/// A builder struct for an array field.
+fn keys_struct(struct_name: &str, nesting: &[Nesting]) -> syn::ItemStruct {
+    let struct_ident = syn::Ident::new(struct_name, Span::call_site());
+    let nesting_key_doc_str = nesting_key_doc_str(nesting);
+    let doc_str = format!(
+        "A keys builder struct for the array at key `{nesting_key_doc_str}`.\n\n\
+        Generated solely for use within the `Keys` builder pattern.",
+    );
+    syn::parse_quote! {
+        #[doc = #doc_str]
+        #[allow(non_camel_case_types)]
+        pub struct #struct_ident<'a> {
+            keys: &'a mut Keys,
+        }
+    }
+}
+
+/// A map key builder method for entries with nested array values.
+fn key_method_for_array(arr_nesting: &[Nesting]) -> syn::ImplItemFn {
+    let struct_name = struct_name(arr_nesting);
+    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
+    syn::parse_quote! {
+        /// Add keys for the nested array at the given key.
+        pub fn entry(mut self, ix: usize, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
+            self.key_elems.push(pint_abi::key::Elem::ArrayIx(ix));
+            f(#struct_ident { keys: &mut self.keys });
+            self.key_elems.pop();
+            self
+        }
+    }
+}
+
+/// An array key builder method for entries with nested map values.
+fn key_method_for_map(map_nesting: &[Nesting]) -> syn::ImplItemFn {
+    let struct_name = map::struct_name(map_nesting);
+    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
+    syn::parse_quote! {
+        /// Add keys for the nested map at the given key.
+        pub fn entry(mut self, ix: usize, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
+            self.key_elems.push(pint_abi::key::Elem::ArrayIx(ix));
+            f(#struct_ident { keys: &mut self.keys });
+            self.key_elems.pop();
+            self
+        }
+    }
+}
+
+/// An array key builder method for entries with tuple values.
+fn key_method_for_tuple(tup_nesting: &[Nesting]) -> syn::ImplItemFn {
+    let struct_name = tuple::struct_name(tup_nesting);
+    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
+    syn::parse_quote! {
+        /// Add keys for the tuple at the given index.
+        pub fn entry(mut self, ix: usize, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
+            self.key_elems.push(pint_abi::key::Elem::ArrayIx(ix));
+            f(#struct_ident { keys: &mut self.keys });
+            self.key_elems.pop();
+            self
+        }
+    }
+}
+
+/// An array key builder method for an element with a single-key.
+fn key_method_for_single_key(elem_nesting: &[Nesting]) -> syn::ImplItemFn {
+    let nesting_expr: syn::ExprArray = nesting_expr(elem_nesting);
+    let construct_key_expr: syn::Expr = construct_key_expr();
+    let nesting_key_doc_str = nesting_key_doc_str(elem_nesting);
+    let method_doc_str = format!(
+        "The given index will be flattened and encoded as a word and merged into the full key `{nesting_key_doc_str}`."
+    );
+    syn::parse_quote! {
+        /// Add a key for the element at the given index.
+        ///
+        #[doc = #method_doc_str]
+        pub fn entry(mut self, ix: usize) -> Self {
+            use pint_abi::types::essential::Key;
+            // Add the array index to the key stack.
+            self.key_elems.push(pint_abi::key::Elem::ArrayIx(ix));
+            // Merge the key stack with the ABI key.
+            let nesting = #nesting_expr;
+            let key: Key = #construct_key_expr;
+            // Add the key to the set.
+            self.set.retain(|k: &Key| k != &key);
+            self.set.push(key);
+            // Pop the entry key from the stack.
+            self.key_elems.pop();
+            self
+        }
+    }
+}
+
+/// An array method for inserting keys for an entry associated with a given index.
+fn key_method(tree: &KeyedVarTree, elem: NodeIx, elem_ty: &TypeABI) -> syn::ImplItemFn {
+    let elem_nesting = tree.nesting(elem);
+    match elem_ty {
+        TypeABI::Bool | TypeABI::Int | TypeABI::Real | TypeABI::String | TypeABI::B256 => (),
+        TypeABI::Array { .. } => return key_method_for_array(&elem_nesting),
+        TypeABI::Tuple { .. } => {
+            return key_method_for_tuple(&elem_nesting);
+        }
+        TypeABI::Map { .. } => {
+            return key_method_for_map(&elem_nesting);
+        }
+    };
+    key_method_for_single_key(&elem_nesting)
+}
+
+/// The implementation for the map keys builder of the given name.
+fn keys_impl(tree: &KeyedVarTree, array: NodeIx, struct_name: &str, ty: &TypeABI) -> syn::ItemImpl {
+    let struct_ident = syn::Ident::new(struct_name, Span::call_site());
+    // The node for an array elem is its only child.
+    let elem = tree.children(array)[0];
+    let method = key_method(tree, elem, ty);
+    syn::parse_quote! {
+        impl<'a> #struct_ident<'a> {
+            #method
+        }
+    }
+}
+
+/// Array builder types and impls for a given keyed array type.
+pub(crate) fn keys_items(tree: &KeyedVarTree, array: NodeIx, ty: &TypeABI) -> Vec<syn::Item> {
+    let nesting = tree.nesting(array);
+    let struct_name = struct_name(&nesting);
+    let mut items = vec![];
+    items.push(keys_struct(&struct_name, &nesting).into());
+    items.push(keys_impl(tree, array, &struct_name, ty).into());
+    items.extend(
+        keys::impl_deref_for_nested(&struct_name)
+            .into_iter()
+            .map(syn::Item::from),
+    );
+    items
+}
+
+// ------------------------------------
+// Mutations
+// ------------------------------------
 
 /// A builder struct for an array field.
 fn mutations_struct(struct_name: &str, nesting: &[Nesting]) -> syn::ItemStruct {
@@ -31,7 +174,7 @@ fn mutations_struct(struct_name: &str, nesting: &[Nesting]) -> syn::ItemStruct {
 
 /// A map mutation builder method for entries with nested array values.
 fn mutation_method_for_array(arr_nesting: &[Nesting]) -> syn::ImplItemFn {
-    let struct_name = mutations_struct_name(arr_nesting);
+    let struct_name = struct_name(arr_nesting);
     let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
     syn::parse_quote! {
         /// Add mutations for the nested array at the given key.
@@ -46,7 +189,7 @@ fn mutation_method_for_array(arr_nesting: &[Nesting]) -> syn::ImplItemFn {
 
 /// An array mutation builder method for entries with nested map values.
 fn mutation_method_for_map(map_nesting: &[Nesting]) -> syn::ImplItemFn {
-    let struct_name = map::mutations_struct_name(map_nesting);
+    let struct_name = map::struct_name(map_nesting);
     let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
     syn::parse_quote! {
         /// Add mutations for the nested map at the given key.
@@ -61,7 +204,7 @@ fn mutation_method_for_map(map_nesting: &[Nesting]) -> syn::ImplItemFn {
 
 /// An array mutation builder method for entries with tuple values.
 fn mutation_method_for_tuple(tup_nesting: &[Nesting]) -> syn::ImplItemFn {
-    let struct_name = tuple::mutations_struct_name(tup_nesting);
+    let struct_name = tuple::struct_name(tup_nesting);
     let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
     syn::parse_quote! {
         /// Add mutations for the tuple at the given index.
@@ -148,14 +291,14 @@ fn mutations_impl(
 }
 
 /// Array builder types and impls for a given keyed array type.
-pub(crate) fn builder_items(tree: &KeyedVarTree, array: NodeIx, ty: &TypeABI) -> Vec<syn::Item> {
+pub(crate) fn mutations_items(tree: &KeyedVarTree, array: NodeIx, ty: &TypeABI) -> Vec<syn::Item> {
     let nesting = tree.nesting(array);
-    let struct_name = mutations_struct_name(&nesting);
+    let struct_name = struct_name(&nesting);
     let mut items = vec![];
     items.push(mutations_struct(&struct_name, &nesting).into());
     items.push(mutations_impl(tree, array, &struct_name, ty).into());
     items.extend(
-        mutation::impl_deref_for_nested(&struct_name)
+        mutations::impl_deref_for_nested(&struct_name)
             .into_iter()
             .map(syn::Item::from),
     );

--- a/pint-abi-gen/src/keys.rs
+++ b/pint-abi-gen/src/keys.rs
@@ -1,0 +1,247 @@
+//! Items for the `Keys` type generated for `storage` and `pub vars`, aimed
+//! at making it easier to build a set of [`Key`][essential_types::Key]s for
+//! a solution.
+
+use crate::{array, map, tuple};
+use pint_abi_types::{TypeABI, VarABI};
+use pint_abi_visit::{KeyedVarTree, Nesting, NodeIx};
+use proc_macro2::Span;
+
+/// Recursively traverse the given keyed var and create a builder struct and
+/// associated impl for each tuple, map and array.
+fn nested_items_from_node(tree: &KeyedVarTree, n: NodeIx) -> Vec<syn::Item> {
+    let mut items = vec![];
+    match tree[n].ty {
+        TypeABI::Array { ty, size: _ } => {
+            items.extend(array::keys_items(tree, n, ty));
+        }
+        TypeABI::Map { ty_from, ty_to } => {
+            items.extend(map::keys_items(tree, n, ty_from, ty_to));
+        }
+        TypeABI::Tuple(_fields) => {
+            items.extend(tuple::keys_items(tree, n));
+        }
+        TypeABI::Bool | TypeABI::Int | TypeABI::Real | TypeABI::String | TypeABI::B256 => (),
+    }
+    items
+}
+
+/// Recursively traverse the given keyed vars and create a builder structs and
+/// impls for each tuple, map and array.
+fn nested_items_from_keyed_vars(vars: &[VarABI]) -> Vec<syn::Item> {
+    let mut items = vec![];
+    let tree = KeyedVarTree::from_keyed_vars(vars);
+    tree.dfs(|n| {
+        items.extend(nested_items_from_node(&tree, n));
+    });
+    items
+}
+
+/// The `From<Keys>` implementation for `Vec<Key>`.
+fn impl_from_keys_for_vec() -> syn::ItemImpl {
+    syn::parse_quote! {
+        impl From<Keys> for Vec<pint_abi::types::essential::Key> {
+            fn from(m: Keys) -> Self {
+                m.set
+            }
+        }
+    }
+}
+
+/// The docstring for a `Keys` method.
+fn method_doc_str(name: &str) -> String {
+    format!(
+        "Add a key for the `{name}` field into the set.\n\n\
+        Relaces any existing entry for the given key.",
+    )
+}
+
+/// A `Keys` builder method for an array field.
+fn method_for_array(name: &str, array_nesting: &[Nesting]) -> syn::ImplItemFn {
+    let struct_name = array::struct_name(array_nesting);
+    let method_ident = syn::Ident::new(name, Span::call_site());
+    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
+    let doc_str = method_doc_str(name);
+    syn::parse_quote! {
+        #[doc = #doc_str]
+        pub fn #method_ident(mut self, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
+            f(#struct_ident { keys: &mut self });
+            self
+        }
+    }
+}
+
+/// A `Keys` builder method for a map field.
+fn method_for_map(name: &str, map_nesting: &[Nesting]) -> syn::ImplItemFn {
+    let struct_name = map::struct_name(map_nesting);
+    let method_ident = syn::Ident::new(name, Span::call_site());
+    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
+    let doc_str = method_doc_str(name);
+    syn::parse_quote! {
+        #[doc = #doc_str]
+        pub fn #method_ident(mut self, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
+            f(#struct_ident { keys: &mut self });
+            self
+        }
+    }
+}
+
+/// A `Keys` builder method for a tuple field.
+fn method_for_tuple(name: &str, nesting: &[Nesting]) -> syn::ImplItemFn {
+    let struct_name = tuple::struct_name(nesting);
+    let method_ident = syn::Ident::new(name, Span::call_site());
+    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
+    let doc_str = method_doc_str(name);
+    syn::parse_quote! {
+        #[doc = #doc_str]
+        pub fn #method_ident(mut self, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
+            f(#struct_ident { keys: &mut self });
+            self
+        }
+    }
+}
+
+/// A `Keys` builder method for a single-key.
+fn method_for_single_key(name: &str, nesting: &[Nesting]) -> syn::ImplItemFn {
+    let method_ident = syn::Ident::new(name, Span::call_site());
+    let nesting_key_doc_str = crate::nesting_key_doc_str(nesting);
+    let doc_str = format!("{}\n\nKey: `{nesting_key_doc_str}`", method_doc_str(name));
+    let nesting_expr: syn::ExprArray = crate::nesting_expr(nesting);
+    let construct_key_expr: syn::Expr = crate::construct_key_expr();
+    syn::parse_quote! {
+        #[doc = #doc_str]
+        pub fn #method_ident(mut self) -> Self {
+            use pint_abi::types::essential::Key;
+            let nesting = #nesting_expr;
+            let key: Key = #construct_key_expr;
+            self.set.retain(|k: &Key| k != &key);
+            self.set.push(key);
+            self
+        }
+    }
+}
+
+/// A builder method that takes an argument of the keyed type at the given index
+/// within the tree.
+///
+/// This is shared between both the `Keys` and `Tuple_*` implementations.
+pub(crate) fn method_from_node(tree: &KeyedVarTree, n: NodeIx, name: &str) -> syn::ImplItemFn {
+    let nesting = tree.nesting(n);
+    match &tree[n].ty {
+        TypeABI::Bool | TypeABI::Int | TypeABI::Real | TypeABI::String | TypeABI::B256 => (),
+        TypeABI::Array { ty: _, size: _ } => {
+            return method_for_array(name, &nesting);
+        }
+        TypeABI::Tuple(_) => {
+            return method_for_tuple(name, &nesting);
+        }
+        TypeABI::Map { .. } => {
+            return method_for_map(name, &nesting);
+        }
+    };
+    method_for_single_key(name, &nesting)
+}
+
+/// All builder methods for the `Keys` builder type.
+fn impl_keys_methods(vars: &[VarABI]) -> Vec<syn::ImplItemFn> {
+    let tree = KeyedVarTree::from_keyed_vars(vars);
+    tree.roots()
+        .iter()
+        .map(|&n| {
+            let name = crate::field_name_from_var_name(tree[n].name.unwrap());
+            method_from_node(&tree, n, &name)
+        })
+        .collect()
+}
+
+/// The implementation for the `Keys` builder type.
+fn impl_keys(vars: &[VarABI]) -> syn::ItemImpl {
+    let methods = impl_keys_methods(vars);
+    syn::parse_quote! {
+        impl Keys {
+            #(
+                #methods
+            )*
+        }
+    }
+}
+
+/// Shorthand constructor for the `Keys` builder.
+fn keys_fn() -> syn::ItemFn {
+    syn::parse_quote! {
+        /// Begin building a set of [`Keys`].
+        pub fn keys() -> Keys {
+            Keys::default()
+        }
+    }
+}
+
+/// The builder struct for keys.
+fn keys_struct() -> syn::ItemStruct {
+    syn::parse_quote! {
+        /// A builder for a set of keys.
+        ///
+        /// Can be constructed via the [`keys`] function.
+        #[derive(Debug, Default)]
+        pub struct Keys {
+            /// The set of keys being built.
+            set: Vec<pint_abi::types::essential::Key>,
+            /// The stack of key elements that need to be merged with the
+            /// `&[Nesting]` derived by the `TypeABI` traversal.
+            ///
+            /// For example, when a map's `entry` method is called, the provided
+            /// key is pushed to this stack. Upon completion of the `entry`
+            /// method, the key is popped.
+            key_elems: Vec<pint_abi::key::Elem>,
+        }
+    }
+}
+
+/// A `DerefMut<Target = Keys>` impl for a nested builder struct.
+///
+/// This allows for easily accessing the `Keys` type's `key_elems` and
+/// `set` fields within impls for the nested tuple, map and array builder types.
+pub(crate) fn impl_deref_for_nested(struct_name: &str) -> Vec<syn::ItemImpl> {
+    let struct_ident = syn::Ident::new(struct_name, Span::call_site());
+    let deref_impl = syn::parse_quote! {
+        impl<'a> core::ops::Deref for #struct_ident<'a> {
+            type Target = Keys;
+            fn deref(&self) -> &Self::Target {
+                &*self.keys
+            }
+        }
+    };
+    let deref_mut_impl = syn::parse_quote! {
+        impl<'a> core::ops::DerefMut for #struct_ident<'a> {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut *self.keys
+            }
+        }
+    };
+    vec![deref_impl, deref_mut_impl]
+}
+
+/// All items for the `Keys` type, nested keys builder types and their impls.
+fn items(vars: &[VarABI]) -> Vec<syn::Item> {
+    let mut items = vec![
+        keys_struct().into(),
+        keys_fn().into(),
+        impl_keys(vars).into(),
+        impl_from_keys_for_vec().into(),
+    ];
+    items.extend(nested_items_from_keyed_vars(vars));
+    items
+}
+
+/// A `keys` module for all `Keys`-related items.
+pub(crate) fn module(vars: &[VarABI]) -> syn::ItemMod {
+    let items = items(vars);
+    syn::parse_quote! {
+        pub mod keys {
+            //! All items related to building a set of [`Keys`].
+            #(
+                #items
+            )*
+        }
+    }
+}

--- a/pint-abi-gen/src/map.rs
+++ b/pint-abi-gen/src/map.rs
@@ -1,17 +1,186 @@
 //! Items related to generating the `Map` mutations and keys builders.
 
 use crate::{
-    array, construct_key_expr, mutation, nesting_expr, nesting_key_doc_str, nesting_ty_str, tuple,
-    ty_from_pint_ty, SingleKeyTy,
+    array, construct_key_expr, keys, mutations, nesting_expr, nesting_key_doc_str, nesting_ty_str,
+    tuple, ty_from_pint_ty, SingleKeyTy,
 };
 use pint_abi_types::TypeABI;
 use pint_abi_visit::{KeyedVarTree, Nesting, NodeIx};
 use proc_macro2::Span;
 
 /// The name for the a map builder struct.
-pub(crate) fn mutations_struct_name(nesting: &[Nesting]) -> String {
+pub(crate) fn struct_name(nesting: &[Nesting]) -> String {
     format!("Map_{}", nesting_ty_str(nesting))
 }
+
+// ------------------------------------
+// Keys
+// ------------------------------------
+
+/// A builder struct for a map field.
+fn keys_struct(struct_name: &str, nesting: &[Nesting]) -> syn::ItemStruct {
+    let struct_ident = syn::Ident::new(struct_name, Span::call_site());
+    let nesting_key_doc_str = nesting_key_doc_str(nesting);
+    let doc_str = format!(
+        "A keys builder struct for the map at key `{nesting_key_doc_str}`.\n\n\
+        Generated solely for use within the `Keys` builder pattern.",
+    );
+    syn::parse_quote! {
+        #[doc = #doc_str]
+        #[allow(non_camel_case_types)]
+        pub struct #struct_ident<'a> {
+            keys: &'a mut Keys,
+        }
+    }
+}
+
+/// A map key builder method for entries with nested array values.
+fn key_method_for_array(ty_from: &TypeABI, array_nesting: &[Nesting]) -> syn::ImplItemFn {
+    let key_ty = ty_from_pint_ty(ty_from);
+    let struct_name = array::struct_name(array_nesting);
+    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
+    syn::parse_quote! {
+        /// Add keys for the nested map at the given key.
+        pub fn entry(mut self, key: #key_ty, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
+            let key_words: pint_abi::types::essential::Key = pint_abi::encode(&key);
+            self.key_elems.push(pint_abi::key::Elem::MapKey(key_words));
+            f(#struct_ident { keys: &mut self.keys });
+            self.key_elems.pop();
+            self
+        }
+    }
+}
+
+/// A map key builder method for entries with nested map values.
+fn key_method_for_map(ty_from: &TypeABI, map_nesting: &[Nesting]) -> syn::ImplItemFn {
+    let key_ty = ty_from_pint_ty(ty_from);
+    let struct_name = struct_name(map_nesting);
+    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
+    syn::parse_quote! {
+        /// Add keys for the nested map at the given key.
+        pub fn entry(mut self, key: #key_ty, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
+            let key_words: pint_abi::types::essential::Key = pint_abi::encode(&key);
+            self.key_elems.push(pint_abi::key::Elem::MapKey(key_words));
+            f(#struct_ident { keys: &mut self.keys });
+            self.key_elems.pop();
+            self
+        }
+    }
+}
+
+/// A map key builder method for entries with tuple values.
+fn key_method_for_tuple(ty_from: &TypeABI, tup_nesting: &[Nesting]) -> syn::ImplItemFn {
+    let key_ty = ty_from_pint_ty(ty_from);
+    let struct_name = tuple::struct_name(tup_nesting);
+    let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
+    syn::parse_quote! {
+        /// Add keys for the tuple at the given key.
+        pub fn entry(mut self, key: #key_ty, f: impl FnOnce(#struct_ident) -> #struct_ident) -> Self {
+            let key_words: pint_abi::types::essential::Key = pint_abi::encode(&key);
+            self.key_elems.push(pint_abi::key::Elem::MapKey(key_words));
+            f(#struct_ident { keys: &mut self.keys });
+            self.key_elems.pop();
+            self
+        }
+    }
+}
+
+/// A map key builder method for an entry with a single-key value.
+fn key_method_for_single_key(ty_from: &TypeABI, val_nesting: &[Nesting]) -> syn::ImplItemFn {
+    let key_ty = ty_from_pint_ty(ty_from);
+    let nesting_expr: syn::ExprArray = nesting_expr(val_nesting);
+    let construct_key_expr: syn::Expr = construct_key_expr();
+    let abi_key_doc_str = nesting_key_doc_str(val_nesting);
+    let merge_doc_str = format!(
+        "The given key will be encoded as words and merged into the full key `{abi_key_doc_str}`."
+    );
+    syn::parse_quote! {
+        /// Add a key for the entry at the given key.
+        ///
+        #[doc = #merge_doc_str]
+        pub fn entry(mut self, key: #key_ty) -> Self {
+            use pint_abi::types::essential::Key;
+            // Add the map key to the stack.
+            let key: Key = pint_abi::encode(&key);
+            self.key_elems.push(pint_abi::key::Elem::MapKey(key));
+            // Merge the key stack with the ABI key.
+            let nesting = #nesting_expr;
+            let key: Key = #construct_key_expr;
+            // Add the key to the set.
+            self.set.retain(|k: &Key| k != &key);
+            self.set.push(key);
+            // Pop the entry key from the stack.
+            self.key_elems.pop();
+            self
+        }
+    }
+}
+
+/// A map method for inserting keys for an entry associated with a given key.
+fn key_method(
+    tree: &KeyedVarTree,
+    entry: NodeIx,
+    ty_from: &TypeABI,
+    ty_to: &TypeABI,
+) -> syn::ImplItemFn {
+    let nesting = tree.nesting(entry);
+    match ty_to {
+        TypeABI::Bool | TypeABI::Int | TypeABI::Real | TypeABI::String | TypeABI::B256 => (),
+        TypeABI::Array { ty: _, size: _ } => {
+            return key_method_for_array(ty_from, &nesting);
+        }
+        TypeABI::Tuple(_) => {
+            return key_method_for_tuple(ty_from, &nesting);
+        }
+        TypeABI::Map { .. } => {
+            return key_method_for_map(ty_from, &nesting);
+        }
+    };
+    key_method_for_single_key(ty_from, &nesting)
+}
+
+/// The implementation for the map keys builder of the given name.
+fn keys_impl(
+    tree: &KeyedVarTree,
+    map: NodeIx,
+    struct_name: &str,
+    ty_from: &TypeABI,
+    ty_to: &TypeABI,
+) -> syn::ItemImpl {
+    let struct_ident = syn::Ident::new(struct_name, Span::call_site());
+    // The node for a map entry is its only child.
+    let entry = tree.children(map)[0];
+    let method = key_method(tree, entry, ty_from, ty_to);
+    syn::parse_quote! {
+        impl<'a> #struct_ident<'a> {
+            #method
+        }
+    }
+}
+
+/// Map builder types and impls for a given keyed map type.
+pub(crate) fn keys_items(
+    tree: &KeyedVarTree,
+    map: NodeIx,
+    ty_from: &TypeABI,
+    ty_to: &TypeABI,
+) -> Vec<syn::Item> {
+    let nesting = tree.nesting(map);
+    let struct_name = struct_name(&nesting);
+    let mut items = vec![];
+    items.push(keys_struct(&struct_name, &nesting).into());
+    items.push(keys_impl(tree, map, &struct_name, ty_from, ty_to).into());
+    items.extend(
+        keys::impl_deref_for_nested(&struct_name)
+            .into_iter()
+            .map(syn::Item::from),
+    );
+    items
+}
+
+// ------------------------------------
+// Mutations
+// ------------------------------------
 
 /// A builder struct for a map field.
 fn mutations_struct(struct_name: &str, nesting: &[Nesting]) -> syn::ItemStruct {
@@ -33,7 +202,7 @@ fn mutations_struct(struct_name: &str, nesting: &[Nesting]) -> syn::ItemStruct {
 /// A map mutation builder method for entries with nested array values.
 fn mutation_method_for_array(ty_from: &TypeABI, array_nesting: &[Nesting]) -> syn::ImplItemFn {
     let key_ty = ty_from_pint_ty(ty_from);
-    let struct_name = array::mutations_struct_name(array_nesting);
+    let struct_name = array::struct_name(array_nesting);
     let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
     syn::parse_quote! {
         /// Add mutations for the nested map at the given key.
@@ -50,7 +219,7 @@ fn mutation_method_for_array(ty_from: &TypeABI, array_nesting: &[Nesting]) -> sy
 /// A map mutation builder method for entries with nested map values.
 fn mutation_method_for_map(ty_from: &TypeABI, map_nesting: &[Nesting]) -> syn::ImplItemFn {
     let key_ty = ty_from_pint_ty(ty_from);
-    let struct_name = mutations_struct_name(map_nesting);
+    let struct_name = struct_name(map_nesting);
     let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
     syn::parse_quote! {
         /// Add mutations for the nested map at the given key.
@@ -67,7 +236,7 @@ fn mutation_method_for_map(ty_from: &TypeABI, map_nesting: &[Nesting]) -> syn::I
 /// A map mutation builder method for entries with tuple values.
 fn mutation_method_for_tuple(ty_from: &TypeABI, tup_nesting: &[Nesting]) -> syn::ImplItemFn {
     let key_ty = ty_from_pint_ty(ty_from);
-    let struct_name = tuple::mutations_struct_name(tup_nesting);
+    let struct_name = tuple::struct_name(tup_nesting);
     let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
     syn::parse_quote! {
         /// Add mutations for the tuple at the given key.
@@ -169,19 +338,19 @@ fn mutations_impl(
 }
 
 /// Map builder types and impls for a given keyed map type.
-pub(crate) fn builder_items(
+pub(crate) fn mutations_items(
     tree: &KeyedVarTree,
     map: NodeIx,
     ty_from: &TypeABI,
     ty_to: &TypeABI,
 ) -> Vec<syn::Item> {
     let nesting = tree.nesting(map);
-    let struct_name = mutations_struct_name(&nesting);
+    let struct_name = struct_name(&nesting);
     let mut items = vec![];
     items.push(mutations_struct(&struct_name, &nesting).into());
     items.push(mutations_impl(tree, map, &struct_name, ty_from, ty_to).into());
     items.extend(
-        mutation::impl_deref_for_nested(&struct_name)
+        mutations::impl_deref_for_nested(&struct_name)
             .into_iter()
             .map(syn::Item::from),
     );

--- a/pint-abi-gen/src/mutations.rs
+++ b/pint-abi-gen/src/mutations.rs
@@ -9,17 +9,17 @@ use proc_macro2::Span;
 
 /// Recursively traverse the given keyed var and create a builder struct and
 /// associated impl for each tuple, map and array.
-fn nested_builder_items_from_node(tree: &KeyedVarTree, n: NodeIx) -> Vec<syn::Item> {
+fn nested_items_from_node(tree: &KeyedVarTree, n: NodeIx) -> Vec<syn::Item> {
     let mut items = vec![];
     match tree[n].ty {
         TypeABI::Array { ty, size: _ } => {
-            items.extend(array::builder_items(tree, n, ty));
+            items.extend(array::mutations_items(tree, n, ty));
         }
         TypeABI::Map { ty_from, ty_to } => {
-            items.extend(map::builder_items(tree, n, ty_from, ty_to));
+            items.extend(map::mutations_items(tree, n, ty_from, ty_to));
         }
         TypeABI::Tuple(_fields) => {
-            items.extend(tuple::builder_items(tree, n));
+            items.extend(tuple::mutations_items(tree, n));
         }
         TypeABI::Bool | TypeABI::Int | TypeABI::Real | TypeABI::String | TypeABI::B256 => (),
     }
@@ -28,11 +28,11 @@ fn nested_builder_items_from_node(tree: &KeyedVarTree, n: NodeIx) -> Vec<syn::It
 
 /// Recursively traverse the given keyed vars and create a builder structs and
 /// impls for each tuple, map and array.
-fn nested_builder_items_from_keyed_vars(vars: &[VarABI]) -> Vec<syn::Item> {
+fn nested_items_from_keyed_vars(vars: &[VarABI]) -> Vec<syn::Item> {
     let mut items = vec![];
     let tree = KeyedVarTree::from_keyed_vars(vars);
     tree.dfs(|n| {
-        items.extend(nested_builder_items_from_node(&tree, n));
+        items.extend(nested_items_from_node(&tree, n));
     });
     items
 }
@@ -58,7 +58,7 @@ fn method_doc_str(name: &str) -> String {
 
 /// A `Mutations` builder method for an array field.
 fn method_for_array(name: &str, array_nesting: &[Nesting]) -> syn::ImplItemFn {
-    let struct_name = array::mutations_struct_name(array_nesting);
+    let struct_name = array::struct_name(array_nesting);
     let method_ident = syn::Ident::new(name, Span::call_site());
     let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
     let doc_str = method_doc_str(name);
@@ -73,7 +73,7 @@ fn method_for_array(name: &str, array_nesting: &[Nesting]) -> syn::ImplItemFn {
 
 /// A `Mutations` builder method for a map field.
 fn method_for_map(name: &str, map_nesting: &[Nesting]) -> syn::ImplItemFn {
-    let struct_name = map::mutations_struct_name(map_nesting);
+    let struct_name = map::struct_name(map_nesting);
     let method_ident = syn::Ident::new(name, Span::call_site());
     let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
     let doc_str = method_doc_str(name);
@@ -88,7 +88,7 @@ fn method_for_map(name: &str, map_nesting: &[Nesting]) -> syn::ImplItemFn {
 
 /// A `Mutations` builder method for a tuple field.
 fn method_for_tuple(name: &str, nesting: &[Nesting]) -> syn::ImplItemFn {
-    let struct_name = tuple::mutations_struct_name(nesting);
+    let struct_name = tuple::struct_name(nesting);
     let method_ident = syn::Ident::new(name, Span::call_site());
     let struct_ident = syn::Ident::new(&struct_name, Span::call_site());
     let doc_str = method_doc_str(name);
@@ -146,7 +146,6 @@ pub(crate) fn method_from_node(tree: &KeyedVarTree, n: NodeIx, name: &str) -> sy
             return method_for_map(name, &nesting);
         }
     };
-    // A mutation builder method for a single mutation.
     method_for_single_key(name, &arg_ty, &nesting)
 }
 
@@ -230,13 +229,26 @@ pub(crate) fn impl_deref_for_nested(struct_name: &str) -> Vec<syn::ItemImpl> {
 }
 
 /// All items for the `Mutations` type, nested mutations builder types and their impls.
-pub(crate) fn items(vars: &[VarABI]) -> Vec<syn::Item> {
+fn items(vars: &[VarABI]) -> Vec<syn::Item> {
     let mut items = vec![
         mutations_struct().into(),
         mutations_fn().into(),
         impl_mutations(vars).into(),
         impl_from_mutations_for_vec().into(),
     ];
-    items.extend(nested_builder_items_from_keyed_vars(vars));
+    items.extend(nested_items_from_keyed_vars(vars));
     items
+}
+
+/// A `mutations` module for all `Mutations`-related items.
+pub(crate) fn module(vars: &[VarABI]) -> syn::ItemMod {
+    let items = items(vars);
+    syn::parse_quote! {
+        pub mod mutations {
+            //! All items related to building a set of [`Mutations`].
+            #(
+                #items
+            )*
+        }
+    }
 }

--- a/pint-abi-gen/src/tuple.rs
+++ b/pint-abi-gen/src/tuple.rs
@@ -1,13 +1,88 @@
 //! Items related to generating the `Map` mutations and keys builders.
 
-use crate::{mutation, nesting_key_doc_str, nesting_ty_str};
+use crate::{keys, mutations, nesting_key_doc_str, nesting_ty_str};
 use pint_abi_visit::{KeyedVarTree, Nesting, NodeIx};
 use proc_macro2::Span;
 
 /// The name for the a tuple builder struct.
-pub(crate) fn mutations_struct_name(nesting: &[Nesting]) -> String {
+pub(crate) fn struct_name(nesting: &[Nesting]) -> String {
     format!("Tuple_{}", nesting_ty_str(nesting))
 }
+
+// ------------------------------------
+// Keys
+// ------------------------------------
+
+/// A builder struct for a tuple field.
+fn keys_struct(nesting: &[Nesting], struct_name: &str) -> syn::ItemStruct {
+    let struct_ident = syn::Ident::new(struct_name, Span::call_site());
+    let key_doc_str = nesting_key_doc_str(nesting);
+    let doc_str = format!(
+        "A keys builder struct for the tuple at key `{key_doc_str}`.\n\n\
+        Generated solely for use within the `Keys` builder pattern.",
+    );
+    syn::parse_quote! {
+        #[doc = #doc_str]
+        #[allow(non_camel_case_types)]
+        pub struct #struct_ident<'a> {
+            keys: &'a mut Keys,
+        }
+    }
+}
+
+/// A key builder method for a tuple struct.
+fn key_method(tree: &KeyedVarTree, field: NodeIx) -> syn::ImplItemFn {
+    let field_keyed = &tree[field];
+    let name = field_keyed.name.map(|s| s.to_string()).unwrap_or_else(|| {
+        let ix = match &field_keyed.nesting {
+            Nesting::TupleField { ix, .. } => ix,
+            nesting => todo!("expected tuple field, found {nesting:?}"),
+        };
+        format!("_{ix}")
+    });
+    keys::method_from_node(tree, field, &name)
+}
+
+/// The key builder methods for a tuple struct.
+fn keys_methods(tree: &KeyedVarTree, tuple: NodeIx) -> Vec<syn::ImplItemFn> {
+    tree.children(tuple)
+        .into_iter()
+        .map(|field| key_method(tree, field))
+        .collect()
+}
+
+/// The implementation for the tuple keys builder of the given name.
+/// `n` is the node index of the tuple within the tree.
+fn keys_impl(tree: &KeyedVarTree, tuple: NodeIx, struct_name: &str) -> syn::ItemImpl {
+    let struct_ident = syn::Ident::new(struct_name, Span::call_site());
+    let methods = keys_methods(tree, tuple);
+    syn::parse_quote! {
+        impl<'a> #struct_ident<'a> {
+            #(
+                #methods
+            )*
+        }
+    }
+}
+
+/// Tuple key builder types and impls for a given keyed tuple type.
+pub(crate) fn keys_items(tree: &KeyedVarTree, tuple: NodeIx) -> Vec<syn::Item> {
+    let nesting = tree.nesting(tuple);
+    let struct_name = struct_name(&nesting);
+    let mut items = vec![];
+    items.push(keys_struct(&nesting, &struct_name).into());
+    items.push(keys_impl(tree, tuple, &struct_name).into());
+    items.extend(
+        keys::impl_deref_for_nested(&struct_name)
+            .into_iter()
+            .map(syn::Item::from),
+    );
+    items
+}
+
+// ------------------------------------
+// Mutations
+// ------------------------------------
 
 /// A builder struct for a tuple field.
 fn mutations_struct(nesting: &[Nesting], struct_name: &str) -> syn::ItemStruct {
@@ -36,7 +111,7 @@ fn mutation_method(tree: &KeyedVarTree, field: NodeIx) -> syn::ImplItemFn {
         };
         format!("_{ix}")
     });
-    mutation::method_from_node(tree, field, &name)
+    mutations::method_from_node(tree, field, &name)
 }
 
 /// The mutation builder methods for a tuple struct.
@@ -61,15 +136,15 @@ fn mutations_impl(tree: &KeyedVarTree, tuple: NodeIx, struct_name: &str) -> syn:
     }
 }
 
-/// Tuple builder types and impls for a given keyed tuple type.
-pub(crate) fn builder_items(tree: &KeyedVarTree, tuple: NodeIx) -> Vec<syn::Item> {
+/// Tuple mutation builder types and impls for a given keyed tuple type.
+pub(crate) fn mutations_items(tree: &KeyedVarTree, tuple: NodeIx) -> Vec<syn::Item> {
     let nesting = tree.nesting(tuple);
-    let struct_name = mutations_struct_name(&nesting);
+    let struct_name = struct_name(&nesting);
     let mut items = vec![];
     items.push(mutations_struct(&nesting, &struct_name).into());
     items.push(mutations_impl(tree, tuple, &struct_name).into());
     items.extend(
-        mutation::impl_deref_for_nested(&struct_name)
+        mutations::impl_deref_for_nested(&struct_name)
             .into_iter()
             .map(syn::Item::from),
     );


### PR DESCRIPTION
*Based on #761.*

The `Keys` builder is very similar to the `Mutations` builder, but just builds the keys rather than the key value pairs.

This will be useful for querying state from a server or node.

Part of solving #734.