### PR TITLE
feat(pint-abi): Generate `ADDRESS` consts for contracts, predicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,11 +1148,13 @@ dependencies = [
 name = "pint-abi-gen"
 version = "0.1.0"
 dependencies = [
+ "essential-hash",
  "essential-types",
  "pint-abi-types",
  "pint-abi-visit",
  "proc-macro2",
  "quote",
+ "serde",
  "serde_json",
  "syn 2.0.71",
 ]

--- a/pint-abi-gen-tests/src/array.rs
+++ b/pint-abi-gen-tests/src/array.rs
@@ -1,2 +1,6 @@
 //! All items generated from `array-abi.json`.
-pint_abi::gen_from_file!("test-pkgs/array/out/debug/array-abi.json");
+
+pint_abi::gen_from_file! {
+    abi: "test-pkgs/array/out/debug/array-abi.json",
+    contract: "test-pkgs/array/out/debug/array.json",
+}

--- a/pint-abi-gen-tests/src/counter.rs
+++ b/pint-abi-gen-tests/src/counter.rs
@@ -1,6 +1,9 @@
 //! All items generated from `counter-abi.json`.
 
-pint_abi::gen_from_file!("test-pkgs/counter/out/debug/counter-abi.json");
+pint_abi::gen_from_file! {
+    abi: "test-pkgs/counter/out/debug/counter-abi.json",
+    contract: "test-pkgs/counter/out/debug/counter.json",
+}
 
 mod counter_from_str {
     // Just check that this doesn't fail - the implementation almost entirely

--- a/pint-abi-gen-tests/src/pub_vars.rs
+++ b/pint-abi-gen-tests/src/pub_vars.rs
@@ -1,3 +1,5 @@
 //! All items generated from `pub-vars-abi.json`.
 
-pint_abi::gen_from_file!("test-pkgs/pub-vars/out/debug/pub-vars-abi.json");
+pint_abi::gen_from_file! {
+    abi: "test-pkgs/pub-vars/out/debug/pub-vars-abi.json",
+}

--- a/pint-abi-gen-tests/src/simple.rs
+++ b/pint-abi-gen-tests/src/simple.rs
@@ -1,3 +1,6 @@
 //! All items generated from `simple-abi.json`.
 
-pint_abi::gen_from_file!("test-pkgs/simple/out/debug/simple-abi.json");
+pint_abi::gen_from_file! {
+    abi: "test-pkgs/simple/out/debug/simple-abi.json",
+    contract: "test-pkgs/simple/out/debug/simple.json",
+}

--- a/pint-abi-gen-tests/tests/array.rs
+++ b/pint-abi-gen-tests/tests/array.rs
@@ -20,17 +20,20 @@ async fn test_array_solution_foo() {
     // Determine the content address of the contract.
     let contract_path = pkg_dir.join("out/debug/array.json");
     let contract = pint_abi::contract_from_path(&contract_path).unwrap();
-    let contract_ca = essential_hash::contract_addr::from_contract(&contract);
 
     // Determine the predicate address by loading the ABI and finding the matching predicate.
     let abi_path = pkg_dir.join("out/debug/array-abi.json");
     let abi = pint_abi::from_path(&abi_path).unwrap();
     let (pred, _pred_abi) = pint_abi::find_predicate(&contract, &abi, "Foo").unwrap();
-    let pred_ca = essential_hash::content_addr(pred);
+
+    // Check the generated addresses are correct.
+    let contract_ca = essential_hash::contract_addr::from_contract(&contract);
     let pred_addr = PredicateAddress {
         contract: contract_ca.clone(),
-        predicate: pred_ca,
+        predicate: essential_hash::content_addr(pred),
     };
+    assert_eq!(contract_ca, array::ADDRESS);
+    assert_eq!(pred_addr, array::Foo::ADDRESS);
 
     // State mutations.
     let state_mutations: Vec<Mutation> = array::storage::mutations()
@@ -152,7 +155,7 @@ async fn test_array_solution_foo() {
 
     // Create the solution data.
     let solution_data = SolutionData {
-        predicate_to_solve: pred_addr,
+        predicate_to_solve: array::Foo::ADDRESS,
         decision_variables: vec![],
         transient_data: vec![],
         state_mutations,
@@ -167,7 +170,7 @@ async fn test_array_solution_foo() {
     essential_check::solution::check(&solution).unwrap();
 
     // Start with an empty pre-state.
-    let pre_state = State::new(vec![(contract_ca, vec![])]);
+    let pre_state = State::new(vec![(array::ADDRESS, vec![])]);
 
     // Create the post-state by applying the mutations.
     let mut post_state = pre_state.clone();

--- a/pint-abi-gen/Cargo.toml
+++ b/pint-abi-gen/Cargo.toml
@@ -12,10 +12,12 @@ repository.workspace = true
 proc-macro = true
 
 [dependencies]
+essential-hash = { workspace = true }
 essential-types = { workspace = true }
 pint-abi-types = { workspace = true }
 pint-abi-visit = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 syn = { workspace = true }

--- a/pint-abi-gen/src/addr.rs
+++ b/pint-abi-gen/src/addr.rs
@@ -14,7 +14,7 @@ impl<'a> From<&'a Contract> for Addresses {
         let predicates: Vec<_> = contract
             .predicates
             .iter()
-            .map(|pred| essential_hash::content_addr(pred))
+            .map(essential_hash::content_addr)
             .collect();
         Self {
             contract: essential_hash::contract_addr::from_predicate_addrs(

--- a/pint-abi-gen/src/addr.rs
+++ b/pint-abi-gen/src/addr.rs
@@ -1,0 +1,89 @@
+//! Items related to the generation of address constants for contracts and their predicates.
+
+use essential_types::{contract::Contract, ContentAddress};
+
+/// The contract and predicate addresses.
+pub(crate) struct Addresses {
+    pub(crate) contract: ContentAddress,
+    /// Predicate content addresses in the order declared within the ABI.
+    pub(crate) predicates: Vec<ContentAddress>,
+}
+
+impl<'a> From<&'a Contract> for Addresses {
+    fn from(contract: &'a Contract) -> Self {
+        let predicates: Vec<_> = contract
+            .predicates
+            .iter()
+            .map(|pred| essential_hash::content_addr(pred))
+            .collect();
+        Self {
+            contract: essential_hash::contract_addr::from_predicate_addrs(
+                predicates.iter().cloned(),
+                &contract.salt,
+            ),
+            predicates,
+        }
+    }
+}
+
+/// The array of bytes for a content address.
+fn content_addr_expr_array(addr: &ContentAddress) -> syn::ExprArray {
+    let elems = addr
+        .0
+        .iter()
+        .map(|b| {
+            let byte: syn::Expr = syn::parse_quote!(#b);
+            byte
+        })
+        .collect();
+    syn::ExprArray {
+        attrs: vec![],
+        bracket_token: Default::default(),
+        elems,
+    }
+}
+
+/// An expression of type `ContentAddress`.
+fn content_addr_expr(addr: &ContentAddress) -> syn::Expr {
+    let expr_array = content_addr_expr_array(addr);
+    syn::parse_quote!(pint_abi::types::essential::ContentAddress(#expr_array))
+}
+
+/// A `PredicateAddress` expression for predicate address consts.
+fn predicate_addr_expr(contract: &ContentAddress, predicate: &ContentAddress) -> syn::Expr {
+    let contract = content_addr_expr(contract);
+    let predicate = content_addr_expr(predicate);
+    syn::parse_quote! {
+        pint_abi::types::essential::PredicateAddress {
+            contract: #contract,
+            predicate: #predicate,
+        }
+    }
+}
+
+/// An `ADDRESS` constant with the contract's `ContentAddress`.
+pub(crate) fn contract_const(addr: &ContentAddress) -> syn::ItemConst {
+    let expr: syn::Expr = content_addr_expr(addr);
+    let doc_str = format!("- Address: `{addr}`");
+    syn::parse_quote! {
+        /// The content address of the contract.
+        ///
+        #[doc = #doc_str]
+        pub const ADDRESS: pint_abi::types::essential::ContentAddress = #expr;
+    }
+}
+
+/// An `ADDRESS` constant with the predicate's `PredicateAddress`.
+pub(crate) fn predicate_const(
+    contract: &ContentAddress,
+    predicate: &ContentAddress,
+) -> syn::ItemConst {
+    let expr = predicate_addr_expr(contract, predicate);
+    let doc_str = format!("- Contract: `{contract}`\n- Predicate: `{predicate}`");
+    syn::parse_quote! {
+        /// The predicate address, composed of the contract and predicate content addresses.
+        ///
+        #[doc = #doc_str]
+        pub const ADDRESS: pint_abi::types::essential::PredicateAddress = #expr;
+    }
+}

--- a/pint-abi-gen/src/args.rs
+++ b/pint-abi-gen/src/args.rs
@@ -1,0 +1,41 @@
+//! A type and `Parse` implementation for the args provided to the `from_file!` macro.
+
+use syn::parse::{Parse, ParseStream};
+
+/// Arguments provided to the `from_file!` macro.
+pub(crate) struct FromFile {
+    pub(crate) abi: syn::LitStr,
+    pub(crate) contract: Option<syn::LitStr>,
+}
+
+impl Parse for FromFile {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut abi = None;
+        let mut contract = None;
+        while !input.is_empty() {
+            let ident: syn::Ident = input.parse()?;
+            input.parse::<syn::Token![:]>()?;
+            match ident.to_string().as_str() {
+                "abi" => {
+                    if abi.is_some() {
+                        return Err(input.error("duplicate `abi` argument"));
+                    }
+                    abi = Some(input.parse()?);
+                }
+                "contract" => {
+                    if contract.is_some() {
+                        return Err(input.error("duplicate `contract` argument"));
+                    }
+                    contract = Some(input.parse()?);
+                }
+                _ => return Err(input.error("unexpected argument")),
+            }
+            if !input.is_empty() {
+                input.parse::<syn::Token![,]>()?;
+            }
+        }
+        let abi =
+            abi.ok_or_else(|| syn::Error::new(input.span(), "missing required `abi` argument"))?;
+        Ok(FromFile { abi, contract })
+    }
+}

--- a/pint-abi-gen/src/lib.rs
+++ b/pint-abi-gen/src/lib.rs
@@ -390,7 +390,7 @@ fn resolve_path(path: &std::path::Path) -> std::path::PathBuf {
         let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
             .expect("`CARGO_MANIFEST_DIR` not set, but required for relative path expansion");
         let manifest_dir_path = std::path::Path::new(&manifest_dir);
-        manifest_dir_path.join(&path)
+        manifest_dir_path.join(path)
     } else {
         path.to_path_buf()
     }

--- a/pint-abi-gen/src/lib.rs
+++ b/pint-abi-gen/src/lib.rs
@@ -420,6 +420,22 @@ where
 
 /// Generate all items from an ABI JSON file at the given path.
 ///
+/// Also allows for optionally providing a path to the associated contract JSON
+/// for generating `ADDRESS` consts for the contract and its predicates.
+///
+/// NOTE: This macro is designed for use via the `pint-abi` crate, from which
+/// it is re-exported as `pint_abi::gen_from_file!`. Much of the code generation
+/// assumes the `pint-abi` crate is available as a dependency.
+///
+/// ## Usage
+///
+/// ```ignore
+/// pint_abi::gen_from_file! {
+///     abi: "path/to/abi.json",
+///     contract: "path/to/contract.json",
+/// }
+/// ```
+///
 /// ## Supported Paths
 ///
 /// The given path must be either:


### PR DESCRIPTION
This adds support for generating `ADDRESS` constants for contracts and predicates by optionally providing the path to the compiled contract associated with the ABI.

The `pint_abi::gen_from_file!` macro API has been changed slightly. Previously, it was used like so:

```rust
pint_abi::gen_from_file!("path/to/abi.json");
```

Now, the invocation looks like:

```rust
pint_abi::gen_from_file! {
    abi: "path/to/abi.json",
    contract: "path/to/contract.json",
}
```

The `contract` field is optional. When provided, the contract at the specified path will be used to determine the contract and predicate `ADDRESS` consts and include them in their associated generated modules. If not provided, the old behaviour remains the same.