### PR TITLE
feat: Add support for decoding ABI types from `Word`s

### DIFF
--- a/pint-abi-gen-tests/tests/simple.rs
+++ b/pint-abi-gen-tests/tests/simple.rs
@@ -1,6 +1,6 @@
 use pint_abi::types::essential::{
     solution::{Mutation, Solution, SolutionData},
-    Key, PredicateAddress,
+    Key, PredicateAddress, Value,
 };
 use pint_abi_gen_tests::simple;
 use std::sync::Arc;
@@ -108,6 +108,16 @@ async fn test_solution_foo() {
     for (key, mutation) in keys.iter().zip(&state_mutations) {
         assert_eq!(key, &mutation.key);
     }
+
+    // Check Encoding/Decoding roundtrip for decision vars.
+    let words = pint_abi::encode(&vars);
+    let vars2: simple::Foo::Vars = pint_abi::decode(&words[..]).unwrap();
+    assert_eq!(&vars, &vars2);
+
+    // Check To/From Vec<Value> roundtrip.
+    let values: Vec<Value> = vars.clone().into();
+    let vars3 = simple::Foo::Vars::try_from(&values[..]).unwrap();
+    assert_eq!(&vars, &vars3);
 
     // Create the solution data.
     let solution_data = SolutionData {

--- a/pint-abi-gen/src/vars.rs
+++ b/pint-abi-gen/src/vars.rs
@@ -18,12 +18,19 @@ fn fields(vars: &[VarABI]) -> Vec<syn::Field> {
         .collect()
 }
 
+/// Just the ident for each field.
+fn field_idents(vars: &[VarABI]) -> impl '_ + Iterator<Item = syn::Ident> {
+    vars.iter()
+        .map(|var| field_name_from_var_name(&var.name))
+        .map(|name| syn::Ident::new(&name, Span::call_site()))
+}
+
 /// Generate a struct for an predicate's decision variables.
 fn struct_decl(vars: &[VarABI]) -> syn::ItemStruct {
     let fields = fields(vars);
     syn::parse_quote! {
         /// The predicate's decision variables.
-        #[derive(Clone, Debug)]
+        #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
         pub struct Vars {
             #(
                 #fields
@@ -32,12 +39,9 @@ fn struct_decl(vars: &[VarABI]) -> syn::ItemStruct {
     }
 }
 
-/// Generate a `Encode` implementation for a `Vars` type.
+/// Generate an `Encode` implementation for a `Vars` type.
 fn impl_encode(vars: &[VarABI]) -> syn::ItemImpl {
-    let field_idents = vars
-        .iter()
-        .map(|var| field_name_from_var_name(&var.name))
-        .map(|name| syn::Ident::new(&name, Span::call_site()));
+    let field_idents = field_idents(vars);
     syn::parse_quote! {
         impl pint_abi::Encode for Vars {
             fn encode<W: pint_abi::Write>(&self, w: &mut W) -> Result<(), W::Error> {
@@ -50,12 +54,34 @@ fn impl_encode(vars: &[VarABI]) -> syn::ItemImpl {
     }
 }
 
+/// Generate a `Decode` implementation for a `Vars` type.
+fn impl_decode(vars: &[VarABI]) -> syn::ItemImpl {
+    let field_idents: Vec<_> = field_idents(vars).collect();
+    syn::parse_quote! {
+        impl pint_abi::Decode for Vars {
+            type Error = DecodeError;
+            fn decode<R: pint_abi::Read>(r: &mut R) -> Result<Self, Self::Error> {
+                #(
+                    let #field_idents = <_>::decode(r).map_err(|e| {
+                        DecodeError {
+                            field: DecodeFieldError::#field_idents,
+                            err: format!("{e}"),
+                        }
+                    })?;
+                )*
+                Ok(Self {
+                    #(
+                        #field_idents,
+                    )*
+                })
+            }
+        }
+    }
+}
+
 /// Generate a `From<Vars>` implementation for converting `Vars` to `Vec<Value>`.
-fn impl_(vars: &[VarABI]) -> syn::ItemImpl {
-    let field_idents = vars
-        .iter()
-        .map(|var| field_name_from_var_name(&var.name))
-        .map(|name| syn::Ident::new(&name, Span::call_site()));
+fn impl_from_vars_for_vec_value(vars: &[VarABI]) -> syn::ItemImpl {
+    let field_idents = field_idents(vars);
     syn::parse_quote! {
         impl From<Vars> for Vec<pint_abi::types::essential::Value> {
             fn from(vars: Vars) -> Self {
@@ -69,11 +95,103 @@ fn impl_(vars: &[VarABI]) -> syn::ItemImpl {
     }
 }
 
+fn impl_try_from_values_for_vars(vars: &[VarABI]) -> syn::ItemImpl {
+    let field_idents: Vec<_> = field_idents(vars).collect();
+    syn::parse_quote! {
+        impl<'a> core::convert::TryFrom<&'a [pint_abi::types::essential::Value]> for Vars {
+            type Error = DecodeError;
+            fn try_from(mut values: &[pint_abi::types::essential::Value]) -> Result<Self, Self::Error> {
+                const NOT_ENOUGH_VALUES: &str = "not enough values";
+                let mut values = values.iter();
+                #(
+                    let value = values.next().ok_or_else(|| {
+                        DecodeError {
+                            field: DecodeFieldError::#field_idents,
+                            err: NOT_ENOUGH_VALUES.to_string(),
+                        }
+                    })?;
+                    let #field_idents = pint_abi::decode(value).map_err(|e| {
+                        DecodeError {
+                            field: DecodeFieldError::#field_idents,
+                            err: format!("{e}"),
+                        }
+                    })?;
+                )*
+                Ok(Self {
+                    #(
+                        #field_idents,
+                    )*
+                })
+            }
+        }
+    }
+}
+
+/// A declaration for the `DecodeError` enum for the `Decode` impl.
+fn decode_error_struct() -> syn::ItemStruct {
+    syn::parse_quote! {
+        /// An error type for the [`Vars`] [`pint_abi::Decode`] implementation.
+        #[derive(Debug)]
+        pub struct DecodeError {
+            /// The field that failed to be decoded.
+            pub field: DecodeFieldError,
+            /// The `Display` formatted error message produced by decoding.
+            pub err: String,
+        }
+    }
+}
+
+/// Generate a type describing which field failed to decode.
+fn decode_field_error_enum(vars: &[VarABI]) -> syn::ItemEnum {
+    let field_idents = field_idents(vars);
+    syn::parse_quote! {
+        /// A type describing which field failed to decode.
+        #[derive(Debug)]
+        pub enum DecodeFieldError {
+            #(
+                #field_idents,
+            )*
+        }
+    }
+}
+
+/// An implementation of `Display` for `DecodeError`.
+fn decode_error_impl_display() -> syn::ItemImpl {
+    syn::parse_quote! {
+        impl core::fmt::Display for DecodeError {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "failed to decode field `{:?}`: {}", self.field, self.err)
+            }
+        }
+    }
+}
+
+/// An implementation of `Error` for `DecodeError`.
+fn decode_error_impl_error() -> syn::ItemImpl {
+    syn::parse_quote! {
+        impl std::error::Error for DecodeError {}
+    }
+}
+
+/// Generate an enum for the `DecodeError` type.
+fn decode_error_items(vars: &[VarABI]) -> Vec<syn::Item> {
+    vec![
+        decode_error_struct().into(),
+        decode_field_error_enum(vars).into(),
+        decode_error_impl_display().into(),
+        decode_error_impl_error().into(),
+    ]
+}
+
 /// The struct decl and impls for the decision variables `Vars` type.
 pub(crate) fn items(vars: &[VarABI]) -> Vec<syn::Item> {
-    vec![
+    let mut items = vec![
         struct_decl(vars).into(),
         impl_encode(vars).into(),
-        impl_(vars).into(),
-    ]
+        impl_decode(vars).into(),
+        impl_from_vars_for_vec_value(vars).into(),
+        impl_try_from_values_for_vars(vars).into(),
+    ];
+    items.extend(decode_error_items(vars));
+    items
 }

