### PR TITLE
Introduce `PredKey` and a slotmap for `Contract::preds`.

### DIFF
--- a/pintc/src/asm_gen.rs
+++ b/pintc/src/asm_gen.rs
@@ -2,7 +2,7 @@ use crate::{
     error::{CompileError, Error, ErrorEmitted, Handler},
     expr::{BinaryOp, Expr, Immediate, TupleAccess, UnaryOp},
     predicate::{
-        ConstraintDecl, Contract, ExprKey, Predicate, PredicateInstance, State as StateVar,
+        ConstraintDecl, Contract, ExprKey, PredKey, Predicate, PredicateInstance, State as StateVar,
     },
     span::empty_span,
     types::Type,
@@ -44,12 +44,12 @@ pub fn compile_contract(
     let mut names = Vec::new();
     let mut predicates = Vec::new();
 
-    for (name, pred) in contract.preds.iter() {
-        if name != Contract::ROOT_PRED_NAME {
+    for (pred_key, pred) in contract.preds.iter() {
+        if pred_key != contract.root_pred_key() {
             if let Ok(predicate) =
-                handler.scope(|handler| predicate_to_asm(handler, contract, pred))
+                handler.scope(|handler| predicate_to_asm(handler, contract, pred_key, pred))
             {
-                names.push(name.to_string());
+                names.push(pred.name.clone());
                 predicates.push(predicate);
             }
         }
@@ -105,6 +105,7 @@ impl AsmBuilder {
         asm: &mut Vec<Constraint>,
         expr: &ExprKey,
         contract: &Contract,
+        pred_key: PredKey,
         pred: &Predicate,
     ) -> Result<Location, ErrorEmitted> {
         match &expr.get(contract) {
@@ -127,18 +128,21 @@ impl AsmBuilder {
                 UnaryOp::NextState => {
                     // Next state expressions produce state expressions (i.e. ones that require
                     // `State` or `StateRange`
-                    Self::compile_expr_pointer(handler, asm, expr, contract, pred)?;
+                    Self::compile_expr_pointer(handler, asm, expr, contract, pred_key, pred)?;
                     Ok(Location::State(true))
                 }
                 _ => Ok(Location::Value),
             },
-            Expr::PathByName(path, _) => Self::compile_path(handler, asm, path, contract, pred),
+            Expr::PathByName(path, _) => {
+                Self::compile_path(handler, asm, path, contract, pred_key, pred)
+            }
             Expr::PathByKey(var_key, _) => {
                 let path = &var_key.get(pred).name;
-                Self::compile_path(handler, asm, path, contract, pred)
+                Self::compile_path(handler, asm, path, contract, pred_key, pred)
             }
             Expr::TupleFieldAccess { tuple, field, .. } => {
-                let location = Self::compile_expr_pointer(handler, asm, tuple, contract, pred)?;
+                let location =
+                    Self::compile_expr_pointer(handler, asm, tuple, contract, pred_key, pred)?;
                 match location {
                     Location::State(_) | Location::Transient(..) | Location::DecisionVar(_) => {
                         // Offset calculation is pretty much the same for all types of data
@@ -182,9 +186,9 @@ impl AsmBuilder {
                                 // at the "storage size" which may yield different results (e.g. a
                                 // `b256` is 4 words but its storage size is 1
                                 if let Location::DecisionVar(_) = location {
-                                    ty.size(handler, contract, pred)
+                                    ty.size(handler, contract, pred_key)
                                 } else {
-                                    ty.storage_or_transient_slots(handler, contract, pred)
+                                    ty.storage_or_transient_slots(handler, contract, pred_key)
                                 }
                                 .map(|slots| acc + slots)
                             })?;
@@ -200,7 +204,8 @@ impl AsmBuilder {
                 }
             }
             Expr::Index { expr, index, .. } => {
-                let location = Self::compile_expr_pointer(handler, asm, expr, contract, pred)?;
+                let location =
+                    Self::compile_expr_pointer(handler, asm, expr, contract, pred_key, pred)?;
                 match location {
                     Location::State(_) | Location::Transient(..) | Location::DecisionVar(_) => {
                         // Offset calculation is pretty much the same for all types of data
@@ -216,7 +221,7 @@ impl AsmBuilder {
                         };
 
                         // Compile the index
-                        Self::compile_expr(handler, asm, index, contract, pred)?;
+                        Self::compile_expr(handler, asm, index, contract, pred_key, pred)?;
 
                         // Multiply the index by the number of storage slots for `ty` to get the
                         // offset, then add the result to the base key
@@ -226,9 +231,9 @@ impl AsmBuilder {
                             // at the "storage size" which may yield different results (e.g. a
                             // `b256` is 4 words but its storage size is 1
                             Stack::Push(if let Location::DecisionVar(_) = location {
-                                ty.size(handler, contract, pred)?
+                                ty.size(handler, contract, pred_key)?
                             } else {
-                                ty.storage_or_transient_slots(handler, contract, pred)?
+                                ty.storage_or_transient_slots(handler, contract, pred_key)?
                             } as i64)
                             .into(),
                         );
@@ -255,6 +260,7 @@ impl AsmBuilder {
         s_asm: &mut Vec<StateRead>,
         expr: &ExprKey,
         contract: &Contract,
+        pred_key: PredKey,
         pred: &Predicate,
     ) -> Result<StorageKey, ErrorEmitted> {
         let expr_ty = expr.get_ty(contract);
@@ -273,7 +279,7 @@ impl AsmBuilder {
                     };
 
                     let mut asm = Vec::new();
-                    Self::compile_expr(handler, &mut asm, &args[0], contract, pred)?;
+                    Self::compile_expr(handler, &mut asm, &args[0], contract, pred_key, pred)?;
                     s_asm.extend(asm.iter().map(|op| StateRead::Constraint(*op)));
                     Ok(StorageKey {
                         len: key_len as usize,
@@ -295,8 +301,8 @@ impl AsmBuilder {
 
                     // First, get the contract address and the storage key
                     let mut asm = Vec::new();
-                    Self::compile_expr(handler, &mut asm, &args[0], contract, pred)?;
-                    Self::compile_expr(handler, &mut asm, &args[1], contract, pred)?;
+                    Self::compile_expr(handler, &mut asm, &args[0], contract, pred_key, pred)?;
+                    Self::compile_expr(handler, &mut asm, &args[1], contract, pred_key, pred)?;
                     s_asm.extend(asm.iter().map(|op| StateRead::Constraint(*op)));
                     Ok(StorageKey {
                         len: key_len as usize,
@@ -356,6 +362,7 @@ impl AsmBuilder {
                     &mut asm,
                     &interface_instance.address,
                     contract,
+                    pred_key,
                     pred,
                 )?;
                 s_asm.extend(asm.iter().map(|op| StateRead::Constraint(*op)));
@@ -402,14 +409,14 @@ impl AsmBuilder {
                 if expr.get_ty(contract).is_map() {
                     // Compile the key corresponding to `expr`
                     let storage_key =
-                        Self::compile_state_key(handler, s_asm, expr, contract, pred)?;
+                        Self::compile_state_key(handler, s_asm, expr, contract, pred_key, pred)?;
 
                     // Compile the index
                     let mut asm = vec![];
-                    Self::compile_expr(handler, &mut asm, index, contract, pred)?;
+                    Self::compile_expr(handler, &mut asm, index, contract, pred_key, pred)?;
                     s_asm.extend(asm.iter().copied().map(StateRead::from));
-                    let mut key_length =
-                        storage_key.len + index.get_ty(contract).size(handler, contract, pred)?;
+                    let mut key_length = storage_key.len
+                        + index.get_ty(contract).size(handler, contract, pred_key)?;
                     if !(expr_ty.is_any_primitive() || expr_ty.is_map()) {
                         s_asm.push(StateRead::from(Stack::Push(0)));
                         key_length += 1;
@@ -430,18 +437,20 @@ impl AsmBuilder {
 
                     // Compile the key corresponding to `expr`
                     let storage_key =
-                        Self::compile_state_key(handler, s_asm, expr, contract, pred)?;
+                        Self::compile_state_key(handler, s_asm, expr, contract, pred_key, pred)?;
 
                     // Compile the index
                     let mut asm = vec![];
-                    Self::compile_expr(handler, &mut asm, index, contract, pred)?;
+                    Self::compile_expr(handler, &mut asm, index, contract, pred_key, pred)?;
                     s_asm.extend(asm.iter().copied().map(StateRead::from));
 
                     // Multiply the index by the number of storage slots for `ty` to get the
                     // offset, then add the result to the base key
                     s_asm.push(
-                        Stack::Push(ty.storage_or_transient_slots(handler, contract, pred)? as i64)
-                            .into(),
+                        Stack::Push(
+                            ty.storage_or_transient_slots(handler, contract, pred_key)? as i64
+                        )
+                        .into(),
                     );
                     s_asm.push(Alu::Mul.into());
                     s_asm.push(Alu::Add.into());
@@ -451,7 +460,8 @@ impl AsmBuilder {
             }
             Expr::TupleFieldAccess { tuple, field, .. } => {
                 // Compile the key corresponding to `tuple`
-                let storage_key = Self::compile_state_key(handler, s_asm, tuple, contract, pred)?;
+                let storage_key =
+                    Self::compile_state_key(handler, s_asm, tuple, contract, pred_key, pred)?;
 
                 // Grab the fields of the tuple
                 let Type::Tuple { ref fields, .. } = tuple.get_ty(contract) else {
@@ -487,7 +497,7 @@ impl AsmBuilder {
                 // This is the offset from the base key where the full tuple is stored.
                 let key_offset: usize =
                     fields.iter().take(field_idx).try_fold(0, |acc, (_, ty)| {
-                        ty.storage_or_transient_slots(handler, contract, pred)
+                        ty.storage_or_transient_slots(handler, contract, pred_key)
                             .map(|slots| acc + slots)
                     })?;
 
@@ -511,13 +521,14 @@ impl AsmBuilder {
         asm: &mut Vec<Constraint>,
         expr: &ExprKey,
         contract: &Contract,
+        pred_key: PredKey,
         pred: &Predicate,
     ) -> Result<usize, ErrorEmitted> {
         let old_asm_len = asm.len();
         let expr_ty = expr.get_ty(contract);
-        match Self::compile_expr_pointer(handler, asm, expr, contract, pred)? {
+        match Self::compile_expr_pointer(handler, asm, expr, contract, pred_key, pred)? {
             Location::Value => {
-                Self::compile_value_expr(handler, asm, expr, contract, pred)?;
+                Self::compile_value_expr(handler, asm, expr, contract, pred_key, pred)?;
             }
             Location::DecisionVar(len) => {
                 if len == 1 {
@@ -526,16 +537,16 @@ impl AsmBuilder {
                     // etc.)
                     asm.push(Access::DecisionVar.into());
                 } else {
-                    asm.push(Stack::Push(expr_ty.size(handler, contract, pred)? as i64).into()); // len
+                    asm.push(Stack::Push(expr_ty.size(handler, contract, pred_key)? as i64).into()); // len
                     asm.push(Access::DecisionVarRange.into());
                 }
             }
             Location::Transient(pathway, len) => {
-                for i in 0..expr_ty.storage_or_transient_slots(handler, contract, pred)? {
+                for i in 0..expr_ty.storage_or_transient_slots(handler, contract, pred_key)? {
                     if i != 0 {
                         // Recompute the key and offset. We do this manually here because we don't
                         // have a `TransientRange` op that is similar to `StateRange`
-                        Self::compile_expr_pointer(handler, asm, expr, contract, pred)?;
+                        Self::compile_expr_pointer(handler, asm, expr, contract, pred_key, pred)?;
                         asm.push(Stack::Push(i as i64).into());
                         asm.push(Alu::Add.into());
                     }
@@ -556,7 +567,7 @@ impl AsmBuilder {
                 }
             }
             Location::State(next_state) => {
-                let slots = expr_ty.storage_or_transient_slots(handler, contract, pred)?;
+                let slots = expr_ty.storage_or_transient_slots(handler, contract, pred_key)?;
                 if slots == 1 {
                     asm.push(Stack::Push(next_state as i64).into());
                     asm.push(Access::State.into());
@@ -577,6 +588,7 @@ impl AsmBuilder {
         asm: &mut Vec<Constraint>,
         expr: &ExprKey,
         contract: &Contract,
+        pred_key: PredKey,
         pred: &Predicate,
     ) -> Result<usize, ErrorEmitted> {
         fn compile_immediate(asm: &mut Vec<Constraint>, imm: &Immediate) {
@@ -616,17 +628,17 @@ impl AsmBuilder {
             Expr::Immediate { value, .. } => compile_immediate(asm, value),
             Expr::Array { elements, .. } => {
                 for element in elements {
-                    Self::compile_expr(handler, asm, element, contract, pred)?;
+                    Self::compile_expr(handler, asm, element, contract, pred_key, pred)?;
                 }
             }
             Expr::Tuple { fields, .. } => {
                 for (_, field) in fields {
-                    Self::compile_expr(handler, asm, field, contract, pred)?;
+                    Self::compile_expr(handler, asm, field, contract, pred_key, pred)?;
                 }
             }
             Expr::BinaryOp { op, lhs, rhs, .. } => {
-                let lhs_len = Self::compile_expr(handler, asm, lhs, contract, pred)?;
-                let rhs_len = Self::compile_expr(handler, asm, rhs, contract, pred)?;
+                let lhs_len = Self::compile_expr(handler, asm, lhs, contract, pred_key, pred)?;
+                let rhs_len = Self::compile_expr(handler, asm, rhs, contract, pred_key, pred)?;
                 match op {
                     BinaryOp::Add => asm.push(Alu::Add.into()),
                     BinaryOp::Sub => asm.push(Alu::Sub.into()),
@@ -634,7 +646,7 @@ impl AsmBuilder {
                     BinaryOp::Div => asm.push(Alu::Div.into()),
                     BinaryOp::Mod => asm.push(Alu::Mod.into()),
                     BinaryOp::Equal => {
-                        let type_size = lhs.get_ty(contract).size(handler, contract, pred)?;
+                        let type_size = lhs.get_ty(contract).size(handler, contract, pred_key)?;
                         if type_size == 1 {
                             asm.push(Pred::Eq.into());
                         } else {
@@ -722,7 +734,7 @@ impl AsmBuilder {
             Expr::UnaryOp { op, expr, .. } => {
                 match op {
                     UnaryOp::Not => {
-                        Self::compile_expr(handler, asm, expr, contract, pred)?;
+                        Self::compile_expr(handler, asm, expr, contract, pred_key, pred)?;
                         asm.push(Pred::Not.into());
                     }
                     UnaryOp::NextState => {
@@ -737,7 +749,7 @@ impl AsmBuilder {
                         // Push `0` (i.e. `lhs`) before the `expr` (i.e. `rhs`) opcodes. Then
                         // subtract `lhs` - `rhs` to negate the value.
                         asm.push(Constraint::Stack(Stack::Push(0)));
-                        Self::compile_expr(handler, asm, expr, contract, pred)?;
+                        Self::compile_expr(handler, asm, expr, contract, pred_key, pred)?;
                         asm.push(Alu::Sub.into())
                     }
                     UnaryOp::Error => unreachable!("unexpected Unary::Error"),
@@ -770,9 +782,9 @@ impl AsmBuilder {
 
                     // Compile the mut key argument, insert its length, and then insert the
                     // `Sha256` opcode
-                    Self::compile_expr(handler, asm, &mut_key, contract, pred)?;
+                    Self::compile_expr(handler, asm, &mut_key, contract, pred_key, pred)?;
                     asm.push(Constraint::Stack(Stack::Push(
-                        mut_key_type.size(handler, contract, pred)? as i64,
+                        mut_key_type.size(handler, contract, pred_key)? as i64,
                     )));
                     asm.push(Constraint::Access(Access::MutKeysContains));
                 }
@@ -801,9 +813,9 @@ impl AsmBuilder {
 
                     // Compile the data argument, insert its length, and then insert the `Sha256`
                     // opcode
-                    Self::compile_expr(handler, asm, &data, contract, pred)?;
+                    Self::compile_expr(handler, asm, &data, contract, pred_key, pred)?;
                     asm.push(Constraint::Stack(Stack::Push(
-                        data_type.size(handler, contract, pred)? as i64,
+                        data_type.size(handler, contract, pred_key)? as i64,
                     )));
                     asm.push(Constraint::Crypto(Crypto::Sha256));
                 }
@@ -830,12 +842,12 @@ impl AsmBuilder {
                     assert!(public_key_type.is_b256());
 
                     // Compile all arguments separately and then insert the `VerifyEd25519` opcode
-                    Self::compile_expr(handler, asm, &data, contract, pred)?;
+                    Self::compile_expr(handler, asm, &data, contract, pred_key, pred)?;
                     asm.push(Constraint::Stack(Stack::Push(
-                        data_type.size(handler, contract, pred)? as i64,
+                        data_type.size(handler, contract, pred_key)? as i64,
                     )));
-                    Self::compile_expr(handler, asm, &signature, contract, pred)?;
-                    Self::compile_expr(handler, asm, &public_key, contract, pred)?;
+                    Self::compile_expr(handler, asm, &signature, contract, pred_key, pred)?;
+                    Self::compile_expr(handler, asm, &public_key, contract, pred_key, pred)?;
                     asm.push(Constraint::Crypto(Crypto::VerifyEd25519));
                 }
 
@@ -863,8 +875,8 @@ impl AsmBuilder {
                     );
 
                     // Compile all arguments separately and then insert the `VerifyEd25519` opcode
-                    Self::compile_expr(handler, asm, &data_hash, contract, pred)?;
-                    Self::compile_expr(handler, asm, &signature, contract, pred)?;
+                    Self::compile_expr(handler, asm, &data_hash, contract, pred_key, pred)?;
+                    Self::compile_expr(handler, asm, &signature, contract, pred_key, pred)?;
                     asm.push(Constraint::Crypto(Crypto::RecoverSecp256k1));
                 }
 
@@ -889,7 +901,7 @@ impl AsmBuilder {
                         _ => false,
                     });
 
-                    Self::compile_expr(handler, asm, &args[0], contract, pred)?;
+                    Self::compile_expr(handler, asm, &args[0], contract, pred_key, pred)?;
 
                     // After compiling a path to a state var or a "next state" expression, we
                     // expect that the last opcode is a `State` or a `StateRange`. Pop that and
@@ -905,7 +917,7 @@ impl AsmBuilder {
                         // we have slots for `args[0]`.
                         let slots = args[0]
                             .get_ty(contract)
-                            .storage_or_transient_slots(handler, contract, pred)?;
+                            .storage_or_transient_slots(handler, contract, pred_key)?;
                         (0..slots - 1).for_each(|_| asm.push(Alu::Add.into()));
                     }
                 }
@@ -932,14 +944,15 @@ impl AsmBuilder {
                     // This jump to 'then' will get updated with the proper distance below.
                     let to_then_jump_idx = asm.len();
                     asm.push(Constraint::Stack(Stack::Push(-1)));
-                    Self::compile_expr(handler, asm, condition, contract, pred)?;
+                    Self::compile_expr(handler, asm, condition, contract, pred_key, pred)?;
                     asm.push(Constraint::TotalControlFlow(
                         TotalControlFlow::JumpForwardIf,
                     ));
 
                     // Compile the 'else' selection, update the prior jump.  We need to jump over
                     // the size of 'else` plus 3 instructions it uses to jump the 'then'.
-                    let else_size = Self::compile_expr(handler, asm, else_expr, contract, pred)?;
+                    let else_size =
+                        Self::compile_expr(handler, asm, else_expr, contract, pred_key, pred)?;
                     asm[to_then_jump_idx] = Constraint::Stack(Stack::Push(else_size as i64 + 4));
 
                     // This (unconditional) jump over 'then' will also get updated.
@@ -951,19 +964,22 @@ impl AsmBuilder {
                     ));
 
                     // Compile the 'then' selection, update the prior jump.
-                    let then_size = Self::compile_expr(handler, asm, then_expr, contract, pred)?;
+                    let then_size =
+                        Self::compile_expr(handler, asm, then_expr, contract, pred_key, pred)?;
                     asm[to_end_jump_idx] = Constraint::Stack(Stack::Push(then_size as i64 + 1));
                 } else {
                     // Alternatively, evaluate both options and use ASM `select` to choose one.
-                    let type_size = then_expr.get_ty(contract).size(handler, contract, pred)?;
-                    Self::compile_expr(handler, asm, else_expr, contract, pred)?;
-                    Self::compile_expr(handler, asm, then_expr, contract, pred)?;
+                    let type_size = then_expr
+                        .get_ty(contract)
+                        .size(handler, contract, pred_key)?;
+                    Self::compile_expr(handler, asm, else_expr, contract, pred_key, pred)?;
+                    Self::compile_expr(handler, asm, then_expr, contract, pred_key, pred)?;
                     if type_size == 1 {
-                        Self::compile_expr(handler, asm, condition, contract, pred)?;
+                        Self::compile_expr(handler, asm, condition, contract, pred_key, pred)?;
                         asm.push(Constraint::Stack(Stack::Select));
                     } else {
                         asm.push(Constraint::Stack(Stack::Push(type_size as i64)));
-                        Self::compile_expr(handler, asm, condition, contract, pred)?;
+                        Self::compile_expr(handler, asm, condition, contract, pred_key, pred)?;
                         asm.push(Constraint::Stack(Stack::SelectRange));
                     }
                 }
@@ -996,6 +1012,7 @@ impl AsmBuilder {
         asm: &mut Vec<Constraint>,
         path: &String,
         contract: &Contract,
+        pred_key: PredKey,
         pred: &Predicate,
     ) -> Result<Location, ErrorEmitted> {
         let var_index = pred
@@ -1012,9 +1029,9 @@ impl AsmBuilder {
 
         if let Some(var_index) = var_index {
             let var_key = pred.vars().find(|(_, var)| &var.name == path).unwrap().0;
-            let var_ty_size = var_key.get_ty(pred).size(handler, contract, pred)?;
+            let var_ty_size = var_key.get_ty(pred).size(handler, contract, pred_key)?;
             asm.push(Stack::Push(var_index as i64).into()); // slot
-            if var_key.get_ty(pred).size(handler, contract, pred)? > 1 {
+            if var_key.get_ty(pred).size(handler, contract, pred_key)? > 1 {
                 asm.push(Stack::Push(0).into()); // placeholder for index computation
             }
             Ok(Location::DecisionVar(var_ty_size))
@@ -1034,7 +1051,7 @@ impl AsmBuilder {
                     .try_fold(0, |acc, (state_key, _)| {
                         state_key
                             .get_ty(pred)
-                            .storage_or_transient_slots(handler, contract, pred)
+                            .storage_or_transient_slots(handler, contract, pred_key)
                             .map(|slots| acc + slots)
                     })?;
 
@@ -1121,10 +1138,11 @@ impl AsmBuilder {
         handler: &Handler,
         expr: &ExprKey,
         contract: &Contract,
+        pred_key: PredKey,
         pred: &Predicate,
     ) -> Result<(), ErrorEmitted> {
         let mut asm = Vec::new();
-        Self::compile_expr(handler, &mut asm, expr, contract, pred)?;
+        Self::compile_expr(handler, &mut asm, expr, contract, pred_key, pred)?;
         self.c_asm.push(asm);
         Ok(())
     }
@@ -1136,18 +1154,19 @@ impl AsmBuilder {
         state: &StateVar,
         slot_idx: &mut u32,
         contract: &Contract,
+        pred_key: PredKey,
         pred: &Predicate,
     ) -> Result<(), ErrorEmitted> {
         let mut s_asm: Vec<StateRead> = Vec::new();
 
         // First, get the storage key
         let storage_key =
-            Self::compile_state_key(handler, &mut s_asm, &state.expr, contract, pred)?;
+            Self::compile_state_key(handler, &mut s_asm, &state.expr, contract, pred_key, pred)?;
 
         let storage_or_transient_slots = state
             .expr
             .get_ty(contract)
-            .storage_or_transient_slots(handler, contract, pred)?;
+            .storage_or_transient_slots(handler, contract, pred_key)?;
         s_asm.extend([
             Stack::Push(storage_or_transient_slots as i64).into(),
             StateSlots::AllocSlots.into(),
@@ -1173,20 +1192,21 @@ impl AsmBuilder {
 pub fn predicate_to_asm(
     handler: &Handler,
     contract: &Contract,
+    pred_key: PredKey,
     pred: &Predicate,
 ) -> Result<CompiledPredicate, ErrorEmitted> {
     let mut builder = AsmBuilder::default();
 
     let mut slot_idx = 0;
     for (_, state) in pred.states() {
-        let _ = builder.compile_state(handler, state, &mut slot_idx, contract, pred);
+        let _ = builder.compile_state(handler, state, &mut slot_idx, contract, pred_key, pred);
     }
 
     for ConstraintDecl {
         expr: constraint, ..
     } in &pred.constraints
     {
-        let _ = builder.compile_constraint(handler, constraint, contract, pred);
+        let _ = builder.compile_constraint(handler, constraint, contract, pred_key, pred);
     }
 
     if handler.has_errors() {

--- a/pintc/src/parser/context.rs
+++ b/pintc/src/parser/context.rs
@@ -4,7 +4,7 @@ use crate::{
     macros::{MacroCall, MacroDecl},
     parser::{Ident, NextModPath, UsePath, UseTree},
     predicate::{
-        CallKey, ConstraintDecl, Contract, ExprKey, Interface, InterfaceDecl, Predicate,
+        CallKey, ConstraintDecl, Contract, ExprKey, Interface, InterfaceDecl, PredKey, Predicate,
         PredicateInstance, StorageVar, Var,
     },
     span::{self, Span},
@@ -17,10 +17,10 @@ pub struct ParserContext<'a> {
     pub(crate) mod_prefix: &'a str,
     pub(crate) local_scope: Option<&'a str>,
     pub(crate) contract: &'a mut Contract,
-    pub(crate) current_pred: &'a mut String,
+    pub(crate) current_pred: PredKey,
     pub(crate) macros: &'a mut Vec<MacroDecl>,
     pub(crate) macro_calls:
-        &'a mut BTreeMap<String, slotmap::SecondaryMap<CallKey, (ExprKey, MacroCall)>>,
+        &'a mut BTreeMap<PredKey, slotmap::SecondaryMap<CallKey, (ExprKey, MacroCall)>>,
     pub(crate) span_from: &'a dyn Fn(usize, usize) -> Span,
     pub(crate) use_paths: &'a mut Vec<UsePath>,
     pub(crate) next_paths: &'a mut Vec<NextModPath>,

--- a/pintc/src/parser/use_path.rs
+++ b/pintc/src/parser/use_path.rs
@@ -100,14 +100,13 @@ lalrpop_mod!(#[allow(unused)] pub pint_parser);
 
 #[test]
 fn gather_use_paths() {
-    use crate::{
-        error::Handler,
-        predicate::{Contract, Exprs, Predicate},
-    };
+    use crate::{error::Handler, predicate::Contract};
     use std::collections::BTreeMap;
+
     let parser = pint_parser::TestDelegateParser::new();
-    let mut current_pred = Contract::ROOT_PRED_NAME.to_string();
     let filepath = std::rc::Rc::from(std::path::Path::new("test"));
+    let mut contract = Contract::default();
+    let current_pred = contract.root_pred_key();
 
     let mut to_use_paths = |src: &str| -> Vec<UsePath> {
         parser
@@ -116,19 +115,11 @@ fn gather_use_paths() {
                     mod_path: &[],
                     mod_prefix: "",
                     local_scope: None,
-                    contract: &mut Contract {
-                        preds: BTreeMap::from([(
-                            Contract::ROOT_PRED_NAME.to_string(),
-                            Predicate::default(),
-                        )]),
-                        exprs: Exprs::default(),
-                        consts: fxhash::FxHashMap::default(),
-                        removed_macro_calls: slotmap::SecondaryMap::default(),
-                    },
-                    current_pred: &mut current_pred,
+                    contract: &mut contract,
+                    current_pred,
                     macros: &mut Vec::default(),
                     macro_calls: &mut BTreeMap::from([(
-                        Contract::ROOT_PRED_NAME.to_string(),
+                        current_pred,
                         slotmap::SecondaryMap::default(),
                     )]),
                     span_from: &|_, _| span::empty_span(),

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -3,7 +3,7 @@ use crate::{
     expr::*,
     predicate::{
         BlockStatement, Const, ConstraintDecl, ExprKey, IfDecl, PredicateInterface, InterfaceDecl,
-        InterfaceInstance, InterfaceVar, Predicate, Contract,
+        InterfaceInstance, InterfaceVar, Predicate,
         StorageVar,
     },
     lexer,
@@ -69,26 +69,26 @@ PredicateOpen: () = {
         );
 
         // Brand new Pred in the contract
-        context
+        let pred_key = context
             .contract
             .preds
-            .insert(name.to_string(), Predicate::new(name.to_string()));
+            .insert(Predicate::new(name.to_string()));
 
         // Keep track of the macro call in this new predicate
         context
             .macro_calls
-            .insert(name.to_string(), slotmap::SecondaryMap::default());
+            .insert(pred_key, slotmap::SecondaryMap::default());
 
         // Switch the current_pred so that the parser inserts items in the right Pred until the
         // predicate closes
-        *context.current_pred = name.to_string();
+        context.current_pred = pred_key;
     }
 }
 
 PredicateClose: () = {
     "}" => {
         // At the end of the predicate declaration, return back to the root Pred
-        *context.current_pred = Contract::ROOT_PRED_NAME.to_string();
+        context.current_pred = context.contract.root_pred_key();
     }
 }
 
@@ -821,7 +821,7 @@ MacroCallExpr: ExprKey = {
         );
         context
             .macro_calls
-            .get_mut(context.current_pred)
+            .get_mut(&context.current_pred)
             .unwrap()
             .insert(call_key, (call_expr_key, call_data));
         call_expr_key

--- a/pintc/src/predicate/analyse/array_check.rs
+++ b/pintc/src/predicate/analyse/array_check.rs
@@ -1,31 +1,37 @@
-use super::{Contract, Evaluator, ExprKey, Predicate};
+use super::{Contract, Evaluator, ExprKey};
 use crate::{
     error::{CompileError, Error, ErrorEmitted, Handler},
     expr::{BinaryOp, Expr, Immediate},
+    predicate::PredKey,
     span::Spanned,
     types::Type,
 };
 
 fn get_array_size_from_type(
     contract: &Contract,
-    pred: &Predicate,
+    pred_key: PredKey,
     handler: &Handler,
     array_ty: &Type,
 ) -> Result<i64, ErrorEmitted> {
     if let Some(n) = array_ty.get_array_size() {
         Ok(n)
     } else if let Some(range_expr_key) = array_ty.get_array_range_expr() {
-        Type::get_array_size_from_range_expr(handler, range_expr_key.get(contract), contract, pred)
+        Type::get_array_size_from_range_expr(
+            handler,
+            range_expr_key.get(contract),
+            contract,
+            pred_key,
+        )
     } else {
         unreachable!("array_ty MUST be an array type for this call")
     }
 }
 
-impl Predicate {
-    pub(crate) fn check_array_lengths(&self, contract: &Contract, handler: &Handler) {
-        fn check_array_type(contract: &Contract, pred: &Predicate, handler: &Handler, ty: &Type) {
+impl Contract {
+    pub(crate) fn check_array_lengths(&self, handler: &Handler, pred_key: PredKey) {
+        fn check_array_type(contract: &Contract, pred_key: PredKey, handler: &Handler, ty: &Type) {
             if ty.is_array() {
-                if let Ok(n) = get_array_size_from_type(contract, pred, handler, ty) {
+                if let Ok(n) = get_array_size_from_type(contract, pred_key, handler, ty) {
                     if n < 1 {
                         handler.emit_err(Error::Compile {
                             error: CompileError::InvalidConstArrayLength {
@@ -37,23 +43,25 @@ impl Predicate {
             }
         }
 
-        for var_key in self.vars().map(|(k, _)| k) {
-            check_array_type(contract, self, handler, var_key.get_ty(self));
+        let pred = &self.preds[pred_key];
+
+        for var_key in pred.vars().map(|(k, _)| k) {
+            check_array_type(self, pred_key, handler, var_key.get_ty(pred));
         }
 
-        for expr_key in contract.exprs(self) {
-            check_array_type(contract, self, handler, expr_key.get_ty(contract));
+        for expr_key in self.exprs(pred_key) {
+            check_array_type(self, pred_key, handler, expr_key.get_ty(self));
         }
     }
 
-    pub(crate) fn check_array_indexing(&self, contract: &Contract, handler: &Handler) {
+    pub(crate) fn check_array_indexing(&self, handler: &Handler, pred_key: PredKey) {
         // Gather all accesses into *arrays*.  `Expr::Index` is also used for maps.
-        let accesses: Vec<(Type, ExprKey)> = contract
-            .exprs(self)
+        let accesses: Vec<(Type, ExprKey)> = self
+            .exprs(pred_key)
             .filter_map(|expr_key| {
-                expr_key.try_get(contract).and_then(|expr| {
+                expr_key.try_get(self).and_then(|expr| {
                     if let Expr::Index { expr, index, .. } = expr {
-                        let indexed_ty = expr.get_ty(contract);
+                        let indexed_ty = expr.get_ty(self);
                         indexed_ty.is_array().then(|| (indexed_ty.clone(), *index))
                     } else {
                         None
@@ -62,14 +70,14 @@ impl Predicate {
             })
             .collect();
 
-        let evaluator = Evaluator::new(self);
+        let evaluator = Evaluator::new(&self.preds[pred_key]);
         for (array_ty, index_key) in accesses {
             // First, try evaluating the index value, since it must be an immediate int (or enum
             // variant, which evaluates to int).
-            let index_expr = index_key.get(contract);
+            let index_expr = index_key.get(self);
             let index_span = index_expr.span().clone();
             if let Ok(index_value) = evaluator
-                .evaluate(index_expr, handler, contract, &self.name)
+                .evaluate(index_expr, handler, self, pred_key)
                 .map_err(|_| {
                     handler.emit_err(Error::Compile {
                         error: CompileError::NonConstArrayIndex {
@@ -79,7 +87,7 @@ impl Predicate {
                 })
             {
                 // Get the size of the accessed array.
-                if let Ok(array_size) = get_array_size_from_type(contract, self, handler, &array_ty)
+                if let Ok(array_size) = get_array_size_from_type(self, pred_key, handler, &array_ty)
                 {
                     // Check for OOB.
                     if let Immediate::Int(imm_val) = index_value {
@@ -98,18 +106,18 @@ impl Predicate {
         }
     }
 
-    pub(crate) fn check_array_compares(&self, contract: &Contract, handler: &Handler) {
+    pub(crate) fn check_array_compares(&self, handler: &Handler, pred_key: PredKey) {
         // Analyse all comparisons between arrays.  The only valid operators are Eq and NotEq.
-        for expr_key in contract.exprs(self) {
-            if let Expr::BinaryOp { op, lhs, rhs, span } = expr_key.get(contract) {
+        for expr_key in self.exprs(pred_key) {
+            if let Expr::BinaryOp { op, lhs, rhs, span } = expr_key.get(self) {
                 if *op == BinaryOp::Equal || *op == BinaryOp::NotEqual {
-                    let lhs_ty = lhs.get_ty(contract);
-                    let rhs_ty = rhs.get_ty(contract);
+                    let lhs_ty = lhs.get_ty(self);
+                    let rhs_ty = rhs.get_ty(self);
 
                     if lhs_ty.is_array() && rhs_ty.is_array() {
                         // We're comparing arrays.  Now compare their sizes.
-                        let lhs_size = get_array_size_from_type(contract, self, handler, lhs_ty);
-                        let rhs_size = get_array_size_from_type(contract, self, handler, rhs_ty);
+                        let lhs_size = get_array_size_from_type(self, pred_key, handler, lhs_ty);
+                        let rhs_size = get_array_size_from_type(self, pred_key, handler, rhs_ty);
 
                         if let (Ok(lhs_size), Ok(rhs_size)) = (lhs_size, rhs_size) {
                             if lhs_size != rhs_size {

--- a/pintc/src/predicate/display.rs
+++ b/pintc/src/predicate/display.rs
@@ -6,11 +6,11 @@ impl Display for super::Contract {
             writeln!(f, "const {path}{};", self.root_pred().with_pred(self, cnst))?;
         }
 
-        for (name, pred) in &self.preds {
-            if name == Self::ROOT_PRED_NAME {
+        for pred in self.preds.values() {
+            if pred.name == Self::ROOT_PRED_NAME {
                 self.root_pred().fmt_with_indent(f, self, 0)?
             } else {
-                writeln!(f, "\npredicate {name} {{")?;
+                writeln!(f, "\npredicate {} {{", pred.name)?;
                 pred.fmt_with_indent(f, self, 1)?;
                 writeln!(f, "}}")?;
             }

--- a/pintc/src/predicate/exprs.rs
+++ b/pintc/src/predicate/exprs.rs
@@ -1,4 +1,4 @@
-use super::{Contract, Predicate};
+use super::{Contract, PredKey, Predicate};
 use crate::{expr::Expr, types::Type};
 use std::collections::HashSet;
 
@@ -168,9 +168,9 @@ pub(crate) struct ExprsIter<'a> {
 }
 
 impl<'a> ExprsIter<'a> {
-    pub(super) fn new(contract: &'a Contract, pred: &Predicate) -> ExprsIter<'a> {
+    pub(super) fn new(contract: &'a Contract, pred_key: PredKey) -> ExprsIter<'a> {
         // We start with all the constraint and state exprs.
-        let queue = pred.root_set().collect();
+        let queue = contract.root_set(pred_key).collect();
 
         ExprsIter {
             contract,

--- a/pintc/src/predicate/transform.rs
+++ b/pintc/src/predicate/transform.rs
@@ -32,10 +32,10 @@ impl super::Contract {
 
         // Do some array checks now that generators have been unrolled (and ephemerals aren't
         // going to cause problems).
-        for pred in self.preds.values() {
-            pred.check_array_lengths(&self, handler);
-            pred.check_array_indexing(&self, handler);
-            pred.check_array_compares(&self, handler);
+        for pred_key in self.preds.keys() {
+            self.check_array_lengths(handler, pred_key);
+            self.check_array_indexing(handler, pred_key);
+            self.check_array_compares(handler, pred_key);
         }
 
         // Transform each enum variant into its integer discriminant

--- a/pintc/src/predicate/vars.rs
+++ b/pintc/src/predicate/vars.rs
@@ -1,4 +1,4 @@
-use super::{Contract, DisplayWithPred, Ident, Predicate};
+use super::{Contract, DisplayWithPred, Ident, PredKey, Predicate};
 use crate::{
     error::{ErrorEmitted, Handler},
     span::Span,
@@ -99,16 +99,17 @@ impl VarKey {
         pred.vars.var_types.insert(*self, ty);
     }
 
-    /// Generate a `VarABI` given a `VarKey` and an `Predicate`
+    /// Generate a `VarABI` given a `VarKey` and a `PredKey`
     pub fn abi(
         &self,
         handler: &Handler,
         contract: &Contract,
-        pred: &Predicate,
+        pred_key: PredKey,
     ) -> Result<VarABI, ErrorEmitted> {
+        let pred = &contract.preds[pred_key];
         Ok(VarABI {
             name: self.get(pred).name.clone(),
-            ty: self.get_ty(pred).abi(handler, contract, pred)?,
+            ty: self.get_ty(pred).abi(handler, contract, pred_key)?,
         })
     }
 }

--- a/pintc/src/types.rs
+++ b/pintc/src/types.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{CompileError, Error, ErrorEmitted, Handler},
     expr::{evaluate::Evaluator, Expr, Ident, Immediate},
-    predicate::{Contract, ExprKey, Predicate},
+    predicate::{Contract, ExprKey, PredKey, Predicate},
     span::{Span, Spanned},
 };
 use pint_abi_types::{TupleField, TypeABI};
@@ -200,8 +200,10 @@ impl Type {
         handler: &Handler,
         range_expr: &Expr,
         contract: &Contract,
-        pred: &Predicate,
+        pred_key: PredKey,
     ) -> Result<i64, ErrorEmitted> {
+        let pred = &contract.preds[pred_key];
+
         if let Expr::PathByName(path, _) = range_expr {
             // It's hopefully an enum for the range expression.
             if let Some(size) = pred.enums.iter().find_map(|enum_decl| {
@@ -216,7 +218,7 @@ impl Type {
                 }))
             }
         } else {
-            match Evaluator::new(pred).evaluate(range_expr, handler, contract, &pred.name) {
+            match Evaluator::new(pred).evaluate(range_expr, handler, contract, pred_key) {
                 Ok(Immediate::Int(size)) if size > 0 => Ok(size),
                 Ok(_) => Err(handler.emit_err(Error::Compile {
                     error: CompileError::InvalidConstArrayLength {
@@ -290,7 +292,7 @@ impl Type {
         &self,
         handler: &Handler,
         contract: &Contract,
-        pred: &Predicate,
+        pred_key: PredKey,
     ) -> Result<usize, ErrorEmitted> {
         match self {
             Self::Primitive {
@@ -305,13 +307,13 @@ impl Type {
 
             Self::Tuple { fields, .. } => fields.iter().try_fold(0, |acc, (_, field_ty)| {
                 field_ty
-                    .size(handler, contract, pred)
+                    .size(handler, contract, pred_key)
                     .map(|size| acc + size)
             }),
 
             Self::Array {
                 ty, range, size, ..
-            } => Ok(ty.size(handler, contract, pred)?
+            } => Ok(ty.size(handler, contract, pred_key)?
                 * size.unwrap_or(
                     Self::get_array_size_from_range_expr(
                         handler,
@@ -320,7 +322,7 @@ impl Type {
                             .and_then(|e| e.try_get(contract))
                             .expect("expr key guaranteed to exist"),
                         contract,
-                        pred,
+                        pred_key,
                     )
                     .unwrap(),
                 ) as usize),
@@ -340,20 +342,20 @@ impl Type {
         &self,
         handler: &Handler,
         contract: &Contract,
-        pred: &Predicate,
+        pred_key: PredKey,
     ) -> Result<usize, ErrorEmitted> {
         match self {
             Self::Primitive { .. } => Ok(1),
 
             Self::Tuple { fields, .. } => fields.iter().try_fold(0, |acc, (_, field_ty)| {
                 field_ty
-                    .storage_or_transient_slots(handler, contract, pred)
+                    .storage_or_transient_slots(handler, contract, pred_key)
                     .map(|slots| acc + slots)
             }),
 
             Self::Array {
                 ty, range, size, ..
-            } => Ok(ty.storage_or_transient_slots(handler, contract, pred)?
+            } => Ok(ty.storage_or_transient_slots(handler, contract, pred_key)?
                 * size.unwrap_or(Self::get_array_size_from_range_expr(
                     handler,
                     range
@@ -361,7 +363,7 @@ impl Type {
                         .and_then(|e| e.try_get(contract))
                         .expect("expr key guaranteed to exist"),
                     contract,
-                    pred,
+                    pred_key,
                 )?) as usize),
 
             // The point here is that a `Map` takes up a storage slot, even though it doesn't
@@ -377,7 +379,7 @@ impl Type {
         &self,
         handler: &Handler,
         contract: &Contract,
-        pred: &Predicate,
+        pred_key: PredKey,
     ) -> Result<TypeABI, ErrorEmitted> {
         match self {
             Type::Primitive { kind, .. } => Ok(match kind {
@@ -394,7 +396,7 @@ impl Type {
                     .map(|(name, field_ty)| {
                         Ok(TupleField {
                             name: name.as_ref().map(|name| name.name.clone()),
-                            ty: field_ty.abi(handler, contract, pred)?,
+                            ty: field_ty.abi(handler, contract, pred_key)?,
                         })
                     })
                     .collect::<Result<Vec<_>, _>>()?,
@@ -402,7 +404,7 @@ impl Type {
             Type::Array {
                 ty, range, size, ..
             } => Ok(TypeABI::Array {
-                ty: Box::new(ty.abi(handler, contract, pred)?),
+                ty: Box::new(ty.abi(handler, contract, pred_key)?),
                 size: size.unwrap_or(Self::get_array_size_from_range_expr(
                     handler,
                     range
@@ -410,12 +412,12 @@ impl Type {
                         .and_then(|e| e.try_get(contract))
                         .expect("expr key guaranteed to exist"),
                     contract,
-                    pred,
+                    pred_key,
                 )?),
             }),
             Type::Map { ty_from, ty_to, .. } => Ok(TypeABI::Map {
-                ty_from: Box::new((*ty_from).abi(handler, contract, pred)?),
-                ty_to: Box::new((*ty_to).abi(handler, contract, pred)?),
+                ty_from: Box::new((*ty_from).abi(handler, contract, pred_key)?),
+                ty_to: Box::new((*ty_to).abi(handler, contract, pred_key)?),
             }),
             _ => unimplemented!("other types are not yet supported"),
         }

--- a/pintc/tests/basic_tests/if_statements_in_predicates.pnt
+++ b/pintc/tests/basic_tests/if_statements_in_predicates.pnt
@@ -64,6 +64,34 @@ predicate Bar {
 }
 
 // parsed <<<
+// predicate ::Foo {
+//     var ::condition: bool;
+//     var ::condition2: bool;
+//     var ::x: int;
+//     var ::y: int;
+//     var ::xx: int;
+//     var ::yy: int;
+//     var ::z: bool;
+//     if ::condition {
+//         constraint (::x == 0)
+//         constraint (::y != ::x)
+//     }
+//     if ::condition {
+//     }
+//     if ::condition2 {
+//         constraint (::xx == 1)
+//         constraint (::yy != ::xx)
+//     } else {
+//         constraint (::yy != 0)
+//         constraint (::xx > (::yy + 1))
+//         constraint ::z
+//     }
+//     if ::condition2 {
+//         constraint (::yy != ::xx)
+//     } else {
+//     }
+// }
+//
 // predicate ::Bar {
 //     var ::condition: bool;
 //     var ::condition2: bool;
@@ -94,54 +122,9 @@ predicate Bar {
 //         }
 //     }
 // }
-//
-// predicate ::Foo {
-//     var ::condition: bool;
-//     var ::condition2: bool;
-//     var ::x: int;
-//     var ::y: int;
-//     var ::xx: int;
-//     var ::yy: int;
-//     var ::z: bool;
-//     if ::condition {
-//         constraint (::x == 0)
-//         constraint (::y != ::x)
-//     }
-//     if ::condition {
-//     }
-//     if ::condition2 {
-//         constraint (::xx == 1)
-//         constraint (::yy != ::xx)
-//     } else {
-//         constraint (::yy != 0)
-//         constraint (::xx > (::yy + 1))
-//         constraint ::z
-//     }
-//     if ::condition2 {
-//         constraint (::yy != ::xx)
-//     } else {
-//     }
-// }
 // >>>
 
 // flattened <<<
-// predicate ::Bar {
-//     var ::condition: bool;
-//     var ::condition2: bool;
-//     var ::condition3: bool;
-//     var ::x: int;
-//     var ::xx: int;
-//     var ::yy: int;
-//     var ::z: bool;
-//     constraint (!(::condition2 && ::condition) || (false || (::z && !::z)));
-//     constraint (!(::condition2 && ::condition) || (::yy != ::xx));
-//     constraint (!(::condition2 && ::condition) || (!true || (::x + 1)));
-//     constraint (!(::condition2 && ::condition) || (true || ::z));
-//     constraint ((::condition2 && ::condition) || (!::condition3 || ((::yy + ::xx) == (::yy * ::xx))));
-//     constraint ((::condition2 && ::condition) || (!::condition3 || ::z));
-//     constraint ((::condition2 && ::condition) || (::condition3 || (!::z || (::z && true))));
-// }
-//
 // predicate ::Foo {
 //     var ::condition: bool;
 //     var ::condition2: bool;
@@ -158,5 +141,22 @@ predicate Bar {
 //     constraint (::condition2 || (::xx > (::yy + 1)));
 //     constraint (::condition2 || ::z);
 //     constraint (!::condition2 || (::yy != ::xx));
+// }
+//
+// predicate ::Bar {
+//     var ::condition: bool;
+//     var ::condition2: bool;
+//     var ::condition3: bool;
+//     var ::x: int;
+//     var ::xx: int;
+//     var ::yy: int;
+//     var ::z: bool;
+//     constraint (!(::condition2 && ::condition) || (false || (::z && !::z)));
+//     constraint (!(::condition2 && ::condition) || (::yy != ::xx));
+//     constraint (!(::condition2 && ::condition) || (!true || (::x + 1)));
+//     constraint (!(::condition2 && ::condition) || (true || ::z));
+//     constraint ((::condition2 && ::condition) || (!::condition3 || ((::yy + ::xx) == (::yy * ::xx))));
+//     constraint ((::condition2 && ::condition) || (!::condition3 || ::z));
+//     constraint ((::condition2 && ::condition) || (::condition3 || (!::z || (::z && true))));
 // }
 // >>>

--- a/pintc/tests/contracts/macros.pnt
+++ b/pintc/tests/contracts/macros.pnt
@@ -51,24 +51,24 @@ predicate Sum {
 }
 
 // parsed <<<
-// predicate ::Bar {
+// predicate ::Foo {
 //     var ::anon@0::a: int;
-//     constraint ([1e0, 2e0] == [1e0, 2e0]);
-//     constraint (::anon@0::a == 4);
+//     constraint (4 == 4);
+//     constraint (::anon@0::a == 3);
 // }
-// 
+//
+// predicate ::Bar {
+//     var ::anon@1::a: int;
+//     constraint ([1e0, 2e0] == [1e0, 2e0]);
+//     constraint (::anon@1::a == 4);
+// }
+//
 // predicate ::Baz {
 //     var ::v: int;
 //     constraint (::v == 0);
 //     constraint (::v == 0);
 //     constraint (::v == 0);
 //     constraint (::v == 0);
-// }
-//
-// predicate ::Foo {
-//     var ::anon@2::a: int;
-//     constraint (4 == 4);
-//     constraint (::anon@2::a == 3);
 // }
 //
 // predicate ::Sum {
@@ -80,12 +80,18 @@ predicate Sum {
 // >>>
 
 // flattened <<<
-// predicate ::Bar {
+// predicate ::Foo {
 //     var ::anon@0::a: int;
-//     constraint ([1e0, 2e0] == [1e0, 2e0]);
-//     constraint (::anon@0::a == 4);
+//     constraint (4 == 4);
+//     constraint (::anon@0::a == 3);
 // }
-// 
+//
+// predicate ::Bar {
+//     var ::anon@1::a: int;
+//     constraint ([1e0, 2e0] == [1e0, 2e0]);
+//     constraint (::anon@1::a == 4);
+// }
+//
 // predicate ::Baz {
 //     var ::v: int;
 //     constraint (::v == 0);
@@ -93,13 +99,7 @@ predicate Sum {
 //     constraint (::v == 0);
 //     constraint (::v == 0);
 // }
-// 
-// predicate ::Foo {
-//     var ::anon@2::a: int;
-//     constraint (4 == 4);
-//     constraint (::anon@2::a == 3);
-// }
-// 
+//
 // predicate ::Sum {
 //     var ::a: int;
 //     var ::b: int;

--- a/pintc/tests/contracts/macros_multifile/main.pnt
+++ b/pintc/tests/contracts/macros_multifile/main.pnt
@@ -28,29 +28,29 @@ predicate Bar {
 //}
 
 // parsed <<<
-// predicate ::Bar {
-//     var ::anon@0::a: int;
-//     constraint ([1e0, 2e0] == [1e0, 2e0]);
-//     constraint (::anon@0::a == 4);
-// }
-// 
 // predicate ::Foo {
-//     var ::anon@1::a: int;
+//     var ::anon@0::a: int;
 //     constraint (4 == 4);
-//     constraint (::anon@1::a == 3);
+//     constraint (::anon@0::a == 3);
+// }
+//
+// predicate ::Bar {
+//     var ::anon@1::a: int;
+//     constraint ([1e0, 2e0] == [1e0, 2e0]);
+//     constraint (::anon@1::a == 4);
 // }
 // >>>
 
 // flattened <<<
-// predicate ::Bar {
-//     var ::anon@0::a: int;
-//     constraint ([1e0, 2e0] == [1e0, 2e0]);
-//     constraint (::anon@0::a == 4);
-// }
-// 
 // predicate ::Foo {
-//     var ::anon@1::a: int;
+//     var ::anon@0::a: int;
 //     constraint (4 == 4);
-//     constraint (::anon@1::a == 3);
+//     constraint (::anon@0::a == 3);
+// }
+//
+// predicate ::Bar {
+//     var ::anon@1::a: int;
+//     constraint ([1e0, 2e0] == [1e0, 2e0]);
+//     constraint (::anon@1::a == 4);
 // }
 // >>>

--- a/pintc/tests/contracts/simple.pnt
+++ b/pintc/tests/contracts/simple.pnt
@@ -18,15 +18,6 @@ predicate Bar {
 // enum ::MyEnum = A | B;
 // type ::MyType = ::MyEnum;
 //
-// predicate ::Bar {
-//     var ::x: int;
-//     var ::y: ::MyType;
-//     enum ::MyEnum = A | B;
-//     type ::MyType = ::MyEnum;
-//     constraint (::y == ::MyType::A);
-//     constraint (::x < 2);
-// }
-//
 // predicate ::Foo {
 //     var ::x: int;
 //     var ::y: ::MyEnum;
@@ -35,24 +26,22 @@ predicate Bar {
 //     constraint (::y == ::MyEnum::A);
 //     constraint (::x == 3);
 // }
+//
+// predicate ::Bar {
+//     var ::x: int;
+//     var ::y: ::MyType;
+//     enum ::MyEnum = A | B;
+//     type ::MyType = ::MyEnum;
+//     constraint (::y == ::MyType::A);
+//     constraint (::x < 2);
+// }
 // >>>
 
 
 // flattened <<<
 // enum ::MyEnum = A | B;
 // type ::MyType = ::MyEnum;
-// 
-// predicate ::Bar {
-//     var ::x: int;
-//     var ::y: int;
-//     enum ::MyEnum = A | B;
-//     type ::MyType = ::MyEnum;
-//     constraint (::y == 0);
-//     constraint (::x < 2);
-//     constraint (::y >= 0);
-//     constraint (::y <= 1);
-// }
-// 
+//
 // predicate ::Foo {
 //     var ::x: int;
 //     var ::y: int;
@@ -60,6 +49,17 @@ predicate Bar {
 //     type ::MyType = ::MyEnum;
 //     constraint (::y == 0);
 //     constraint (::x == 3);
+//     constraint (::y >= 0);
+//     constraint (::y <= 1);
+// }
+//
+// predicate ::Bar {
+//     var ::x: int;
+//     var ::y: int;
+//     enum ::MyEnum = A | B;
+//     type ::MyType = ::MyEnum;
+//     constraint (::y == 0);
+//     constraint (::x < 2);
 //     constraint (::y >= 0);
 //     constraint (::y <= 1);
 // }

--- a/pintc/tests/storage/erc20.pnt
+++ b/pintc/tests/storage/erc20.pnt
@@ -51,33 +51,6 @@ predicate Burn {
 //     total_supply: int,
 // }
 //
-// predicate ::Burn {
-//     storage {
-//         balances: ( b256 => int ),
-//         total_supply: int,
-//     }
-//     var ::account: b256;
-//     var ::value: int;
-//     state ::account_balance = storage::balances[::account];
-//     state ::total_supply = storage::total_supply;
-//     constraint (::account_balance >= ::value);
-//     constraint (::account_balance' == (::account_balance - ::value));
-//     constraint (::total_supply' == (::total_supply - ::value));
-// }
-//
-// predicate ::Mint {
-//     storage {
-//         balances: ( b256 => int ),
-//         total_supply: int,
-//     }
-//     var ::account: b256;
-//     var ::value: int;
-//     state ::total_supply = storage::total_supply;
-//     state ::account_balance = storage::balances[::account];
-//     constraint (::total_supply' == (::total_supply + ::value));
-//     constraint (::account_balance' == (::account_balance + ::value));
-// }
-//
 // predicate ::Transfer {
 //     storage {
 //         balances: ( b256 => int ),
@@ -94,12 +67,18 @@ predicate Burn {
 //     constraint (::from_balance' == (::from_balance - ::value));
 //     constraint (::to_balance' == (::to_balance + ::value));
 // }
-// >>>
-
-// flattened <<<
-// storage {
-//     balances: ( b256 => int ),
-//     total_supply: int,
+//
+// predicate ::Mint {
+//     storage {
+//         balances: ( b256 => int ),
+//         total_supply: int,
+//     }
+//     var ::account: b256;
+//     var ::value: int;
+//     state ::total_supply = storage::total_supply;
+//     state ::account_balance = storage::balances[::account];
+//     constraint (::total_supply' == (::total_supply + ::value));
+//     constraint (::account_balance' == (::account_balance + ::value));
 // }
 //
 // predicate ::Burn {
@@ -109,24 +88,18 @@ predicate Burn {
 //     }
 //     var ::account: b256;
 //     var ::value: int;
-//     state ::account_balance: int = storage::balances[::account];
-//     state ::total_supply: int = storage::total_supply;
+//     state ::account_balance = storage::balances[::account];
+//     state ::total_supply = storage::total_supply;
 //     constraint (::account_balance >= ::value);
 //     constraint (::account_balance' == (::account_balance - ::value));
 //     constraint (::total_supply' == (::total_supply - ::value));
 // }
-//
-// predicate ::Mint {
-//     storage {
-//         balances: ( b256 => int ),
-//         total_supply: int,
-//     }
-//     var ::account: b256;
-//     var ::value: int;
-//     state ::total_supply: int = storage::total_supply;
-//     state ::account_balance: int = storage::balances[::account];
-//     constraint (::total_supply' == (::total_supply + ::value));
-//     constraint (::account_balance' == (::account_balance + ::value));
+// >>>
+
+// flattened <<<
+// storage {
+//     balances: ( b256 => int ),
+//     total_supply: int,
 // }
 //
 // predicate ::Transfer {
@@ -144,5 +117,32 @@ predicate Burn {
 //     constraint (::from_balance >= ::value);
 //     constraint (::from_balance' == (::from_balance - ::value));
 //     constraint (::to_balance' == (::to_balance + ::value));
+// }
+//
+// predicate ::Mint {
+//     storage {
+//         balances: ( b256 => int ),
+//         total_supply: int,
+//     }
+//     var ::account: b256;
+//     var ::value: int;
+//     state ::total_supply: int = storage::total_supply;
+//     state ::account_balance: int = storage::balances[::account];
+//     constraint (::total_supply' == (::total_supply + ::value));
+//     constraint (::account_balance' == (::account_balance + ::value));
+// }
+//
+// predicate ::Burn {
+//     storage {
+//         balances: ( b256 => int ),
+//         total_supply: int,
+//     }
+//     var ::account: b256;
+//     var ::value: int;
+//     state ::account_balance: int = storage::balances[::account];
+//     state ::total_supply: int = storage::total_supply;
+//     constraint (::account_balance >= ::value);
+//     constraint (::account_balance' == (::account_balance - ::value));
+//     constraint (::total_supply' == (::total_supply - ::value));
 // }
 // >>>

--- a/pintc/tests/storage/external_storage/main.pnt
+++ b/pintc/tests/storage/external_storage/main.pnt
@@ -93,50 +93,6 @@ predicate Bar {
 //     }
 // }
 //
-// predicate ::Bar {
-//     storage {
-//         x: int,
-//         y: bool,
-//         map: ( int => ( int => b256 ) ),
-//     }
-//     interface ::ERC20_0 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::lib::ERC20_1 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::lib::ERC20_2 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::ERC20_0_instance = ::ERC20_0(0x0000000000000000000000000000000000000000000000000000000000000000)
-//     interface ::ERC20_1_instance = ::lib::ERC20_1(0x1111111111111111111111111111111111111111111111111111111111111111)
-//     interface ::ERC20_2_instance = ::ERC20_0(0x2222222222222222222222222222222222222222222222222222222222222222)
-//     state ::internal_x = storage::x;
-//     state ::internal_y = storage::y;
-//     state ::internal_map = storage::map[3][4];
-//     state ::external_x_0 = ::ERC20_0_instance::storage::x;
-//     state ::external_y_0 = ::ERC20_0_instance::storage::y;
-//     state ::external_map_0 = ::ERC20_0_instance::storage::map[3][4];
-//     state ::external_x_1 = ::ERC20_1_instance::storage::x;
-//     state ::external_y_1 = ::ERC20_1_instance::storage::y;
-//     state ::external_map_1 = ::ERC20_1_instance::storage::map[3][4];
-//     state ::external_x_2 = ::ERC20_2_instance::storage::x;
-//     state ::external_y_2 = ::ERC20_2_instance::storage::y;
-//     state ::external_map_2 = ::ERC20_2_instance::storage::map[3][4];
-// }
-//
 // predicate ::Foo {
 //     storage {
 //         x: int,
@@ -167,6 +123,50 @@ predicate Bar {
 //     interface ::ERC20_0_instance = ::ERC20_0(0x0000000000000000000000000000000000000000000000000000000000000000)
 //     interface ::ERC20_1_instance = ::lib::ERC20_1(0x1111111111111111111111111111111111111111111111111111111111111111)
 //     interface ::ERC20_2_instance = ::lib::ERC20_2(0x2222222222222222222222222222222222222222222222222222222222222222)
+//     state ::internal_x = storage::x;
+//     state ::internal_y = storage::y;
+//     state ::internal_map = storage::map[3][4];
+//     state ::external_x_0 = ::ERC20_0_instance::storage::x;
+//     state ::external_y_0 = ::ERC20_0_instance::storage::y;
+//     state ::external_map_0 = ::ERC20_0_instance::storage::map[3][4];
+//     state ::external_x_1 = ::ERC20_1_instance::storage::x;
+//     state ::external_y_1 = ::ERC20_1_instance::storage::y;
+//     state ::external_map_1 = ::ERC20_1_instance::storage::map[3][4];
+//     state ::external_x_2 = ::ERC20_2_instance::storage::x;
+//     state ::external_y_2 = ::ERC20_2_instance::storage::y;
+//     state ::external_map_2 = ::ERC20_2_instance::storage::map[3][4];
+// }
+//
+// predicate ::Bar {
+//     storage {
+//         x: int,
+//         y: bool,
+//         map: ( int => ( int => b256 ) ),
+//     }
+//     interface ::ERC20_0 {
+//         storage {
+//             x: int,
+//             y: bool,
+//             map: ( int => ( int => b256 ) ),
+//         }
+//     }
+//     interface ::lib::ERC20_1 {
+//         storage {
+//             x: int,
+//             y: bool,
+//             map: ( int => ( int => b256 ) ),
+//         }
+//     }
+//     interface ::lib::ERC20_2 {
+//         storage {
+//             x: int,
+//             y: bool,
+//             map: ( int => ( int => b256 ) ),
+//         }
+//     }
+//     interface ::ERC20_0_instance = ::ERC20_0(0x0000000000000000000000000000000000000000000000000000000000000000)
+//     interface ::ERC20_1_instance = ::lib::ERC20_1(0x1111111111111111111111111111111111111111111111111111111111111111)
+//     interface ::ERC20_2_instance = ::ERC20_0(0x2222222222222222222222222222222222222222222222222222222222222222)
 //     state ::internal_x = storage::x;
 //     state ::internal_y = storage::y;
 //     state ::internal_map = storage::map[3][4];
@@ -210,50 +210,6 @@ predicate Bar {
 //     }
 // }
 //
-// predicate ::Bar {
-//     storage {
-//         x: int,
-//         y: bool,
-//         map: ( int => ( int => b256 ) ),
-//     }
-//     interface ::ERC20_0 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::lib::ERC20_1 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::lib::ERC20_2 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::ERC20_0_instance = ::ERC20_0(0x0000000000000000000000000000000000000000000000000000000000000000)
-//     interface ::ERC20_1_instance = ::lib::ERC20_1(0x1111111111111111111111111111111111111111111111111111111111111111)
-//     interface ::ERC20_2_instance = ::ERC20_0(0x2222222222222222222222222222222222222222222222222222222222222222)
-//     state ::internal_x: int = storage::x;
-//     state ::internal_y: bool = storage::y;
-//     state ::internal_map: b256 = storage::map[3][4];
-//     state ::external_x_0: int = ::ERC20_0_instance::storage::x;
-//     state ::external_y_0: bool = ::ERC20_0_instance::storage::y;
-//     state ::external_map_0: b256 = ::ERC20_0_instance::storage::map[3][4];
-//     state ::external_x_1: int = ::ERC20_1_instance::storage::x;
-//     state ::external_y_1: bool = ::ERC20_1_instance::storage::y;
-//     state ::external_map_1: b256 = ::ERC20_1_instance::storage::map[3][4];
-//     state ::external_x_2: int = ::ERC20_2_instance::storage::x;
-//     state ::external_y_2: bool = ::ERC20_2_instance::storage::y;
-//     state ::external_map_2: b256 = ::ERC20_2_instance::storage::map[3][4];
-// }
-//
 // predicate ::Foo {
 //     storage {
 //         x: int,
@@ -284,6 +240,50 @@ predicate Bar {
 //     interface ::ERC20_0_instance = ::ERC20_0(0x0000000000000000000000000000000000000000000000000000000000000000)
 //     interface ::ERC20_1_instance = ::lib::ERC20_1(0x1111111111111111111111111111111111111111111111111111111111111111)
 //     interface ::ERC20_2_instance = ::lib::ERC20_2(0x2222222222222222222222222222222222222222222222222222222222222222)
+//     state ::internal_x: int = storage::x;
+//     state ::internal_y: bool = storage::y;
+//     state ::internal_map: b256 = storage::map[3][4];
+//     state ::external_x_0: int = ::ERC20_0_instance::storage::x;
+//     state ::external_y_0: bool = ::ERC20_0_instance::storage::y;
+//     state ::external_map_0: b256 = ::ERC20_0_instance::storage::map[3][4];
+//     state ::external_x_1: int = ::ERC20_1_instance::storage::x;
+//     state ::external_y_1: bool = ::ERC20_1_instance::storage::y;
+//     state ::external_map_1: b256 = ::ERC20_1_instance::storage::map[3][4];
+//     state ::external_x_2: int = ::ERC20_2_instance::storage::x;
+//     state ::external_y_2: bool = ::ERC20_2_instance::storage::y;
+//     state ::external_map_2: b256 = ::ERC20_2_instance::storage::map[3][4];
+// }
+//
+// predicate ::Bar {
+//     storage {
+//         x: int,
+//         y: bool,
+//         map: ( int => ( int => b256 ) ),
+//     }
+//     interface ::ERC20_0 {
+//         storage {
+//             x: int,
+//             y: bool,
+//             map: ( int => ( int => b256 ) ),
+//         }
+//     }
+//     interface ::lib::ERC20_1 {
+//         storage {
+//             x: int,
+//             y: bool,
+//             map: ( int => ( int => b256 ) ),
+//         }
+//     }
+//     interface ::lib::ERC20_2 {
+//         storage {
+//             x: int,
+//             y: bool,
+//             map: ( int => ( int => b256 ) ),
+//         }
+//     }
+//     interface ::ERC20_0_instance = ::ERC20_0(0x0000000000000000000000000000000000000000000000000000000000000000)
+//     interface ::ERC20_1_instance = ::lib::ERC20_1(0x1111111111111111111111111111111111111111111111111111111111111111)
+//     interface ::ERC20_2_instance = ::ERC20_0(0x2222222222222222222222222222222222222222222222222222222222222222)
 //     state ::internal_x: int = storage::x;
 //     state ::internal_y: bool = storage::y;
 //     state ::internal_map: b256 = storage::map[3][4];

--- a/pintc/tests/storage/storage_multi_intent.pnt
+++ b/pintc/tests/storage/storage_multi_intent.pnt
@@ -61,7 +61,7 @@ predicate Bar {
 //     map3: ( int => ( int => b256 ) ),
 // }
 //
-// predicate ::Bar {
+// predicate ::Foo {
 //     storage {
 //         i: int,
 //         b: bool,
@@ -89,7 +89,7 @@ predicate Bar {
 //     constraint (::sum == (((::x + ::i0) + ::map_1_access_1) + ::map_1_access_2));
 // }
 //
-// predicate ::Foo {
+// predicate ::Bar {
 //     storage {
 //         i: int,
 //         b: bool,
@@ -127,7 +127,7 @@ predicate Bar {
 //     map3: ( int => ( int => b256 ) ),
 // }
 //
-// predicate ::Bar {
+// predicate ::Foo {
 //     storage {
 //         i: int,
 //         b: bool,
@@ -155,7 +155,7 @@ predicate Bar {
 //     constraint (::sum == (((::x + ::i0) + ::map_1_access_1) + ::map_1_access_2));
 // }
 //
-// predicate ::Foo {
+// predicate ::Bar {
 //     storage {
 //         i: int,
 //         b: bool,


### PR DESCRIPTION
And predicates are now almost exclusively referred to by key, rather than by name.

This is the next task for #774.  It's still a bit clumsy in areas, especially some parts of `asm_gen` where functions often take a predicate key _and_ a predicate reference, but this is related to getting the size of types which should no longer need the predicate reference once we move `enums` from `Prediate` to `Contract`.