--- a/pint-abi/src/decode.rs
+++ b/pint-abi/src/decode.rs
@@ -1,0 +1,170 @@
+use crate::{
+    read::Read,
+    types::essential::{convert::bool_from_word, Word},
+};
+use core::fmt::{Debug, Display};
+use thiserror::Error;
+
+/// A trait for decoding types from Essential `Word`s in a manner compatible with Pint's ABI.
+pub trait Decode: Sized {
+    /// Any error that might occur during decoding.
+    type Error: Error;
+    /// Decode an instance of `Self` from words read from the given reader.
+    fn decode<R: Read>(r: &mut R) -> Result<Self, Self::Error>;
+}
+
+/// Requirements for the `Error` type in a `Decode` implementation.
+pub trait Error: Debug + Display {}
+
+/// Construct a decode `Error` from a `Read` implementation error.
+pub trait FromReadError {
+    /// Forward an error produced by the `Read`er.
+    fn from_read_error<E: Debug + Display>(err: E) -> Self;
+}
+
+/// An error occurring during decoding where the `Read` implementation fails to
+/// read enough words.
+#[derive(Debug, Error)]
+#[error("failed to read enough bytes: expected `{expected}`, found `{found}`")]
+pub struct NotEnoughWords {
+    /// The expected number of words.
+    pub expected: usize,
+    /// The actual number of words read.
+    pub found: usize,
+}
+
+/// The `Read` implementation error formatted into a `String` using the `Display` impl.
+#[derive(Debug, Error)]
+#[error("reader error: {0}")]
+pub struct ReadError(String);
+
+/// A general-use error for types with a known size in words.
+#[derive(Debug, Error)]
+pub enum SizedError {
+    /// The `Read` implementation returned an error.
+    #[error("{0}")]
+    Reader(#[from] ReadError),
+    /// Failed to read enough bytes from the reader.
+    #[error("{0}")]
+    NotEnoughWords(#[from] NotEnoughWords),
+}
+
+/// The read `Word` was invalid.
+#[derive(Debug, Error)]
+#[error("`bool` expected `0` or `1`, found `{0}`")]
+pub struct BoolInvalid(pub Word);
+
+/// An error occurring when decoding a `bool`.
+#[derive(Debug, Error)]
+pub enum BoolError {
+    /// Failed to read the word.
+    #[error("{0}")]
+    Sized(#[from] SizedError),
+    /// The read `Word` was invalid.
+    #[error("{0}")]
+    Invalid(#[from] BoolInvalid),
+}
+
+/// Failed to decode a pair in the form of a tuple.
+#[derive(Debug, Error)]
+pub enum PairError<A, B> {
+    #[error("{0}")]
+    Left(A),
+    #[error("{0}")]
+    Right(B),
+}
+
+impl<T: Debug + Display> Error for T {}
+
+impl FromReadError for ReadError {
+    fn from_read_error<E: Debug + Display>(err: E) -> Self {
+        ReadError(format!("{err}"))
+    }
+}
+
+impl FromReadError for SizedError {
+    fn from_read_error<E: Debug + Display>(err: E) -> Self {
+        Self::Reader(ReadError::from_read_error(err))
+    }
+}
+
+impl FromReadError for BoolError {
+    fn from_read_error<E: Debug + Display>(err: E) -> Self {
+        Self::Sized(SizedError::from_read_error(err))
+    }
+}
+
+impl Decode for Word {
+    type Error = SizedError;
+    fn decode<R: Read>(r: &mut R) -> Result<Self, Self::Error> {
+        let [w] = read_exact(r)?;
+        Ok(w)
+    }
+}
+
+impl Decode for bool {
+    type Error = BoolError;
+    fn decode<R: Read>(r: &mut R) -> Result<Self, Self::Error> {
+        let [w] = read_exact(r)?;
+        bool_from_word(w).ok_or(BoolInvalid(w)).map_err(From::from)
+    }
+}
+
+impl<const N: usize, T> Decode for [T; N]
+where
+    T: Decode,
+{
+    type Error = T::Error;
+    fn decode<R: Read>(r: &mut R) -> Result<Self, Self::Error> {
+        // TODO: Use `core::array::try_from_fn` once stabilized rather than `Vec`.
+        let mut vec = Vec::with_capacity(N);
+        for _ in 0..N {
+            vec.push(T::decode(r)?);
+        }
+        let mut elems = vec.into_iter();
+        Ok(core::array::from_fn(|_| {
+            elems.next().expect("Vec gauranteed to have len `N`")
+        }))
+    }
+}
+
+/// A macro for implementing `Decode` for non-pair tuples.
+macro_rules! impl_decode_for_tuple {
+    (A, $($T:ident),+) => {
+        #[allow(unused_parens)]
+        impl<A: Decode, $($T: Decode),+> Decode for (A, $($T),+) {
+            type Error = PairError<A::Error, <($($T),+) as Decode>::Error>;
+            fn decode<R: Read>(r: &mut R) -> Result<Self, Self::Error> {
+                let a: A = <_>::decode(r).map_err(|e| PairError::Left(e))?;
+                #[allow(non_snake_case)]
+                let ($($T),+): ($($T),+) = <_>::decode(r).map_err(|e| PairError::Right(e))?;
+                Ok((a, $($T),+))
+            }
+        }
+    };
+}
+
+impl_decode_for_tuple!(A, B);
+impl_decode_for_tuple!(A, B, C);
+impl_decode_for_tuple!(A, B, C, D);
+impl_decode_for_tuple!(A, B, C, D, E);
+impl_decode_for_tuple!(A, B, C, D, E, F);
+impl_decode_for_tuple!(A, B, C, D, E, F, G);
+impl_decode_for_tuple!(A, B, C, D, E, F, G, H);
+impl_decode_for_tuple!(A, B, C, D, E, F, G, H, I);
+impl_decode_for_tuple!(A, B, C, D, E, F, G, H, I, J);
+impl_decode_for_tuple!(A, B, C, D, E, F, G, H, I, J, K);
+impl_decode_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L);
+
+fn read_exact<const N: usize, R: Read>(r: &mut R) -> Result<[Word; N], SizedError> {
+    let mut arr = [0; N];
+    let amt = r.read(&mut arr).map_err(SizedError::from_read_error)?;
+    if amt != N {
+        let err = NotEnoughWords {
+            expected: N,
+            found: amt,
+        };
+        return Err(err.into());
+    }
+    Ok(arr)
+}

--- a/pint-abi/src/encode.rs
+++ b/pint-abi/src/encode.rs
@@ -1,5 +1,4 @@
-use crate::write::Write;
-use essential_types::Word;
+use crate::{types::essential::Word, write::Write};
 
 /// A trait for encoding types as Essential `Word`s in a manner compatible with Pint's ABI.
 pub trait Encode {

--- a/pint-abi/src/lib.rs
+++ b/pint-abi/src/lib.rs
@@ -11,19 +11,25 @@ pub use pint_abi_gen::from_file as gen_from_file;
 pub use pint_abi_gen::from_str as gen_from_str;
 
 #[doc(inline)]
+pub use decode::Decode;
+#[doc(inline)]
 pub use encode::Encode;
+#[doc(inline)]
+pub use read::Read;
 #[doc(inline)]
 pub use write::Write;
 
 use std::path::Path;
 use thiserror::Error;
 use types::{
-    essential::{contract::Contract, predicate::Predicate},
+    essential::{contract::Contract, predicate::Predicate, Word},
     ContractABI, PredicateABI,
 };
 
+pub mod decode;
 mod encode;
 pub mod key;
+mod read;
 mod write;
 
 /// Both Pint ABI and Essential protocol types.
@@ -48,12 +54,46 @@ pub enum FromPathError {
     Json(#[from] serde_json::Error),
 }
 
+/// Attempted to `Decode` an instance of a type from a slice containing more
+/// `Word`s than necessary.
+#[derive(Debug, Error)]
+#[error("invalid slice length: `{remaining}` words too many")]
+pub struct TooManyWords {
+    /// The number of words left remaining in the slice.
+    pub remaining: usize,
+}
+
+/// Any error that might occur during a call to `decode`.
+#[derive(Debug, Error)]
+pub enum DecodeError<E> {
+    /// Failed to decode the type.
+    #[error("{0}")]
+    Decode(E),
+    /// Invalid slice length. Slice contained more words than necessary.
+    #[error("{0}")]
+    TooManyWords(#[from] TooManyWords),
+}
+
 /// Shorthand for encoding the given value into a `Vec` of Essential `Word`s.
-pub fn encode<T: Encode>(t: &T) -> Vec<types::essential::Word> {
+pub fn encode<T: Encode>(t: &T) -> Vec<Word> {
     let mut v = vec![];
     t.encode(&mut v)
         .expect("encoding into `Vec<Word>` cannot error");
     v
+}
+
+/// Shorthand for decoding an instance of `T` from a slice of Essential `Word`s.
+///
+/// Note that dynamically sized types (like `Vec<T>`) are not supported, as the
+/// length cannot be known.
+pub fn decode<T: Decode>(mut words: &[Word]) -> Result<T, DecodeError<T::Error>> {
+    let cursor = &mut words;
+    let t = T::decode(cursor).map_err(|e| DecodeError::Decode(e))?;
+    if !cursor.is_empty() {
+        let remaining = cursor.len();
+        return Err(TooManyWords { remaining }.into());
+    }
+    Ok(t)
 }
 
 /// Shorthand for loading the [`ContractABI`] from a given ABI JSON file path.

--- a/pint-abi/src/lib.rs
+++ b/pint-abi/src/lib.rs
@@ -88,7 +88,7 @@ pub fn encode<T: Encode>(t: &T) -> Vec<Word> {
 /// length cannot be known.
 pub fn decode<T: Decode>(mut words: &[Word]) -> Result<T, DecodeError<T::Error>> {
     let cursor = &mut words;
-    let t = T::decode(cursor).map_err(|e| DecodeError::Decode(e))?;
+    let t = T::decode(cursor).map_err(DecodeError::Decode)?;
     if !cursor.is_empty() {
         let remaining = cursor.len();
         return Err(TooManyWords { remaining }.into());

--- a/pint-abi/src/read.rs
+++ b/pint-abi/src/read.rs
@@ -1,0 +1,33 @@
+use crate::types::essential::Word;
+
+/// Allows for reading words from a source, largely inspired by [`std::io::Read`].
+pub trait Read {
+    /// A type representing any error that might occur while reading words.
+    type Error: core::fmt::Debug + core::fmt::Display;
+
+    /// Read words from this source into the specified buffer.
+    ///
+    /// Returns how many words were read.
+    ///
+    /// Repeated calls to `read` should use the same cursor, i.e. the same words
+    /// should not be yielded twice.
+    fn read(&mut self, buf: &mut [Word]) -> Result<usize, Self::Error>;
+}
+
+impl<'a, T: Read> Read for &'a mut T {
+    type Error = T::Error;
+    fn read(&mut self, buf: &mut [Word]) -> Result<usize, Self::Error> {
+        (*self).read(buf)
+    }
+}
+
+impl<'a> Read for &'a [Word] {
+    type Error = core::convert::Infallible;
+    fn read(&mut self, buf: &mut [Word]) -> Result<usize, Self::Error> {
+        let amt = core::cmp::min(self.len(), buf.len());
+        let (a, b) = self.split_at(amt);
+        buf[..amt].copy_from_slice(a);
+        *self = b;
+        Ok(amt)
+    }
+}


### PR DESCRIPTION
Adds `Read` and `Decode` traits (complementing `Write` and `Encode`) to `pint-abi` for decoding ABI-generated types from words.

This will be useful when requesting certain kinds of state from the server, and decoding that state into useful representations generated by `pint-abi-gen`.

Closes #734.