### PR TITLE
Restrict `enum`s and `type`s to be only at the top level.

### DIFF
--- a/docs/book/src/basics/custom_types.md
+++ b/docs/book/src/basics/custom_types.md
@@ -4,6 +4,9 @@ Custom data types are named types that you can define in your program to refer, 
 primitive type, a compound type, or an `enum`. Enums are another special class of custom types that
 define enumerations with named variants.
 
+Both custom type and enum declarations must be made at the top level of a module, and are not
+allowed inside a `predicate` declaration.
+
 ### Type Aliases
 
 Pint provides the ability to declare a type alias to give an existing type another name. For this we

--- a/examples/ch_3_5.pnt
+++ b/examples/ch_3_5.pnt
@@ -1,16 +1,17 @@
-predicate test {
 // <disabled>
 // ANCHOR: alias
 type Balance = int;
-// ANCHOR_END: alias 
+// ANCHOR_END: alias
 
+predicate test0 {
 // ANCHOR: alias_same
 var x: int = 5;
 var y: Balance = 5;
 constraint x == y;
 // ANCHOR_END: alias_same
+}
 
-// ANCHOR: simple_struct 
+// ANCHOR: simple_struct
 type User = {
     status: bool,
     address: b256,
@@ -18,6 +19,7 @@ type User = {
 };
 // ANCHOR_END: simple_struct
 
+predicate test1 {
 // ANCHOR: simple_struct_instance
 var user1: User = {
     status: true,
@@ -25,11 +27,13 @@ var user1: User = {
     balance: 42,
 };
 // ANCHOR_END: simple_struct_instance
+}
 
 // ANCHOR: simple_enum
 enum Token = DAI | USDC | USDT;
 // ANCHOR_END: simple_enum
 
+predicate test2 {
 // ANCHOR: simple_enum_instances
 var dai: Token = Token::DAI;
 var usdc: Token = Token::USDC;
@@ -44,26 +48,28 @@ var token_type: Token = cond {
     else  => Token::USDT,
 };
 // ANCHOR_END: enum_selection
+}
 
 // ANCHOR: enum_in_struct
 type Bal = {
     token: Token,
-    bal: int, 
+    bal: int,
 };
 
-var user1_bal = {
-    token: Token::DAI,
-    bal: 42, 
-};
+predicate balances {
+    var user1_bal = {
+        token: Token::DAI,
+        bal: 42,
+    };
 
-var user2_bal = {
-    token: Token::USDC,
-    bal: 96, 
-};
+    var user2_bal = {
+        token: Token::USDC,
+        bal: 96,
+    };
 
-var user3_bal = {
-    token: Token::USDT,
-    bal: 100, 
-};
-// ANCHOR_END: enum_in_struct
+    var user3_bal = {
+        token: Token::USDT,
+        bal: 100,
+    };
 }
+// ANCHOR_END: enum_in_struct

--- a/pintc/src/asm_gen.rs
+++ b/pintc/src/asm_gen.rs
@@ -313,7 +313,7 @@ impl AsmBuilder {
                 }
             }
             Expr::StorageAccess(name, _) => {
-                let storage = &pred
+                let storage = &contract
                     .storage
                     .as_ref()
                     .expect("a storage block must have been declared")

--- a/pintc/src/expr/evaluate.rs
+++ b/pintc/src/expr/evaluate.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{CompileError, Error, ErrorEmitted, Handler},
     expr::{BinaryOp as BinOp, Expr, Immediate as Imm, TupleAccess, UnaryOp},
-    predicate::{Contract, ExprKey, PredKey, Predicate},
+    predicate::{Contract, ExprKey, PredKey},
     span::{empty_span, Spanned},
     types::{EnumDecl, Path},
 };
@@ -13,16 +13,16 @@ pub(crate) struct Evaluator {
 }
 
 impl Evaluator {
-    pub(crate) fn new(pred: &Predicate) -> Evaluator {
+    pub(crate) fn new(enums: &[EnumDecl]) -> Evaluator {
         Evaluator {
-            enum_values: Self::create_enum_map(pred),
+            enum_values: Self::create_enum_map(enums),
             scope_values: FxHashMap::default(),
         }
     }
 
-    pub(crate) fn from_values(pred: &Predicate, scope_values: FxHashMap<Path, Imm>) -> Evaluator {
+    pub(crate) fn from_values(enums: &[EnumDecl], scope_values: FxHashMap<Path, Imm>) -> Evaluator {
         Evaluator {
-            enum_values: Self::create_enum_map(pred),
+            enum_values: Self::create_enum_map(enums),
             scope_values,
         }
     }
@@ -39,8 +39,8 @@ impl Evaluator {
         self.scope_values
     }
 
-    fn create_enum_map(pred: &Predicate) -> FxHashMap<Path, Imm> {
-        FxHashMap::from_iter(pred.enums.iter().flat_map(
+    fn create_enum_map(enums: &[EnumDecl]) -> FxHashMap<Path, Imm> {
+        FxHashMap::from_iter(enums.iter().flat_map(
             |EnumDecl {
                  name: enum_name,
                  variants,

--- a/pintc/src/macros.rs
+++ b/pintc/src/macros.rs
@@ -147,7 +147,7 @@ pub(crate) fn splice_args(
             if !var_ty.is_unknown() {
                 if let Some(range_expr_key) = var_ty.get_array_range_expr() {
                     if let Some((size, opt_enum)) =
-                        splice_get_array_range_size(contract, pred, range_expr_key)
+                        splice_get_array_range_size(contract, range_expr_key)
                     {
                         // Store where and what to replace in the new spliced args.
                         replacements.insert(
@@ -173,7 +173,7 @@ pub(crate) fn splice_args(
             } else if let Some(var_init_key) = pred.var_inits.get(var_key) {
                 if let Some(Expr::Array { range_expr, .. }) = var_init_key.try_get(contract) {
                     if let Some((size, opt_enum)) =
-                        splice_get_array_range_size(contract, pred, *range_expr)
+                        splice_get_array_range_size(contract, *range_expr)
                     {
                         // Store where and what to replace in the new spliced args.
                         replacements.insert(
@@ -276,7 +276,6 @@ type OptEnumDecl = Option<(Ident, Vec<Ident>)>;
 
 fn splice_get_array_range_size(
     contract: &Contract,
-    pred: &Predicate,
     range_expr_key: ExprKey,
 ) -> Option<(usize, OptEnumDecl)> {
     range_expr_key
@@ -287,7 +286,8 @@ fn splice_get_array_range_size(
                 ..
             } => Some((*size as usize, None)),
             Expr::PathByName(path, _) => {
-                pred.enums
+                contract
+                    .enums
                     .iter()
                     .find_map(|EnumDecl { name, variants, .. }| {
                         (&name.name == path)

--- a/pintc/src/parser.rs
+++ b/pintc/src/parser.rs
@@ -239,7 +239,6 @@ impl<'a> ProjectParser<'a> {
         let enums = self.contract.root_pred().enums.clone();
         let new_types = self.contract.root_pred().new_types.clone();
         let root_symbols = self.contract.root_pred().top_level_symbols.clone();
-        let storage = self.contract.root_pred().storage.clone();
         let interfaces = self.contract.root_pred().interfaces.clone();
 
         self.contract
@@ -249,7 +248,6 @@ impl<'a> ProjectParser<'a> {
             .for_each(|pred| {
                 pred.new_types.extend_from_slice(&new_types);
                 pred.enums.extend_from_slice(&enums);
-                pred.storage.clone_from(&storage);
                 pred.interfaces.extend_from_slice(&interfaces);
 
                 for (symbol, span) in &root_symbols {

--- a/pintc/src/parser.rs
+++ b/pintc/src/parser.rs
@@ -231,13 +231,9 @@ impl<'a> ProjectParser<'a> {
     }
 
     fn finalize(mut self) -> Result<Contract, ErrorEmitted> {
-        // Insert all enums, new types, and storage variables from the root Pred into each non-root
-        // Pred (i.e. those declared using an `predicate { }` decl). Also, insert all top level
-        // symbols since shadowing is not allowed. That is, we can't use a symbol inside an
-        // `predicate { .. }` that was already used in the root Pred.
+        // Insert all top level symbols since shadowing is not allowed. That is, we can't use a
+        // symbol inside an `predicate { .. }` that was already used in the root Pred.
 
-        let enums = self.contract.root_pred().enums.clone();
-        let new_types = self.contract.root_pred().new_types.clone();
         let root_symbols = self.contract.root_pred().top_level_symbols.clone();
         let interfaces = self.contract.root_pred().interfaces.clone();
 
@@ -246,8 +242,6 @@ impl<'a> ProjectParser<'a> {
             .values_mut()
             .filter(|pred| pred.name != Contract::ROOT_PRED_NAME)
             .for_each(|pred| {
-                pred.new_types.extend_from_slice(&new_types);
-                pred.enums.extend_from_slice(&enums);
                 pred.interfaces.extend_from_slice(&interfaces);
 
                 for (symbol, span) in &root_symbols {

--- a/pintc/src/parser/context.rs
+++ b/pintc/src/parser/context.rs
@@ -85,7 +85,7 @@ impl<'a> ParserContext<'a> {
         (l, r): (usize, usize),
     ) {
         let span = (self.span_from)(l, r);
-        if let Some((_, prev_span)) = &self.current_pred().storage {
+        if let Some((_, prev_span)) = &self.contract.storage {
             // Multiple `storage` blocks are not allowed
             handler.emit_err(Error::Parse {
                 error: ParseError::TooManyStorageBlocks {
@@ -99,7 +99,7 @@ impl<'a> ParserContext<'a> {
                 error: ParseError::StorageDirectiveMustBeTopLevel { span },
             });
         } else {
-            self.current_pred().storage = Some((storage_vars, span));
+            self.contract.storage = Some((storage_vars, span));
         }
     }
 

--- a/pintc/src/parser/tests.rs
+++ b/pintc/src/parser/tests.rs
@@ -2913,15 +2913,17 @@ predicate Bar {
     var x: int;
     constraint x == 1;
 }
+enum MyEnum = A | B;
+type MyType = MyEnum;
 predicate Baz {
-    enum MyEnum = A | B;
-    type MyType = MyEnum;
 }
 "#;
 
     check(
         &run_parser!((yp::PintParser::new(), ""), src),
         expect_test::expect![[r#"
+            enum ::MyEnum = A | B;
+            type ::MyType = ::MyEnum;
 
             predicate ::Foo {
             }
@@ -2932,8 +2934,6 @@ predicate Baz {
             }
 
             predicate ::Baz {
-                enum ::MyEnum = A | B;
-                type ::MyType = ::MyEnum;
             }"#]],
     );
 }

--- a/pintc/src/parser/tests.rs
+++ b/pintc/src/parser/tests.rs
@@ -906,27 +906,34 @@ interface Foo {
 fn interface_instance() {
     let pint = (yp::PintParser::new(), "");
 
-    let src = r#"
-interface FooInstance =
-    FooInstance(0x0000111100001111000011110000111100001111000011110000111100001111);
-"#;
-
-    check(
-        &run_parser!(pint, src),
-        expect_test::expect!["interface ::FooInstance = ::FooInstance(0x0000111100001111000011110000111100001111000011110000111100001111)"],
-    );
-
-    let src = r#"
-    var addr: b256;
-interface FooInstance =
-    ::path::to::FooInstance(addr);
-"#;
+    let src = r#"predicate test {
+        interface FooInstance =
+            FooInstance(0x0000111100001111000011110000111100001111000011110000111100001111);
+    }"#;
 
     check(
         &run_parser!(pint, src),
         expect_test::expect![[r#"
-            interface ::FooInstance = ::path::to::FooInstance(::addr)
-            var ::addr: b256;"#]],
+
+            predicate ::test {
+                interface ::FooInstance = ::FooInstance(0x0000111100001111000011110000111100001111000011110000111100001111)
+            }"#]],
+    );
+
+    let src = r#"predicate test {
+        var addr: b256;
+        interface FooInstance =
+            ::path::to::FooInstance(addr);
+    }"#;
+
+    check(
+        &run_parser!(pint, src),
+        expect_test::expect![[r#"
+
+            predicate ::test {
+                interface ::FooInstance = ::path::to::FooInstance(::addr)
+                var ::addr: b256;
+            }"#]],
     );
 }
 
@@ -934,80 +941,92 @@ interface FooInstance =
 fn predicate_instance() {
     let pint = (yp::PintParser::new(), "");
 
-    let src = r#"
-predicate FooInstance =
-    InterfaceInstance::FooInstance(0x0000111100001111000011110000111100001111000011110000111100001111);
-"#;
+    let src = r#" predicate test {
+        predicate FooInstance =
+            InterfaceInstance::FooInstance(0x0000111100001111000011110000111100001111000011110000111100001111);
+    }"#;
 
     check(
         &run_parser!(pint, src),
         expect_test::expect![[r#"
-            predicate ::FooInstance = ::InterfaceInstance::FooInstance(0x0000111100001111000011110000111100001111000011110000111100001111)
-            var __::FooInstance_pathway: int;"#]],
+
+            predicate ::test {
+                predicate ::FooInstance = ::InterfaceInstance::FooInstance(0x0000111100001111000011110000111100001111000011110000111100001111)
+                var __::FooInstance_pathway: int;
+            }"#]],
     );
 
-    let src = r#"
-predicate FooInstance =
-    ::InterfaceInstance::FooInstance(0x0000111100001111000011110000111100001111000011110000111100001111);
-"#;
+    let src = r#"predicate test {
+        predicate FooInstance =
+            ::InterfaceInstance::FooInstance(0x0000111100001111000011110000111100001111000011110000111100001111);
+    }"#;
 
     check(
         &run_parser!(pint, src),
         expect_test::expect![[r#"
-            predicate ::FooInstance = ::InterfaceInstance::FooInstance(0x0000111100001111000011110000111100001111000011110000111100001111)
-            var __::FooInstance_pathway: int;"#]],
+
+            predicate ::test {
+                predicate ::FooInstance = ::InterfaceInstance::FooInstance(0x0000111100001111000011110000111100001111000011110000111100001111)
+                var __::FooInstance_pathway: int;
+            }"#]],
     );
 
-    let src = r#"
-var addr: b256;
-predicate FooInstance = path::to::FooInstance(addr);
-"#;
+    let src = r#"predicate test {
+        var addr: b256;
+        predicate FooInstance = path::to::FooInstance(addr);
+    }"#;
 
     check(
         &run_parser!(pint, src),
         expect_test::expect![[r#"
-            predicate ::FooInstance = ::path::to::FooInstance(::addr)
-            var ::addr: b256;
-            var __::FooInstance_pathway: int;"#]],
+
+            predicate ::test {
+                predicate ::FooInstance = ::path::to::FooInstance(::addr)
+                var ::addr: b256;
+                var __::FooInstance_pathway: int;
+            }"#]],
     );
 
-    let src = r#"
-var addr: b256;
-predicate FooInstance = ::path::to::FooInstance(addr);
-"#;
+    let src = r#"predicate test {
+        var addr: b256;
+        predicate FooInstance = ::path::to::FooInstance(addr);
+    }"#;
 
     check(
         &run_parser!(pint, src),
         expect_test::expect![[r#"
-            predicate ::FooInstance = ::path::to::FooInstance(::addr)
-            var ::addr: b256;
-            var __::FooInstance_pathway: int;"#]],
+
+            predicate ::test {
+                predicate ::FooInstance = ::path::to::FooInstance(::addr)
+                var ::addr: b256;
+                var __::FooInstance_pathway: int;
+            }"#]],
     );
 
-    let src = r#"
-var addr: b256;
-predicate FooInstance = FooInstance(addr);
-"#;
+    let src = r#"predicate test {
+        var addr: b256;
+        predicate FooInstance = FooInstance(addr);
+    }"#;
 
     check(
         &run_parser!(pint, src),
         expect_test::expect![[r#"
             path `FooInstance` to a predicate interface is too short
-            @17..58: path `FooInstance` is too short and cannot refer to a predicate interface
+            @49..90: path `FooInstance` is too short and cannot refer to a predicate interface
             a path to a predicate interface must contain a path to an interface instance followed by the name of the predicate, separated by a `::`
         "#]],
     );
 
-    let src = r#"
-var addr: b256;
-predicate FooInstance = ::FooInstance(addr);
-"#;
+    let src = r#"predicate test {
+        var addr: b256;
+        predicate FooInstance = ::FooInstance(addr);
+    }"#;
 
     check(
         &run_parser!(pint, src),
         expect_test::expect![[r#"
             path `::FooInstance` to a predicate interface is too short
-            @17..60: path `::FooInstance` is too short and cannot refer to a predicate interface
+            @49..92: path `::FooInstance` is too short and cannot refer to a predicate interface
             a path to a predicate interface must contain a path to an interface instance followed by the name of the predicate, separated by a `::`
         "#]],
     );
@@ -1045,26 +1064,26 @@ fn storage_access() {
     let pint = (yp::PintParser::new(), "");
 
     check(
-        &run_parser!(pint, r#"var x = storage::foo;"#),
+        &run_parser!(pint, r#"predicate test { var x = storage::foo; }"#),
         expect_test::expect![[r#"
             expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `macro_name`, or `{`, found `storage`
-            @8..15: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `macro_name`, or `{`
+            @25..32: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `macro_name`, or `{`
         "#]],
     );
 
     check(
-        &run_parser!(pint, r#"var x = storage::map[4][3];"#),
+        &run_parser!(pint, r#"predicate test { var x = storage::map[4][3]; }"#),
         expect_test::expect![[r#"
             expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `macro_name`, or `{`, found `storage`
-            @8..15: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `macro_name`, or `{`
+            @25..32: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `macro_name`, or `{`
         "#]],
     );
 
     check(
         &run_parser!(pint, r#"constraint storage::map[69] == 0;"#),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `macro_name`, or `{`, found `storage`
-            @11..18: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `macro_name`, or `{`
+            expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`, found `constraint`
+            @0..10: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`
         "#]],
     );
 }
@@ -1091,26 +1110,29 @@ fn external_storage_access() {
     let pint = (yp::PintParser::new(), "");
 
     check(
-        &run_parser!(pint, r#"var x = ::Foo::storage::foo;"#),
+        &run_parser!(pint, r#"predicate test { var x = ::Foo::storage::foo; }"#),
         expect_test::expect![[r#"
             expected `an identifier`, or `macro_name`, found `storage`
-            @15..22: expected `an identifier`, or `macro_name`
+            @32..39: expected `an identifier`, or `macro_name`
         "#]],
     );
 
     check(
-        &run_parser!(pint, r#"var x = Bar::storage::map[4][3];"#),
+        &run_parser!(
+            pint,
+            r#"predicate test { var x = Bar::storage::map[4][3]; }"#
+        ),
         expect_test::expect![[r#"
             expected `an identifier`, or `macro_name`, found `storage`
-            @13..20: expected `an identifier`, or `macro_name`
+            @30..37: expected `an identifier`, or `macro_name`
         "#]],
     );
 
     check(
         &run_parser!(pint, r#"constraint ::Foo::storage::map[69] == 0;"#),
         expect_test::expect![[r#"
-            expected `an identifier`, or `macro_name`, found `storage`
-            @18..25: expected `an identifier`, or `macro_name`
+            expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`, found `constraint`
+            @0..10: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`
         "#]],
     );
 }
@@ -1121,76 +1143,120 @@ fn var_decls() {
     let pint = (yp::PintParser::new(), "");
 
     check(
-        &run_parser!(pint, "var blah;", mod_path),
+        &run_parser!(pint, "predicate test { var blah; }", mod_path),
         expect_test::expect![[r#"
             type annotation or initializer needed for variable `blah`
-            @0..8: type annotation or initializer needed
+            @17..25: type annotation or initializer needed
             consider giving `blah` an explicit type or an initializer
         "#]],
     );
     check(
-        &run_parser!(pint, "var blah = 1.0;", mod_path),
+        &run_parser!(pint, "predicate test { var blah = 1.0; }", mod_path),
         expect_test::expect![[r#"
-            var ::foo::blah;
-            constraint (::foo::blah == 1e0);"#]],
+
+            predicate ::foo::test {
+                var ::foo::blah;
+                constraint (::foo::blah == 1e0);
+            }"#]],
     );
     check(
-        &run_parser!(pint, "var blah: real = 1.0;", mod_path),
+        &run_parser!(pint, "predicate test { var blah: real = 1.0; }", mod_path),
         expect_test::expect![[r#"
-            var ::foo::blah: real;
-            constraint (::foo::blah == 1e0);"#]],
+
+            predicate ::foo::test {
+                var ::foo::blah: real;
+                constraint (::foo::blah == 1e0);
+            }"#]],
     );
     check(
-        &run_parser!(pint, "var blah: real;", mod_path),
-        expect_test::expect!["var ::foo::blah: real;"],
-    );
-    check(
-        &run_parser!(pint, "var blah = 1;", mod_path),
+        &run_parser!(pint, "predicate test { var blah: real; }", mod_path),
         expect_test::expect![[r#"
-            var ::foo::blah;
-            constraint (::foo::blah == 1);"#]],
+
+            predicate ::foo::test {
+                var ::foo::blah: real;
+            }"#]],
     );
     check(
-        &run_parser!(pint, "var blah: int = 1;", mod_path),
+        &run_parser!(pint, "predicate test { var blah = 1; }", mod_path),
         expect_test::expect![[r#"
-            var ::foo::blah: int;
-            constraint (::foo::blah == 1);"#]],
+
+            predicate ::foo::test {
+                var ::foo::blah;
+                constraint (::foo::blah == 1);
+            }"#]],
     );
     check(
-        &run_parser!(pint, "var blah: int;", mod_path),
-        expect_test::expect!["var ::foo::blah: int;"],
-    );
-    check(
-        &run_parser!(pint, "var blah = true;", mod_path),
+        &run_parser!(pint, "predicate test { var blah: int = 1; }", mod_path),
         expect_test::expect![[r#"
-            var ::foo::blah;
-            constraint (::foo::blah == true);"#]],
+
+            predicate ::foo::test {
+                var ::foo::blah: int;
+                constraint (::foo::blah == 1);
+            }"#]],
     );
     check(
-        &run_parser!(pint, "var blah: bool = false;", mod_path),
+        &run_parser!(pint, "predicate test { var blah: int; }", mod_path),
         expect_test::expect![[r#"
-            var ::foo::blah: bool;
-            constraint (::foo::blah == false);"#]],
+
+            predicate ::foo::test {
+                var ::foo::blah: int;
+            }"#]],
     );
     check(
-        &run_parser!(pint, "var blah: bool;", mod_path),
-        expect_test::expect!["var ::foo::blah: bool;"],
-    );
-    check(
-        &run_parser!(pint, r#"var blah = "hello";"#, mod_path),
+        &run_parser!(pint, "predicate test { var blah = true; }", mod_path),
         expect_test::expect![[r#"
-            var ::foo::blah;
-            constraint (::foo::blah == "hello");"#]],
+
+            predicate ::foo::test {
+                var ::foo::blah;
+                constraint (::foo::blah == true);
+            }"#]],
     );
     check(
-        &run_parser!(pint, r#"var blah: string = "hello";"#, mod_path),
+        &run_parser!(pint, "predicate test { var blah: bool = false; }", mod_path),
         expect_test::expect![[r#"
-            var ::foo::blah: string;
-            constraint (::foo::blah == "hello");"#]],
+
+            predicate ::foo::test {
+                var ::foo::blah: bool;
+                constraint (::foo::blah == false);
+            }"#]],
     );
     check(
-        &run_parser!(pint, r#"var blah: string;"#, mod_path),
-        expect_test::expect!["var ::foo::blah: string;"],
+        &run_parser!(pint, "predicate test { var blah: bool; }", mod_path),
+        expect_test::expect![[r#"
+
+            predicate ::foo::test {
+                var ::foo::blah: bool;
+            }"#]],
+    );
+    check(
+        &run_parser!(pint, r#"predicate test { var blah = "hello"; }"#, mod_path),
+        expect_test::expect![[r#"
+
+            predicate ::foo::test {
+                var ::foo::blah;
+                constraint (::foo::blah == "hello");
+            }"#]],
+    );
+    check(
+        &run_parser!(
+            pint,
+            r#"predicate test { var blah: string = "hello"; }"#,
+            mod_path
+        ),
+        expect_test::expect![[r#"
+
+            predicate ::foo::test {
+                var ::foo::blah: string;
+                constraint (::foo::blah == "hello");
+            }"#]],
+    );
+    check(
+        &run_parser!(pint, r#"predicate test { var blah: string; }"#, mod_path),
+        expect_test::expect![[r#"
+
+            predicate ::foo::test {
+                var ::foo::blah: string;
+            }"#]],
     );
 }
 
@@ -1200,76 +1266,136 @@ fn pub_var_decls() {
     let pint = (yp::PintParser::new(), "");
 
     check(
-        &run_parser!(pint, "pub var blah;", mod_path),
+        &run_parser!(pint, "predicate test { pub var blah; }", mod_path),
         expect_test::expect![[r#"
             type annotation or initializer needed for variable `blah`
-            @0..12: type annotation or initializer needed
+            @17..29: type annotation or initializer needed
             consider giving `blah` an explicit type or an initializer
         "#]],
     );
     check(
-        &run_parser!(pint, "pub var blah = 1.0;", mod_path),
+        &run_parser!(pint, "predicate test { pub var blah = 1.0; }", mod_path),
         expect_test::expect![[r#"
-            pub var ::foo::blah;
-            constraint (::foo::blah == 1e0);"#]],
+
+            predicate ::foo::test {
+                pub var ::foo::blah;
+                constraint (::foo::blah == 1e0);
+            }"#]],
     );
     check(
-        &run_parser!(pint, "pub var blah: real = 1.0;", mod_path),
+        &run_parser!(
+            pint,
+            "predicate test { pub var blah: real = 1.0; }",
+            mod_path
+        ),
         expect_test::expect![[r#"
-            pub var ::foo::blah: real;
-            constraint (::foo::blah == 1e0);"#]],
+
+            predicate ::foo::test {
+                pub var ::foo::blah: real;
+                constraint (::foo::blah == 1e0);
+            }"#]],
     );
     check(
-        &run_parser!(pint, "pub var blah: real;", mod_path),
-        expect_test::expect!["pub var ::foo::blah: real;"],
-    );
-    check(
-        &run_parser!(pint, "pub var blah = 1;", mod_path),
+        &run_parser!(pint, "predicate test { pub var blah: real; }", mod_path),
         expect_test::expect![[r#"
-            pub var ::foo::blah;
-            constraint (::foo::blah == 1);"#]],
+
+            predicate ::foo::test {
+                pub var ::foo::blah: real;
+            }"#]],
     );
     check(
-        &run_parser!(pint, "pub var blah: int = 1;", mod_path),
+        &run_parser!(pint, "predicate test { pub var blah = 1; }", mod_path),
         expect_test::expect![[r#"
-            pub var ::foo::blah: int;
-            constraint (::foo::blah == 1);"#]],
+
+            predicate ::foo::test {
+                pub var ::foo::blah;
+                constraint (::foo::blah == 1);
+            }"#]],
     );
     check(
-        &run_parser!(pint, "pub var blah: int;", mod_path),
-        expect_test::expect!["pub var ::foo::blah: int;"],
-    );
-    check(
-        &run_parser!(pint, "pub var blah = true;", mod_path),
+        &run_parser!(pint, "predicate test { pub var blah: int = 1; }", mod_path),
         expect_test::expect![[r#"
-            pub var ::foo::blah;
-            constraint (::foo::blah == true);"#]],
+
+            predicate ::foo::test {
+                pub var ::foo::blah: int;
+                constraint (::foo::blah == 1);
+            }"#]],
     );
     check(
-        &run_parser!(pint, "pub var blah: bool = false;", mod_path),
+        &run_parser!(pint, "predicate test { pub var blah: int; }", mod_path),
         expect_test::expect![[r#"
-            pub var ::foo::blah: bool;
-            constraint (::foo::blah == false);"#]],
+
+            predicate ::foo::test {
+                pub var ::foo::blah: int;
+            }"#]],
     );
     check(
-        &run_parser!(pint, "pub var blah: bool;", mod_path),
-        expect_test::expect!["pub var ::foo::blah: bool;"],
-    );
-    check(
-        &run_parser!(pint, r#"pub var blah = "hello";"#, mod_path),
+        &run_parser!(pint, "predicate test { pub var blah = true; }", mod_path),
         expect_test::expect![[r#"
-            pub var ::foo::blah;
-            constraint (::foo::blah == "hello");"#]],
+
+            predicate ::foo::test {
+                pub var ::foo::blah;
+                constraint (::foo::blah == true);
+            }"#]],
     );
     check(
-        &run_parser!(pint, r#"pub var blah: string = "hello";"#, mod_path),
+        &run_parser!(
+            pint,
+            "predicate test { pub var blah: bool = false; }",
+            mod_path
+        ),
         expect_test::expect![[r#"
-            pub var ::foo::blah: string;
-            constraint (::foo::blah == "hello");"#]],
+
+            predicate ::foo::test {
+                pub var ::foo::blah: bool;
+                constraint (::foo::blah == false);
+            }"#]],
     );
     check(
-        &run_parser!(pint, r#"pub var blah: string;"#, mod_path),
-        expect_test::expect!["pub var ::foo::blah: string;"],
+        &run_parser!(pint, "predicate test { pub var blah: bool; }", mod_path),
+        expect_test::expect![[r#"
+
+            predicate ::foo::test {
+                pub var ::foo::blah: bool;
+            }"#]],
+    );
+    check(
+        &run_parser!(
+            pint,
+            r#"predicate test { pub var blah = "hello"; }"#,
+            mod_path
+        ),
+        expect_test::expect![[r#"
+
+            predicate ::foo::test {
+                pub var ::foo::blah;
+                constraint (::foo::blah == "hello");
+            }"#]],
+    );
+    check(
+        &run_parser!(
+            pint,
+            r#"predicate test { pub var blah: string = "hello"; }"#,
+            mod_path
+        ),
+        expect_test::expect![[r#"
+
+            predicate ::foo::test {
+                pub var ::foo::blah: string;
+                constraint (::foo::blah == "hello");
+            }"#]],
+    );
+    check(
+        &run_parser!(
+            pint,
+            r#"predicate test { pub var blah: string; }"#,
+            mod_path
+        ),
+        expect_test::expect![[r#"
+
+            predicate ::foo::test {
+                pub var ::foo::blah: string;
+            }"#]],
     );
 }
 
@@ -1278,12 +1404,20 @@ fn state_decls() {
     let pint = (yp::PintParser::new(), "");
 
     check(
-        &run_parser!(pint, "state x: int = __foo();"),
-        expect_test::expect!["state ::x: int = __foo();"],
+        &run_parser!(pint, "predicate test { state x: int = __foo(); }"),
+        expect_test::expect![[r#"
+
+            predicate ::test {
+                state ::x: int = __foo();
+            }"#]],
     );
     check(
-        &run_parser!(pint, "state y = __bar();"),
-        expect_test::expect!["state ::y = __bar();"],
+        &run_parser!(pint, "predicate test { state y = __bar(); }"),
+        expect_test::expect![[r#"
+
+            predicate ::test {
+                state ::y = __bar();
+            }"#]],
     );
 }
 
@@ -1314,8 +1448,12 @@ fn constraint_decls() {
     let pint = (yp::PintParser::new(), "");
 
     check(
-        &run_parser!(pint, "constraint blah;"),
-        expect_test::expect!["constraint ::blah;"],
+        &run_parser!(pint, "predicate test { constraint blah; }"),
+        expect_test::expect![[r#"
+
+            predicate ::test {
+                constraint ::blah;
+            }"#]],
     );
 }
 
@@ -1327,76 +1465,91 @@ fn if_decls() {
     check(
         &run_parser!(
             pint,
-            r#"
-            if true { }
-        "#
+            r#"predicate test {
+                if true { }
+            }"#
         ),
         expect_test::expect![[r#"
-            if true {
+
+            predicate ::test {
+                if true {
+                }
             }"#]],
     );
 
     check(
         &run_parser!(
             pint,
-            r#"
-            if true { } else { }
-        "#
+            r#"predicate test {
+                if true { } else { }
+            }"#
         ),
         expect_test::expect![[r#"
-            if true {
-            } else {
+
+            predicate ::test {
+                if true {
+                } else {
+                }
             }"#]],
     );
 
     check(
         &run_parser!(
             pint,
-            r#"
-            if condition { constraint x; }
-        "#
+            r#"predicate test {
+                if condition { constraint x; }
+            }"#
         ),
         expect_test::expect![[r#"
-            if ::condition {
-                constraint ::x
+
+            predicate ::test {
+                if ::condition {
+                    constraint ::x
+                }
             }"#]],
     );
 
     check(
         &run_parser!(
             pint,
-            r#"
-            if true { constraint x; } else { constraint y; }
-        "#
+            r#"predicate test {
+                if true { constraint x; } else { constraint y; }
+            }"#
         ),
         expect_test::expect![[r#"
-            if true {
-                constraint ::x
-            } else {
-                constraint ::y
-            }"#]],
-    );
 
-    check(
-        &run_parser!(
-            pint,
-            r#"
-            if true { if false { constraint x; } else { constraint y; } }
-            else { if __foo() { if boo && y { constraint true; constraint false; } } }
-        "#
-        ),
-        expect_test::expect![[r#"
-            if true {
-                if false {
+            predicate ::test {
+                if true {
                     constraint ::x
                 } else {
                     constraint ::y
                 }
-            } else {
-                if __foo() {
-                    if (::boo && ::y) {
-                        constraint true
-                        constraint false
+            }"#]],
+    );
+
+    check(
+        &run_parser!(
+            pint,
+            r#"predicate test {
+                if true { if false { constraint x; } else { constraint y; } }
+                else { if __foo() { if boo && y { constraint true; constraint false; } } }
+            }"#
+        ),
+        expect_test::expect![[r#"
+
+            predicate ::test {
+                if true {
+                    if false {
+                        constraint ::x
+                    } else {
+                        constraint ::y
+                    }
+                } else {
+                    if __foo() {
+                        if (::boo && ::y) {
+                            constraint true
+                            constraint false
+                        }
                     }
                 }
             }"#]],
@@ -1717,23 +1870,29 @@ fn enums() {
     check(
         &run_parser!(
             pint,
-            r#"
+            r#"predicate test {
                 var x = MyEnum::Variant3;
-                "#
+            }"#
         ),
         expect_test::expect![[r#"
-            var ::x;
-            constraint (::x == ::MyEnum::Variant3);"#]],
+
+            predicate ::test {
+                var ::x;
+                constraint (::x == ::MyEnum::Variant3);
+            }"#]],
     );
     check(
         &run_parser!(
             pint,
-            r#"
+            r#"predicate test {
                 var e: ::path::to::MyEnum;
-                "#
+            }"#
         ),
         expect_test::expect![[r#"
-            var ::e: ::path::to::MyEnum;"#]],
+
+            predicate ::test {
+                var ::e: ::path::to::MyEnum;
+            }"#]],
     );
 }
 
@@ -1809,11 +1968,14 @@ fn ranges() {
 
     // Range allow in let decls
     check(
-        &run_parser!(pint, "var x = 1..2;"),
+        &run_parser!(pint, "predicate test { var x = 1..2; }"),
         expect_test::expect![[r#"
-            var ::x;
-            constraint (::x >= 1);
-            constraint (::x <= 2);"#]],
+
+            predicate ::test {
+                var ::x;
+                constraint (::x >= 1);
+                constraint (::x <= 2);
+            }"#]],
     );
 
     // Ranges allowed after `in`
@@ -2124,10 +2286,13 @@ fn array_type() {
     );
 
     check(
-        &run_parser!((yp::PintParser::new(), ""), r#"var a: int[];"#),
+        &run_parser!(
+            (yp::PintParser::new(), ""),
+            r#"predicate test { var a: int[]; }"#
+        ),
         expect_test::expect![[r#"
             empty array types are not allowed
-            @7..12: empty array type found
+            @24..29: empty array type found
         "#]],
     );
 }
@@ -2191,10 +2356,13 @@ fn array_element_accesses() {
     );
 
     check(
-        &run_parser!((yp::PintParser::new(), ""), r#"var x = a[];"#),
+        &run_parser!(
+            (yp::PintParser::new(), ""),
+            r#"predicate test { var x = a[]; }"#
+        ),
         expect_test::expect![[r#"
             missing array or map index
-            @8..11: missing array or map element index
+            @25..28: missing array or map element index
         "#]],
     );
 
@@ -2365,35 +2533,44 @@ fn tuple_field_accesses() {
     let pint = (yp::PintParser::new(), "");
 
     check(
-        &run_parser!(pint, "var x = t.0xa;"),
+        &run_parser!(pint, "predicate test { var x = t.0xa; }"),
         expect_test::expect![[r#"
-                invalid integer `0xa` as tuple index
-                @10..13: invalid integer as tuple index
-            "#]],
+            invalid integer `0xa` as tuple index
+            @27..30: invalid integer as tuple index
+        "#]],
     );
 
     check(
-        &run_parser!(pint, "var x = t.111111111111111111111111111;"),
+        &run_parser!(
+            pint,
+            "predicate test { var x = t.111111111111111111111111111; }"
+        ),
         expect_test::expect![[r#"
-                invalid integer `111111111111111111111111111` as tuple index
-                @10..37: invalid integer as tuple index
-            "#]],
+            invalid integer `111111111111111111111111111` as tuple index
+            @27..54: invalid integer as tuple index
+        "#]],
     );
 
     check(
-        &run_parser!(pint, "var x = t.111111111111111111111111111.2;"),
+        &run_parser!(
+            pint,
+            "predicate test { var x = t.111111111111111111111111111.2; }"
+        ),
         expect_test::expect![[r#"
-                invalid integer `111111111111111111111111111` as tuple index
-                @10..37: invalid integer as tuple index
-            "#]],
+            invalid integer `111111111111111111111111111` as tuple index
+            @27..54: invalid integer as tuple index
+        "#]],
     );
 
     check(
-        &run_parser!(pint, "var x = t.2.111111111111111111111111111;"),
+        &run_parser!(
+            pint,
+            "predicate test { var x = t.2.111111111111111111111111111; }"
+        ),
         expect_test::expect![[r#"
-                invalid integer `111111111111111111111111111` as tuple index
-                @12..39: invalid integer as tuple index
-            "#]],
+            invalid integer `111111111111111111111111111` as tuple index
+            @29..56: invalid integer as tuple index
+        "#]],
     );
 
     check(
@@ -2402,28 +2579,26 @@ fn tuple_field_accesses() {
             "var x = t.222222222222222222222.111111111111111111111111111;"
         ),
         expect_test::expect![[r#"
-                invalid integer `222222222222222222222` as tuple index
-                @10..31: invalid integer as tuple index
-                invalid integer `111111111111111111111111111` as tuple index
-                @32..59: invalid integer as tuple index
-            "#]],
+            expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`, found `var`
+            @0..3: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`
+        "#]],
     );
 
     check(
-        &run_parser!(pint, "var x = t.1e5;"),
+        &run_parser!(pint, "predicate test { var x = t.1e5; }"),
         expect_test::expect![[r#"
-                invalid value `1e5` as tuple index
-                @10..13: invalid value as tuple index
-            "#]],
+            invalid value `1e5` as tuple index
+            @27..30: invalid value as tuple index
+        "#]],
     );
 
     check(
-        &run_parser!(pint, "var bad_tuple:{} = {};"),
+        &run_parser!(pint, "predicate test { var bad_tuple:{} = {}; }"),
         expect_test::expect![[r#"
             empty tuple types are not allowed
-            @14..16: empty tuple type found
+            @31..33: empty tuple type found
             empty tuple expressions are not allowed
-            @19..21: empty tuple expression found
+            @36..38: empty tuple expression found
         "#]],
     );
 }
@@ -2490,17 +2665,23 @@ fn casting() {
     );
 
     check(
-        &run_parser!(pint, r#"var x = __foo() as real as { int, real };"#),
+        &run_parser!(
+            pint,
+            r#"predicate test { var x = __foo() as real as { int, real }; }"#
+        ),
         expect_test::expect![[r#"
-            var ::x;
-            constraint (::x == __foo() as real as {int, real});"#]],
+
+            predicate ::test {
+                var ::x;
+                constraint (::x == __foo() as real as {int, real});
+            }"#]],
     );
 
     check(
-        &run_parser!(pint, r#"var x = 5 as"#),
+        &run_parser!(pint, r#"predicate test { var x = 5 as"#),
         expect_test::expect![[r#"
             expected `(`, `::`, `a type`, `an identifier`, or `{`, found `end of file`
-            @12..12: expected `(`, `::`, `a type`, `an identifier`, or `{`
+            @29..29: expected `(`, `::`, `a type`, `an identifier`, or `{`
         "#]],
     )
 }
@@ -2535,10 +2716,13 @@ fn in_expr() {
     );
 
     check(
-        &run_parser!((yp::PintParser::new(), ""), r#"var x = 5 in"#),
+        &run_parser!(
+            (yp::PintParser::new(), ""),
+            r#"predicate test { var x = 5 in"#
+        ),
         expect_test::expect![[r#"
             expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `macro_name`, or `{`, found `end of file`
-            @12..12: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `macro_name`, or `{`
+            @29..29: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `macro_name`, or `{`
         "#]],
     );
 }
@@ -2675,10 +2859,16 @@ fn intrinsic_call() {
     );
 
     check(
-        &run_parser!((yp::PintParser::new(), ""), r#"var x = foo(a*3, c);"#),
+        &run_parser!(
+            (yp::PintParser::new(), ""),
+            r#"predicate test { var x = foo(a*3, c); }"#
+        ),
         expect_test::expect![[r#"
-            var ::x;
-            constraint (::x == foo((::a * 3), ::c));"#]],
+
+            predicate ::test {
+                var ::x;
+                constraint (::x == foo((::a * 3), ::c));
+            }"#]],
     );
 
     check(
@@ -2750,20 +2940,23 @@ predicate Baz {
 
 #[test]
 fn out_of_order_decls() {
-    let src = r#"
-constraint low < high;
-var high = 2.0;
-var low = 1.0;
-"#;
+    let src = r#"predicate test {
+        constraint low < high;
+        var high = 2.0;
+        var low = 1.0;
+    }"#;
 
     check(
         &run_parser!((yp::PintParser::new(), ""), src),
         expect_test::expect![[r#"
-            var ::high;
-            var ::low;
-            constraint (::low < ::high);
-            constraint (::high == 2e0);
-            constraint (::low == 1e0);"#]],
+
+            predicate ::test {
+                var ::high;
+                var ::low;
+                constraint (::low < ::high);
+                constraint (::high == 2e0);
+                constraint (::low == 1e0);
+            }"#]],
     );
 }
 
@@ -2772,12 +2965,12 @@ fn keywords_as_identifiers_errors() {
     // TODO: Ideally, we emit a special error here. Instead, we currently get a generic "expected..
     // found" error.
     for keyword in KEYWORDS {
-        let src = format!("var {keyword} = 5;").to_string();
+        let src = format!("predicate test {{ var {keyword} = 5; }}").to_string();
         assert_eq!(
             &run_parser!((yp::PintParser::new(), ""), &src),
             &format!(
-                "expected `an identifier`, found `{keyword}`\n@4..{}: expected `an identifier`\n",
-                4 + format!("{keyword}").len() // End of the error span)
+                "expected `an identifier`, found `{keyword}`\n@21..{}: expected `an identifier`\n",
+                21 + format!("{keyword}").len() // End of the error span)
             ),
             "Check \"identifier as keyword\" error for  keyword \"{}\"",
             keyword
@@ -2790,20 +2983,26 @@ fn big_ints() {
     let pint = (yp::PintParser::new(), "");
 
     check(
-        &run_parser!(pint, "var blah = 1234567890123456789012345678901234567890;"),
+        &run_parser!(
+            pint,
+            "predicate test { var blah = 1234567890123456789012345678901234567890; }"
+        ),
         expect_test::expect![[r#"
             integer literal is too large
-            @11..51: integer literal is too large
+            @28..68: integer literal is too large
             value exceeds limit of `9,223,372,036,854,775,807`
         "#]],
     );
 
     check(
-        &run_parser!(pint, "var blah = 0xfeedbadfd2adeadc;"),
+        &run_parser!(pint, "predicate test { var blah = 0xfeedbadfd2adeadc; }"),
         // Confirmed by using the Python REPL to convert from hex to dec...
         expect_test::expect![[r#"
-            var ::blah;
-            constraint (::blah == -77200148120343844);"#]],
+
+            predicate ::test {
+                var ::blah;
+                constraint (::blah == -77200148120343844);
+            }"#]],
     );
 
     check(
@@ -2812,8 +3011,9 @@ fn big_ints() {
             "var blah = 0xfeedbadfd2adeadcafed00dbabefacefeedbadf00d2adeadcafed00dbabeface;"
         ),
         expect_test::expect![[r#"
-            var ::blah;
-            constraint (::blah == 0xFEEDBADFD2ADEADCAFED00DBABEFACEFEEDBADF00D2ADEADCAFED00DBABEFACE);"#]],
+            expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`, found `var`
+            @0..3: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`
+        "#]],
     );
 
     check(
@@ -2829,46 +3029,47 @@ fn big_ints() {
 #[test]
 fn error_recovery() {
     let src = r#"
-var untyped;
-var clash = 5;
-var clash = 5;
-var clash = 5;
-var empty_tuple: {} = {};
-var empty_array: int[] = [];
-var empty_index = a[];
-var bad_integer_index = t.0x5;
-var bad_real_index = t.1e5;
-var parse_error
-"#;
+        predicate test {
+            var untyped;
+            var clash = 5;
+            var clash = 5;
+            var clash = 5;
+            var empty_tuple: {} = {};
+            var empty_array: int[] = [];
+            var empty_index = a[];
+            var bad_integer_index = t.0x5;
+            var bad_real_index = t.1e5;
+            var parse_error
+        "#;
 
     check(
         &run_parser!((yp::PintParser::new(), ""), src),
         expect_test::expect![[r#"
             type annotation or initializer needed for variable `untyped`
-            @1..12: type annotation or initializer needed
+            @38..49: type annotation or initializer needed
             consider giving `untyped` an explicit type or an initializer
             symbol `clash` has already been declared
-            @18..23: previous declaration of the symbol `clash` here
-            @33..38: `clash` redeclared here
+            @67..72: previous declaration of the symbol `clash` here
+            @94..99: `clash` redeclared here
             `clash` must be declared or imported only once in this scope
             symbol `clash` has already been declared
-            @18..23: previous declaration of the symbol `clash` here
-            @48..53: `clash` redeclared here
+            @67..72: previous declaration of the symbol `clash` here
+            @121..126: `clash` redeclared here
             `clash` must be declared or imported only once in this scope
             empty tuple types are not allowed
-            @76..78: empty tuple type found
+            @161..163: empty tuple type found
             empty tuple expressions are not allowed
-            @81..83: empty tuple expression found
+            @166..168: empty tuple expression found
             empty array types are not allowed
-            @102..107: empty array type found
+            @199..204: empty array type found
             missing array or map index
-            @132..135: missing array or map element index
+            @241..244: missing array or map element index
             invalid integer `0x5` as tuple index
-            @163..166: invalid integer as tuple index
+            @284..287: invalid integer as tuple index
             invalid value `1e5` as tuple index
-            @191..194: invalid value as tuple index
+            @324..327: invalid value as tuple index
             expected `:`, `;`, or `=`, found `end of file`
-            @211..211: expected `:`, `;`, or `=`
+            @356..356: expected `:`, `;`, or `=`
         "#]],
     );
 }

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -29,30 +29,53 @@ pub Pint: () = {
 /// Declarations ///
 ////////////////////
 
+// Decls allowed at the top level, outside predicates.
 Decl: () = {
-    DeclBarringMacro,
-    PredicateDecl,
-    MacroDecl,
-    StorageDecl,
-    Interface,
     ConstDecl ";",
+    EnumDecl ";",
+    Interface,
+    MacroCallDecl ";",
+    MacroDecl,
+    NewTypeDecl ";",
+    PredicateDecl,
+    StorageDecl,
+    UseStatement ";",
 };
 
-DeclBarringMacro: () = {
+// Decls allowed inside predicates.
+PredicateInnerDecl: () = {
+    ConstraintDecl ";",
+    EnumDecl ";",
+    IfDecl,
+    InterfaceInstance ";",
+    MacroCallDecl ";",
+    NewTypeDecl ";",
+    PredicateInstance ";",
+    StateDecl ";",
     UseStatement ";",
     VarDecl ";",
-    StateDecl ";",
+};
+
+// Decls allowed inside macro bodies, which is ALL of them except `MacroDecl`.
+DeclInnerMacroBody: () = {
+    ConstDecl ";",
     ConstraintDecl ";",
-    IfDecl,
     EnumDecl ";",
-    NewTypeDecl ";",
-    MacroCallDecl ";",
+    IfDecl,
+    Interface,
     InterfaceInstance ";",
+    MacroCallDecl ";",
+    NewTypeDecl ";",
+    PredicateDecl,
     PredicateInstance ";",
+    StateDecl ";",
+    StorageDecl,
+    UseStatement ";",
+    VarDecl ";",
 };
 
 PredicateDecl: () = {
-    PredicateOpen DeclBarringMacro* PredicateClose,
+    PredicateOpen PredicateInnerDecl* PredicateClose,
 }
 
 PredicateOpen: () = {
@@ -369,7 +392,7 @@ MacroCallDecl: () = {
 }
 
 pub MacroBody: Option<ExprKey> = {
-    "{" DeclBarringMacro* <Expr?> "}"
+    "{" DeclInnerMacroBody* <Expr?> "}"
 }
 
 /////////////

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -45,11 +45,9 @@ Decl: () = {
 // Decls allowed inside predicates.
 PredicateInnerDecl: () = {
     ConstraintDecl ";",
-    EnumDecl ";",
     IfDecl,
     InterfaceInstance ";",
     MacroCallDecl ";",
-    NewTypeDecl ";",
     PredicateInstance ";",
     StateDecl ";",
     UseStatement ";",
@@ -340,7 +338,7 @@ EnumDecl: () = {
             variants,
             span: (context.span_from)(l, r),
         };
-        context.current_pred().enums.push(enum_decl);
+        context.contract.enums.push(enum_decl);
     }
 }
 
@@ -351,7 +349,7 @@ NewTypeDecl: () = {
             ty,
             span: (context.span_from)(l, r),
         };
-        context.current_pred().new_types.push(new_type_decl);
+        context.contract.new_types.push(new_type_decl);
     }
 }
 

--- a/pintc/src/predicate.rs
+++ b/pintc/src/predicate.rs
@@ -33,6 +33,7 @@ pub struct Contract {
 
     pub exprs: Exprs,
     pub consts: FxHashMap<String, Const>,
+    pub storage: Option<(Vec<StorageVar>, Span)>,
 
     // Keep track of obsolete expanded macro calls in case they're erroneously depended upon.
     pub removed_macro_calls: slotmap::SecondaryMap<ExprKey, Span>,
@@ -48,6 +49,7 @@ impl Default for Contract {
             root_pred_key,
             exprs: Default::default(),
             consts: Default::default(),
+            storage: Default::default(),
             removed_macro_calls: Default::default(),
         }
     }
@@ -246,7 +248,6 @@ impl Contract {
                 })
                 .collect::<Result<_, _>>()?,
             storage: self
-                .root_pred()
                 .storage
                 .as_ref()
                 .map(|(storage, _)| {
@@ -296,9 +297,6 @@ pub struct Predicate {
 
     // CallKey is used in a secondary map in the parser context to access the actual call data.
     pub calls: slotmap::SlotMap<CallKey, Path>,
-
-    // A list of all storage variables in the order in which they were declared
-    pub storage: Option<(Vec<StorageVar>, Span)>,
 
     // A list of all availabe interfaces
     pub interfaces: Vec<Interface>,

--- a/pintc/src/predicate.rs
+++ b/pintc/src/predicate.rs
@@ -35,6 +35,9 @@ pub struct Contract {
     pub consts: FxHashMap<String, Const>,
     pub storage: Option<(Vec<StorageVar>, Span)>,
 
+    pub enums: Vec<EnumDecl>,
+    pub new_types: Vec<NewTypeDecl>,
+
     // Keep track of obsolete expanded macro calls in case they're erroneously depended upon.
     pub removed_macro_calls: slotmap::SecondaryMap<ExprKey, Span>,
 }
@@ -50,6 +53,8 @@ impl Default for Contract {
             exprs: Default::default(),
             consts: Default::default(),
             storage: Default::default(),
+            enums: Default::default(),
+            new_types: Default::default(),
             removed_macro_calls: Default::default(),
         }
     }
@@ -289,8 +294,6 @@ pub struct Predicate {
     pub if_decls: Vec<IfDecl>,
 
     pub ephemerals: Vec<EphemeralDecl>,
-    pub enums: Vec<EnumDecl>,
-    pub new_types: Vec<NewTypeDecl>,
 
     // Each of the initialised variables.  Used by type inference.
     pub var_inits: slotmap::SecondaryMap<VarKey, ExprKey>,

--- a/pintc/src/predicate/analyse/array_check.rs
+++ b/pintc/src/predicate/analyse/array_check.rs
@@ -70,7 +70,7 @@ impl Contract {
             })
             .collect();
 
-        let evaluator = Evaluator::new(&self.preds[pred_key]);
+        let evaluator = Evaluator::new(&self.enums);
         for (array_ty, index_key) in accesses {
             // First, try evaluating the index value, since it must be an immediate int (or enum
             // variant, which evaluates to int).

--- a/pintc/src/predicate/analyse/type_check.rs
+++ b/pintc/src/predicate/analyse/type_check.rs
@@ -79,13 +79,10 @@ impl Contract {
             }
         }
 
-        for pred in self.preds.values() {
-            for NewTypeDecl { name, ty, span } in &pred.new_types {
-                let mut seen_names =
-                    FxHashMap::from_iter(std::iter::once((name.name.as_str(), span)));
+        for NewTypeDecl { name, ty, span } in &self.new_types {
+            let mut seen_names = FxHashMap::from_iter(std::iter::once((name.name.as_str(), span)));
 
-                let _ = inspect_type_names(handler, &pred.new_types, &mut seen_names, ty);
-            }
+            let _ = inspect_type_names(handler, &self.new_types, &mut seen_names, ty);
         }
 
         if handler.has_errors() {
@@ -125,41 +122,39 @@ impl Contract {
         //   type B = { A, A };
         //   // B will have `Type::Custom("A")` which need to be `Type::Alias("A", int)`
 
-        for pred in self.preds.values_mut() {
-            for new_type_idx in 0..pred.new_types.len() {
-                // We're replacing only a single new type at a time, if found in other new-types.
-                let new_type = pred.new_types[new_type_idx].clone();
+        for new_type_idx in 0..self.new_types.len() {
+            // We're replacing only a single new type at a time, if found in other new-types.
+            let new_type = self.new_types[new_type_idx].clone();
 
-                // Replace the next found custom type which needs to be replaced with a an alias.
-                // There may be multiple replacements required per iteration, so we'll visit every
-                // current new-type decl per iteration until none are updated.
-                for loop_check in 0.. {
-                    let mut modified = false;
+            // Replace the next found custom type which needs to be replaced with a an alias.
+            // There may be multiple replacements required per iteration, so we'll visit every
+            // current new-type decl per iteration until none are updated.
+            for loop_check in 0.. {
+                let mut modified = false;
 
-                    for NewTypeDecl { ref mut ty, .. } in &mut pred.new_types {
-                        if let Some(custom_ty) = get_custom_type_mut_ref(&new_type.name.name, ty) {
-                            *custom_ty = Type::Alias {
-                                path: new_type.name.name.clone(),
-                                ty: Box::new(new_type.ty.clone()),
-                                span: new_type.span.clone(),
-                            };
+                for NewTypeDecl { ref mut ty, .. } in &mut self.new_types {
+                    if let Some(custom_ty) = get_custom_type_mut_ref(&new_type.name.name, ty) {
+                        *custom_ty = Type::Alias {
+                            path: new_type.name.name.clone(),
+                            ty: Box::new(new_type.ty.clone()),
+                            span: new_type.span.clone(),
+                        };
 
-                            modified = true;
-                        }
+                        modified = true;
                     }
+                }
 
-                    if !modified {
-                        break;
-                    }
+                if !modified {
+                    break;
+                }
 
-                    if loop_check > 10_000 {
-                        return Err(handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "infinite loop in lower_newtypes_in_newtypes()",
-                                span: empty_span(),
-                            },
-                        }));
-                    }
+                if loop_check > 10_000 {
+                    return Err(handler.emit_err(Error::Compile {
+                        error: CompileError::Internal {
+                            msg: "infinite loop in lower_newtypes_in_newtypes()",
+                            span: empty_span(),
+                        },
+                    }));
                 }
             }
         }
@@ -211,14 +206,14 @@ impl Contract {
             // Then, loop for every known var or state type, or any `as` cast expr, or any storage
             // type, and replace any custom types which match with the type alias.
             pred.vars
-                .update_types(|_, ty| replace_custom_type(&pred.new_types, ty));
+                .update_types(|_, ty| replace_custom_type(&self.new_types, ty));
 
             pred.states
-                .update_types(|_, ty| replace_custom_type(&pred.new_types, ty));
+                .update_types(|_, ty| replace_custom_type(&self.new_types, ty));
 
             self.exprs.update_exprs(|_, expr| {
                 if let Expr::Cast { ty, .. } = expr {
-                    replace_custom_type(&pred.new_types, ty.borrow_mut());
+                    replace_custom_type(&self.new_types, ty.borrow_mut());
                 }
             });
         }
@@ -231,7 +226,7 @@ impl Contract {
         // different, but then there's no way to fix that anyway.  Lifetimes can only be annotated
         // and controlled in functions.  Hopefully when `new_types` moves to `Contract` it'll work
         // again.
-        let new_types = self.root_pred().new_types.clone();
+        let new_types = self.new_types.clone();
         if let Some((storage_vars, _)) = &mut self.storage {
             for StorageVar { ty, .. } in storage_vars {
                 replace_custom_type(&new_types, ty);
@@ -240,14 +235,14 @@ impl Contract {
     }
 
     pub(super) fn check_undefined_types(&mut self, handler: &Handler) {
-        for (pred_key, pred) in self.preds.iter() {
-            let valid_custom_tys: FxHashSet<&String> = FxHashSet::from_iter(
-                pred.enums
-                    .iter()
-                    .map(|ed| &ed.name.name)
-                    .chain(pred.new_types.iter().map(|ntd| &ntd.name.name)),
-            );
+        let valid_custom_tys: FxHashSet<&String> = FxHashSet::from_iter(
+            self.enums
+                .iter()
+                .map(|ed| &ed.name.name)
+                .chain(self.new_types.iter().map(|ntd| &ntd.name.name)),
+        );
 
+        for (pred_key, pred) in self.preds.iter() {
             for (state_key, _) in pred.states() {
                 if let Type::Custom { path, span, .. } = state_key.get_ty(pred) {
                     if !valid_custom_tys.contains(path) {
@@ -487,7 +482,7 @@ impl Contract {
                 if !state_ty.is_unknown() {
                     let expr_ty = state.expr.get_ty(self);
                     if !expr_ty.is_unknown() {
-                        if !state_ty.eq(&self.preds[pred_key], expr_ty) {
+                        if !state_ty.eq(&self.new_types, expr_ty) {
                             handler.emit_err(Error::Compile {
                                 error: CompileError::StateVarInitTypeError {
                                     large_err: Box::new(LargeTypeError::StateVarInitTypeError {
@@ -573,7 +568,7 @@ impl Contract {
                 if let Err(err) = self.type_check_single_expr(pred_key, *range_expr) {
                     handler.emit_err(err);
                 } else if !(range_expr.get_ty(self).is_int()
-                    || range_expr.get_ty(self).is_enum(&self.preds[pred_key])
+                    || range_expr.get_ty(self).is_enum(&self.enums)
                     || checked_range_exprs.contains(range_expr))
                 {
                     handler.emit_err(Error::Compile {
@@ -948,7 +943,7 @@ impl Contract {
 
             el_imms.iter().try_for_each(|el_imm| {
                 let el_ty = el_imm.get_ty(None);
-                if !el_ty.eq(pred, el0_ty.as_ref()) {
+                if !el_ty.eq(&self.new_types, el0_ty.as_ref()) {
                     Err(Error::Compile {
                         error: CompileError::NonHomogeneousArrayElement {
                             expected_ty: pred.with_pred(self, el0_ty.as_ref()).to_string(),
@@ -1038,7 +1033,7 @@ impl Contract {
         {
             // It's an ephemeral value.
             Ok(Inference::Type(ty.clone()))
-        } else if let Some(ty) = pred
+        } else if let Some(ty) = self
             .new_types
             .iter()
             .find_map(|NewTypeDecl { name, ty, .. }| (&name.name == path).then_some(ty))
@@ -1050,7 +1045,7 @@ impl Contract {
             Ok(ty)
         } else {
             // None of the above. That leaves enums.
-            Self::infer_enum_variant_by_name(pred, path, span)
+            self.infer_enum_variant_by_name(path, span)
         }
     }
 
@@ -1167,12 +1162,12 @@ impl Contract {
     }
 
     pub(super) fn infer_enum_variant_by_name(
-        pred: &Predicate,
+        &self,
         path: &Path,
         span: &Span,
     ) -> Result<Inference, Error> {
         // Check first if the path prefix matches a new type.
-        for NewTypeDecl { name, ty, .. } in &pred.new_types {
+        for NewTypeDecl { name, ty, .. } in &self.new_types {
             if let Type::Custom {
                 path: enum_path,
                 span,
@@ -1185,8 +1180,7 @@ impl Contract {
                     if path.chars().nth(new_type_len) == Some(':') {
                         // Definitely worth trying.  Recurse.
                         let new_path = enum_path.clone() + &path[new_type_len..];
-                        if let ty @ Ok(_) = Self::infer_enum_variant_by_name(pred, &new_path, span)
-                        {
+                        if let ty @ Ok(_) = self.infer_enum_variant_by_name(&new_path, span) {
                             // We found an enum variant.
                             return ty;
                         }
@@ -1199,7 +1193,7 @@ impl Contract {
         // report some hints.
         let mut err_potential_enums = Vec::new();
 
-        if let Some(ty) = pred.enums.iter().find_map(
+        if let Some(ty) = self.enums.iter().find_map(
             |EnumDecl {
                  name: enum_name,
                  variants,
@@ -1402,7 +1396,7 @@ impl Contract {
                         }),
                     },
                 })
-            } else if !lhs_ty.eq(pred, rhs_ty) {
+            } else if !lhs_ty.eq(&self.new_types, rhs_ty) {
                 // Here we assume the LHS is the 'correct' type.
                 Err(Error::Compile {
                     error: CompileError::OperatorTypeError {
@@ -1478,7 +1472,7 @@ impl Contract {
                         // which we check for type mismatches elsewhere, and emit a much better
                         // error then.
                         let mut is_init_constraint = false;
-                        if !lhs_ty.eq(pred, rhs_ty)
+                        if !lhs_ty.eq(&self.new_types, rhs_ty)
                             && op == BinaryOp::Equal
                             && pred
                                 .var_inits
@@ -1490,7 +1484,7 @@ impl Contract {
 
                         // Both args must be equatable, which at this stage is any type; binary op
                         // type is bool.
-                        if !lhs_ty.eq(pred, rhs_ty)
+                        if !lhs_ty.eq(&self.new_types, rhs_ty)
                             && !lhs_ty.is_nil()
                             && !rhs_ty.is_nil()
                             && !is_init_constraint
@@ -1591,7 +1585,7 @@ impl Contract {
                 })
             } else if !then_ty.is_unknown() {
                 if !else_ty.is_unknown() {
-                    if then_ty.eq(pred, else_ty) {
+                    if then_ty.eq(&self.new_types, else_ty) {
                         Ok(Inference::Type(then_ty.clone()))
                     } else {
                         Err(Error::Compile {
@@ -1628,7 +1622,7 @@ impl Contract {
         let ub_ty = upper_bound_key.get_ty(self);
         if !lb_ty.is_unknown() {
             if !ub_ty.is_unknown() {
-                if !lb_ty.eq(pred, ub_ty) {
+                if !lb_ty.eq(&self.new_types, ub_ty) {
                     Err(Error::Compile {
                         error: CompileError::RangeTypesMismatch {
                             lb_ty: pred.with_pred(self, lb_ty).to_string(),
@@ -1680,7 +1674,7 @@ impl Contract {
                 })
             } else if (to_ty.is_int()
                 && !from_ty.is_int()
-                && !from_ty.is_enum(pred)
+                && !from_ty.is_enum(&self.enums)
                 && !from_ty.is_bool())
                 || (to_ty.is_real() && !from_ty.is_int() && !from_ty.is_real())
             {
@@ -1714,7 +1708,7 @@ impl Contract {
         if !value_ty.is_unknown() {
             if !collection_ty.is_unknown() {
                 if collection_ty.is_num() {
-                    if !value_ty.eq(pred, collection_ty) {
+                    if !value_ty.eq(&self.new_types, collection_ty) {
                         Err(Error::Compile {
                             error: CompileError::InExprTypesMismatch {
                                 val_ty: pred.with_pred(self, value_ty).to_string(),
@@ -1729,7 +1723,7 @@ impl Contract {
                         }))
                     }
                 } else if let Some(el_ty) = collection_ty.get_array_el_type() {
-                    if !value_ty.eq(pred, el_ty) {
+                    if !value_ty.eq(&self.new_types, el_ty) {
                         Err(Error::Compile {
                             error: CompileError::InExprTypesArrayMismatch {
                                 val_ty: pred.with_pred(self, value_ty).to_string(),
@@ -1784,7 +1778,7 @@ impl Contract {
             for el_key in elements {
                 let el_ty = el_key.get_ty(self);
                 if !el_ty.is_unknown() {
-                    if !el_ty.eq(pred, el0_ty) {
+                    if !el_ty.eq(&self.new_types, el0_ty) {
                         return Err(Error::Compile {
                             error: CompileError::NonHomogeneousArrayElement {
                                 expected_ty: pred.with_pred(self, &el0_ty).to_string(),
@@ -1842,7 +1836,9 @@ impl Contract {
                 return Ok(Inference::Dependant(range_expr_key));
             }
 
-            if (!index_ty.is_int() && !index_ty.is_enum(pred)) || !index_ty.eq(pred, range_ty) {
+            if (!index_ty.is_int() && !index_ty.is_enum(&self.enums))
+                || !index_ty.eq(&self.new_types, range_ty)
+            {
                 Err(Error::Compile {
                     error: CompileError::ArrayAccessWithWrongType {
                         found_ty: pred.with_pred(self, index_ty).to_string(),
@@ -1866,7 +1862,7 @@ impl Contract {
             Ok(Inference::Type(ty.clone()))
         } else if let Some(from_ty) = ary_ty.get_map_ty_from() {
             // Is this a storage map?
-            if !from_ty.eq(pred, index_ty) {
+            if !from_ty.eq(&self.new_types, index_ty) {
                 Err(Error::Compile {
                     error: CompileError::StorageMapAccessWithWrongType {
                         found_ty: pred.with_pred(self, index_ty).to_string(),
@@ -2063,7 +2059,7 @@ impl Contract {
                 if !var_decl_ty.is_unknown() {
                     let init_ty = init_expr_key.get_ty(self);
 
-                    if !var_decl_ty.eq(pred, init_ty) {
+                    if !var_decl_ty.eq(&self.new_types, init_ty) {
                         handler.emit_err(Error::Compile {
                             error: CompileError::InitTypeError {
                                 init_kind: "variable",
@@ -2093,7 +2089,9 @@ impl Contract {
 
             // Special case for enum variants -- they'll have an init_ty of `int`.  So we have
             // an error if the types mismatch and they're _not_ an enum/int combo exception.
-            if !(init_ty.eq(root_pred, decl_ty) || decl_ty.is_enum(root_pred) && init_ty.is_int()) {
+            if !(init_ty.eq(&self.new_types, decl_ty)
+                || decl_ty.is_enum(&self.enums) && init_ty.is_int())
+            {
                 handler.emit_err(Error::Compile {
                     error: CompileError::InitTypeError {
                         init_kind: "const",

--- a/pintc/src/predicate/display.rs
+++ b/pintc/src/predicate/display.rs
@@ -6,6 +6,14 @@ impl Display for super::Contract {
             writeln!(f, "const {path}{};", self.root_pred().with_pred(self, cnst))?;
         }
 
+        for r#enum in &self.enums {
+            writeln!(f, "{};", self.root_pred().with_pred(self, r#enum))?;
+        }
+
+        for new_type in &self.new_types {
+            writeln!(f, "{};", self.root_pred().with_pred(self, new_type))?;
+        }
+
         if let Some(storage) = &self.storage {
             writeln!(f, "storage {{")?;
             for storage_var in &storage.0 {
@@ -123,14 +131,6 @@ impl super::Predicate {
 
         for (state_key, _) in self.states() {
             writeln!(f, "{indentation}{};", self.with_pred(contract, state_key))?;
-        }
-
-        for r#enum in &self.enums {
-            writeln!(f, "{indentation}{};", self.with_pred(contract, r#enum))?;
-        }
-
-        for new_type in &self.new_types {
-            writeln!(f, "{indentation}{};", self.with_pred(contract, new_type))?;
         }
 
         for constraint in &self.constraints {

--- a/pintc/src/predicate/display.rs
+++ b/pintc/src/predicate/display.rs
@@ -6,6 +6,14 @@ impl Display for super::Contract {
             writeln!(f, "const {path}{};", self.root_pred().with_pred(self, cnst))?;
         }
 
+        if let Some(storage) = &self.storage {
+            writeln!(f, "storage {{")?;
+            for storage_var in &storage.0 {
+                writeln!(f, "    {}", self.root_pred().with_pred(self, storage_var))?;
+            }
+            writeln!(f, "}}")?;
+        }
+
         for pred in self.preds.values() {
             if pred.name == Self::ROOT_PRED_NAME {
                 self.root_pred().fmt_with_indent(f, self, 0)?
@@ -34,18 +42,6 @@ impl super::Predicate {
         indent: usize,
     ) -> Result {
         let indentation = " ".repeat(4 * indent);
-
-        if let Some(storage) = &self.storage {
-            writeln!(f, "{indentation}storage {{")?;
-            for storage_var in &storage.0 {
-                writeln!(
-                    f,
-                    "{indentation}    {}",
-                    self.with_pred(contract, storage_var)
-                )?;
-            }
-            writeln!(f, "{indentation}}}")?;
-        }
 
         for super::Interface {
             name,

--- a/pintc/src/predicate/transform/lower.rs
+++ b/pintc/src/predicate/transform/lower.rs
@@ -11,12 +11,37 @@ use crate::{
 use fxhash::FxHashMap;
 
 pub(crate) fn lower_enums(handler: &Handler, contract: &mut Contract) -> Result<(), ErrorEmitted> {
-    for pred_key in contract.preds.keys().collect::<Vec<_>>() {
-        // Each enum has its variants indexed from 0.  Gather all the enum declarations and create a
-        // map from path to integer index.
-        let mut variant_map = FxHashMap::default();
-        let mut variant_count_map = FxHashMap::default();
+    // Each enum has its variants indexed from 0.  Gather all the enum declarations and create a
+    // map from path to integer index.
+    let mut variant_map = FxHashMap::default();
+    let mut variant_count_map = FxHashMap::default();
 
+    let mut add_variants = |e: &EnumDecl, name: &String| {
+        for (i, v) in e.variants.iter().enumerate() {
+            let full_path = name.clone() + "::" + v.name.as_str();
+            variant_map.insert(full_path, i);
+        }
+        variant_count_map.insert(e.name.name.clone(), e.variants.len());
+    };
+
+    for e in &contract.enums {
+        // Add all variants for the enum.
+        add_variants(e, &e.name.name);
+
+        // We need to do exactly the same for any newtypes which are aliasing this enum.
+        if let Some(alias_name) =
+            contract
+                .new_types
+                .iter()
+                .find_map(|NewTypeDecl { name, ty, .. }| {
+                    (ty.get_enum_name(&contract.enums) == Some(&e.name.name)).then_some(&name.name)
+                })
+        {
+            add_variants(e, alias_name);
+        }
+    }
+
+    for pred_key in contract.preds.keys().collect::<Vec<_>>() {
         let mut enum_replacements = Vec::default();
         let mut variant_replacements = Vec::default();
         let mut enum_var_keys = Vec::default();
@@ -32,30 +57,6 @@ pub(crate) fn lower_enums(handler: &Handler, contract: &mut Contract) -> Result<
         };
 
         let pred = contract.preds.get(pred_key).unwrap();
-
-        let mut add_variants = |e: &EnumDecl, name: &String| {
-            for (i, v) in e.variants.iter().enumerate() {
-                let full_path = name.clone() + "::" + v.name.as_str();
-                variant_map.insert(full_path, i);
-            }
-            variant_count_map.insert(e.name.name.clone(), e.variants.len());
-        };
-
-        for e in &pred.enums {
-            // Add all variants for the enum.
-            add_variants(e, &e.name.name);
-
-            // We need to do exactly the same for any newtypes which are aliasing this enum.
-            if let Some(alias_name) =
-                pred.new_types
-                    .iter()
-                    .find_map(|NewTypeDecl { name, ty, .. }| {
-                        (ty.get_enum_name(pred) == Some(&e.name.name)).then_some(&name.name)
-                    })
-            {
-                add_variants(e, alias_name);
-            }
-        }
 
         // Find all the expressions referring to the variants and save them in a list.
         for old_expr_key in contract.exprs(pred_key) {
@@ -73,17 +74,18 @@ pub(crate) fn lower_enums(handler: &Handler, contract: &mut Contract) -> Result<
         // count.  Clippy says .filter(..).map(..) is cleaner than .filter_map(.. bool.then(..)).
         enum_var_keys.extend(
             pred.vars()
-                .filter(|(var_key, _)| var_key.get_ty(pred).is_enum(pred))
+                .filter(|(var_key, _)| var_key.get_ty(pred).is_enum(&contract.enums))
                 .map(|(var_key, _)| {
                     let enum_ty = var_key.get_ty(pred).clone();
-                    let variant_count = variant_count_map.get(enum_ty.get_enum_name(pred).unwrap());
+                    let variant_count =
+                        variant_count_map.get(enum_ty.get_enum_name(&contract.enums).unwrap());
                     (var_key, enum_ty, variant_count)
                 }),
         );
 
         // Not sure at this stage if we'll ever allow state to be an enum.
         for (state_key, _) in pred.states() {
-            if state_key.get_ty(pred).is_enum(pred) {
+            if state_key.get_ty(pred).is_enum(&contract.enums) {
                 return Err(handler.emit_err(Error::Compile {
                     error: CompileError::Internal {
                         msg: "found state with an enum type",
@@ -175,11 +177,7 @@ pub(crate) fn lower_enums(handler: &Handler, contract: &mut Contract) -> Result<
             // Replace the type.
             let exprs_with_enum_ty = contract
                 .exprs(pred_key)
-                .filter(|expr_key| {
-                    expr_key
-                        .get_ty(contract)
-                        .eq(contract.preds.get(pred_key).unwrap(), enum_ty)
-                })
+                .filter(|expr_key| expr_key.get_ty(contract).eq(&contract.new_types, enum_ty))
                 .collect::<Vec<_>>();
 
             for enum_expr_key in exprs_with_enum_ty {
@@ -279,17 +277,14 @@ pub(crate) fn lower_casts(handler: &Handler, contract: &mut Contract) -> Result<
 pub(crate) fn lower_aliases(contract: &mut Contract) {
     use std::borrow::BorrowMut;
 
-    for pred_key in contract.preds.keys().collect::<Vec<_>>() {
-        let new_types = FxHashMap::from_iter(
-            contract
-                .preds
-                .get(pred_key)
-                .unwrap()
-                .new_types
-                .iter()
-                .map(|NewTypeDecl { name, ty, .. }| (name.name.clone(), ty.clone())),
-        );
+    let new_types = FxHashMap::from_iter(
+        contract
+            .new_types
+            .iter()
+            .map(|NewTypeDecl { name, ty, .. }| (name.name.clone(), ty.clone())),
+    );
 
+    for pred_key in contract.preds.keys().collect::<Vec<_>>() {
         fn replace_alias(new_types_map: &FxHashMap<String, Type>, old_ty: &mut Type) {
             match old_ty {
                 Type::Alias { ty, .. } => {
@@ -388,7 +383,7 @@ pub(crate) fn lower_imm_accesses(
             })
             .collect::<Vec<_>>();
 
-        let evaluator = Evaluator::new(contract.preds.get(pred_key).unwrap());
+        let evaluator = Evaluator::new(&contract.enums);
         let mut replacements = Vec::new();
         for (old_expr_key, array_idx, field_idx) in candidates {
             assert!(

--- a/pintc/src/predicate/transform/lower.rs
+++ b/pintc/src/predicate/transform/lower.rs
@@ -321,13 +321,13 @@ pub(crate) fn lower_aliases(contract: &mut Contract) {
                 .update_types(|_, var_ty| replace_alias(&new_types, var_ty));
             pred.states
                 .update_types(|_, state_ty| replace_alias(&new_types, state_ty));
-
-            if let Some((storage_vars, _)) = &mut pred.storage {
-                for StorageVar { ty, .. } in storage_vars {
-                    replace_alias(&new_types, ty);
-                }
-            }
         };
+
+        if let Some((storage_vars, _)) = &mut contract.storage {
+            for StorageVar { ty, .. } in storage_vars {
+                replace_alias(&new_types, ty);
+            }
+        }
 
         contract
             .exprs

--- a/pintc/src/predicate/transform/unroll.rs
+++ b/pintc/src/predicate/transform/unroll.rs
@@ -164,8 +164,7 @@ fn unroll_generator(
 
         let mut satisfied = true;
         {
-            let pred = contract.preds.get(pred_key).unwrap();
-            let evaluator = Evaluator::from_values(pred, values_map.clone());
+            let evaluator = Evaluator::from_values(&contract.enums, values_map.clone());
 
             // Check each condition, if available, against the values map above
             for condition in &conditions {

--- a/pintc/src/predicate/transform/validate.rs
+++ b/pintc/src/predicate/transform/validate.rs
@@ -251,18 +251,10 @@ predicate test { var x = MyEnum::Variant2; }
 "#;
 
     // Do this manually here because we have to copy the enum into the predicate.
-    // TODO: Should imporve this eventually
     let handler = Handler::default();
-    let mut contract = run_parser(src, &handler);
-    let enums = contract.root_pred().enums.clone();
-    contract
-        .preds
-        .values_mut()
-        .find(|pred| pred.name == "test")
-        .unwrap()
-        .enums
-        .clone_from(&enums);
-    let mut contract = contract.type_check(&handler).expect("Failed to type check");
+    let mut contract = run_parser(src, &handler)
+        .type_check(&handler)
+        .expect("Failed to type check");
     let _ = validate(&handler, &mut contract);
     check(
         &crate::error::Errors(handler.consume()).to_string(),
@@ -271,9 +263,6 @@ predicate test { var x = MyEnum::Variant2; }
         compiler internal error: custom type present in final predicate expr_types slotmap"#]],
     );
 
-    // Do this manually here because we have to copy the enum into the predicate.
-    // TODO: Should imporve this eventually
-
     // type alias
     let src = r#"
 type MyAliasInt = int;
@@ -281,18 +270,10 @@ predicate test { var x: MyAliasInt = 3; }
 "#;
 
     // Do this manually here because we have to copy the new type into the predicate.
-    // TODO: Should imporve this eventually
     let handler = Handler::default();
-    let mut contract = run_parser(src, &handler);
-    let new_types = contract.root_pred().new_types.clone();
-    contract
-        .preds
-        .values_mut()
-        .find(|pred| pred.name == "test")
-        .unwrap()
-        .new_types
-        .clone_from(&new_types);
-    let mut contract = contract.type_check(&handler).expect("Failed to type check");
+    let mut contract = run_parser(src, &handler)
+        .type_check(&handler)
+        .expect("Failed to type check");
     let _ = validate(&handler, &mut contract);
 
     check(

--- a/pintc/tests/abi/arrays.pnt
+++ b/pintc/tests/abi/arrays.pnt
@@ -24,15 +24,8 @@ predicate Foo {
 //     my_map: ( int => int[9][5] ),
 //     my_nested_map: ( int => ( b256 => int[3] ) ),
 // }
-// 
+//
 // predicate ::Foo {
-//     storage {
-//         a1: int[5],
-//         a2: b256[2][3],
-//         a3: {int, b256}[4][3],
-//         my_map: ( int => int[9][5] ),
-//         my_nested_map: ( int => ( b256 => int[3] ) ),
-//     }
 //     pub var ::a1: int[5];
 //     pub var ::a2: b256[2][3];
 //     pub var ::a3: {int, b256}[4][3];
@@ -50,15 +43,8 @@ predicate Foo {
 //     my_map: ( int => int[9][5] ),
 //     my_nested_map: ( int => ( b256 => int[3] ) ),
 // }
-// 
+//
 // predicate ::Foo {
-//     storage {
-//         a1: int[5],
-//         a2: b256[2][3],
-//         a3: {int, b256}[4][3],
-//         my_map: ( int => int[9][5] ),
-//         my_nested_map: ( int => ( b256 => int[3] ) ),
-//     }
 //     pub var ::a1: int[5];
 //     pub var ::a2: b256[2][3];
 //     pub var ::a3: {int, b256}[4][3];

--- a/pintc/tests/abi/simple.pnt
+++ b/pintc/tests/abi/simple.pnt
@@ -32,15 +32,6 @@ predicate Foo {
 // }
 //
 // predicate ::Foo {
-//     storage {
-//         s0: bool,
-//         s1: int,
-//         s2: b256,
-//         s3: {int, int},
-//         s4: {int, int, {int, int}},
-//         my_map: ( int => {int, {b256, int}} ),
-//         my_nested_map: ( int => ( b256 => {int, {b256, int}} ) ),
-//     }
 //     var ::v0: bool;
 //     var ::v1: int;
 //     var ::v2: b256;
@@ -64,15 +55,6 @@ predicate Foo {
 // }
 //
 // predicate ::Foo {
-//     storage {
-//         s0: bool,
-//         s1: int,
-//         s2: b256,
-//         s3: {int, int},
-//         s4: {int, int, {int, int}},
-//         my_map: ( int => {int, {b256, int}} ),
-//         my_nested_map: ( int => ( b256 => {int, {b256, int}} ) ),
-//     }
 //     var ::v0: bool;
 //     var ::v1: int;
 //     var ::v2: b256;

--- a/pintc/tests/arrays/arrays.pnt
+++ b/pintc/tests/arrays/arrays.pnt
@@ -1,8 +1,9 @@
+enum Colour = Red | Green | Blue;
+
 predicate test {
     var a: real[5];
     var a1 = a[1];
 
-    enum Colour = Red | Green | Blue;
     var b: real[Colour][3];
     var b_r_2 = b[Colour::Red][2];
 
@@ -13,6 +14,8 @@ predicate test {
 }
 
 // parsed <<<
+// enum ::Colour = Red | Green | Blue;
+//
 // predicate ::test {
 //     var ::a: real[5];
 //     var ::a1;
@@ -21,7 +24,6 @@ predicate test {
 //     var ::c: int[4];
 //     var ::c1;
 //     var ::cb: bool;
-//     enum ::Colour = Red | Green | Blue;
 //     constraint (::a1 == ::a[1]);
 //     constraint (::b_r_2 == ::b[::Colour::Red][2]);
 //     constraint (::c == [0, 1, 2, 3]);
@@ -31,6 +33,8 @@ predicate test {
 // >>>
 
 // flattened <<<
+// enum ::Colour = Red | Green | Blue;
+//
 // predicate ::test {
 //     var ::a: real[5];
 //     var ::a1: real;
@@ -39,7 +43,6 @@ predicate test {
 //     var ::c: int[4];
 //     var ::c1: int[4];
 //     var ::cb: bool;
-//     enum ::Colour = Red | Green | Blue;
 //     constraint (::a1 == ::a[1]);
 //     constraint (::b_r_2 == ::b[0][2]);
 //     constraint (::c == [0, 1, 2, 3]);

--- a/pintc/tests/arrays/index_enum_with_int.pnt
+++ b/pintc/tests/arrays/index_enum_with_int.pnt
@@ -1,23 +1,25 @@
+enum Num = Zero | One | Two | Three;
+
 predicate test {
-    enum Num = Zero | One | Two | Three;
     var ary: int[Num];
 
     constraint ary[1] == 1;
 }
 
 // parsed <<<
+// enum ::Num = Zero | One | Two | Three;
+//
 // predicate ::test {
 //     var ::ary: int[::Num];
-//     enum ::Num = Zero | One | Two | Three;
 //     constraint (::ary[1] == 1);
 // }
 // >>>
 
 // typecheck_failure <<<
 // attempt to index an array with a mismatched value
-// @101..102: array access must be with a `::Num` variant
+// @98..99: array access must be with a `::Num` variant
 // found access using type `int`
 // constraint expression type error
-// @86..108: constraint expression has unknown type
-// @86..108: expecting type `bool`
+// @83..105: constraint expression has unknown type
+// @83..105: expecting type `bool`
 // >>>

--- a/pintc/tests/arrays/index_int_with_enum.pnt
+++ b/pintc/tests/arrays/index_int_with_enum.pnt
@@ -1,23 +1,25 @@
+enum Num = Zero | One | Two | Three;
+
 predicate test {
-    enum Num = Zero | One | Two | Three;
     var ary: int[4];
 
     constraint ary[Num::One] == 1;
 }
 
 // parsed <<<
+// enum ::Num = Zero | One | Two | Three;
+//
 // predicate ::test {
 //     var ::ary: int[4];
-//     enum ::Num = Zero | One | Two | Three;
 //     constraint (::ary[::Num::One] == 1);
 // }
 // >>>
 
 // typecheck_failure <<<
 // attempt to index an array with a mismatched value
-// @99..107: array access must be with an int value
+// @96..104: array access must be with an int value
 // found access using type `::Num`
 // constraint expression type error
-// @84..113: constraint expression has unknown type
-// @84..113: expecting type `bool`
+// @81..110: constraint expression has unknown type
+// @81..110: expecting type `bool`
 // >>>

--- a/pintc/tests/basic_tests/aust.pnt
+++ b/pintc/tests/basic_tests/aust.pnt
@@ -1,7 +1,7 @@
+enum Colour = Red | Green | Blue;
+
 predicate test {
     // Colouring Australia using 3 colours
-
-    enum Colour = Red | Green | Blue;
 
     var wa: Colour;
     var nt: Colour;
@@ -24,6 +24,8 @@ predicate test {
 }
 
 // parsed <<<
+// enum ::Colour = Red | Green | Blue;
+//
 // predicate ::test {
 //     var ::wa: ::Colour;
 //     var ::nt: ::Colour;
@@ -32,7 +34,6 @@ predicate test {
 //     var ::nsw: ::Colour;
 //     var ::v: ::Colour;
 //     var ::t: ::Colour;
-//     enum ::Colour = Red | Green | Blue;
 //     constraint (::wa != ::nt);
 //     constraint (::wa != ::sa);
 //     constraint (::nt != ::sa);
@@ -46,6 +47,8 @@ predicate test {
 // >>>
 
 // flattened <<<
+// enum ::Colour = Red | Green | Blue;
+//
 // predicate ::test {
 //     var ::wa: int;
 //     var ::nt: int;
@@ -54,7 +57,6 @@ predicate test {
 //     var ::nsw: int;
 //     var ::v: int;
 //     var ::t: int;
-//     enum ::Colour = Red | Green | Blue;
 //     constraint (::wa != ::nt);
 //     constraint (::wa != ::sa);
 //     constraint (::nt != ::sa);

--- a/pintc/tests/basic_tests/in_exprs.pnt
+++ b/pintc/tests/basic_tests/in_exprs.pnt
@@ -1,6 +1,6 @@
-predicate test {
-    enum Cake = Crab | Mud | Uranium | Urinal;
+enum Cake = Crab | Mud | Uranium | Urinal;
 
+predicate test {
     var a: int;
     var b: real;
     var c: bool;
@@ -23,6 +23,8 @@ predicate test {
 }
 
 // parsed <<<
+// enum ::Cake = Crab | Mud | Uranium | Urinal;
+//
 // predicate ::test {
 //     var ::a: int;
 //     var ::b: real;
@@ -31,7 +33,6 @@ predicate test {
 //     var ::e: ::Cake;
 //     var ::f: {bool, int};
 //     var ::g: int[2];
-//     enum ::Cake = Crab | Mud | Uranium | Urinal;
 //     constraint ::a in 11..22;
 //     constraint ::a in [11, 13, 17, 19];
 //     constraint ::b in 1.23e1..6.78e1;
@@ -45,6 +46,8 @@ predicate test {
 // >>>
 
 // flattened <<<
+// enum ::Cake = Crab | Mud | Uranium | Urinal;
+//
 // predicate ::test {
 //     var ::a: int;
 //     var ::b: real;
@@ -53,7 +56,6 @@ predicate test {
 //     var ::e: int;
 //     var ::f: {bool, int};
 //     var ::g: int[2];
-//     enum ::Cake = Crab | Mud | Uranium | Urinal;
 //     constraint ((::a >= 11) && (::a <= 22));
 //     constraint ((((::a == 11) || (::a == 13)) || (::a == 17)) || (::a == 19));
 //     constraint ((::b >= 1.23e1) && (::b <= 6.78e1));

--- a/pintc/tests/basic_tests/mismatch_enums.pnt
+++ b/pintc/tests/basic_tests/mismatch_enums.pnt
@@ -1,7 +1,7 @@
-predicate test {
-    enum Key = CMajor | DMinor;
-    enum Chord = FFlatDiminished | EMinorOverG;
+enum Key = CMajor | DMinor;
+enum Chord = FFlatDiminished | EMinorOverG;
 
+predicate test {
     var saddest_sound: Chord;
 
     // Saddest key is D-minor.  Should produce type error since `saddest_sound` is a `Chord`.
@@ -9,19 +9,20 @@ predicate test {
 }
 
 // parsed <<<
+// enum ::Key = CMajor | DMinor;
+// enum ::Chord = FFlatDiminished | EMinorOverG;
+//
 // predicate ::test {
 //     var ::saddest_sound: ::Chord;
-//     enum ::Key = CMajor | DMinor;
-//     enum ::Chord = FFlatDiminished | EMinorOverG;
 //     constraint (::saddest_sound == ::Key::DMinor);
 // }
 // >>>
 
 // typecheck_failure <<<
 // binary operator type error
-// @255..266: operator `==` argument has unexpected type `::Key`
-// @238..251: expecting type `::Chord`
+// @247..258: operator `==` argument has unexpected type `::Key`
+// @230..243: expecting type `::Chord`
 // constraint expression type error
-// @227..266: constraint expression has unknown type
-// @227..266: expecting type `bool`
+// @219..258: constraint expression has unknown type
+// @219..258: expecting type `bool`
 // >>>

--- a/pintc/tests/basic_tests/nil.pnt
+++ b/pintc/tests/basic_tests/nil.pnt
@@ -33,10 +33,6 @@ predicate test {
 // }
 //
 // predicate ::test {
-//     storage {
-//         x: int,
-//         z: {int, int, int},
-//     }
 //     state ::x = storage::x;
 //     state ::z = storage::z;
 //     constraint (nil == nil);
@@ -61,10 +57,6 @@ predicate test {
 // }
 //
 // predicate ::test {
-//     storage {
-//         x: int,
-//         z: {int, int, int},
-//     }
 //     state ::x: int = storage::x;
 //     state ::z: {int, int, int} = storage::z;
 //     constraint false;

--- a/pintc/tests/basic_tests/parse_failure.pnt
+++ b/pintc/tests/basic_tests/parse_failure.pnt
@@ -1,38 +1,39 @@
-var untyped;
-var clash = 5;
-var clash = 5;
-var clash = 5;
-var empty_tuple: {} = {};
-var empty_array: int[] = [];
-var empty_index = a[];
-var bad_integer_index = t.0x5;
-var bad_real_index = t.1e5;
-var parse_error
+predicate test {
+    var untyped;
+    var clash = 5;
+    var clash = 5;
+    var clash = 5;
+    var empty_tuple: {} = {};
+    var empty_array: int[] = [];
+    var empty_index = a[];
+    var bad_integer_index = t.0x5;
+    var bad_real_index = t.1e5;
+    var parse_error
 
 // parse_failure <<<
 // type annotation or initializer needed for variable `untyped`
-// @0..11: type annotation or initializer needed
+// @21..32: type annotation or initializer needed
 // consider giving `untyped` an explicit type or an initializer
 // symbol `clash` has already been declared
-// @17..22: previous declaration of the symbol `clash` here
-// @32..37: `clash` redeclared here
+// @42..47: previous declaration of the symbol `clash` here
+// @61..66: `clash` redeclared here
 // `clash` must be declared or imported only once in this scope
 // symbol `clash` has already been declared
-// @17..22: previous declaration of the symbol `clash` here
-// @47..52: `clash` redeclared here
+// @42..47: previous declaration of the symbol `clash` here
+// @80..85: `clash` redeclared here
 // `clash` must be declared or imported only once in this scope
 // empty tuple types are not allowed
-// @75..77: empty tuple type found
+// @112..114: empty tuple type found
 // empty tuple expressions are not allowed
-// @80..82: empty tuple expression found
+// @117..119: empty tuple expression found
 // empty array types are not allowed
-// @101..106: empty array type found
+// @142..147: empty array type found
 // missing array or map index
-// @131..134: missing array or map element index
+// @176..179: missing array or map element index
 // invalid integer `0x5` as tuple index
-// @162..165: invalid integer as tuple index
+// @211..214: invalid integer as tuple index
 // invalid value `1e5` as tuple index
-// @190..193: invalid value as tuple index
+// @243..246: invalid value as tuple index
 // expected `:`, `;`, or `=`, found `end of file`
-// @210..210: expected `:`, `;`, or `=`
+// @267..267: expected `:`, `;`, or `=`
 // >>>

--- a/pintc/tests/basic_tests/pub_vars.pnt
+++ b/pintc/tests/basic_tests/pub_vars.pnt
@@ -1,7 +1,7 @@
-predicate Foo {
-    enum MyEnum = A | B;
-    type MyType = MyEnum;
+enum MyEnum = A | B;
+type MyType = MyEnum;
 
+predicate Foo {
     pub var x1: bool;
     pub var x2: int;
     pub var x3: b256;
@@ -31,6 +31,9 @@ predicate Foo {
 }
 
 // parsed <<<
+// enum ::MyEnum = A | B;
+// type ::MyType = ::MyEnum;
+//
 // predicate ::Foo {
 //     pub var ::x1: bool;
 //     pub var ::x2: int;
@@ -56,8 +59,6 @@ predicate Foo {
 //     pub var ::z6;
 //     pub var ::z7;
 //     pub var ::z8;
-//     enum ::MyEnum = A | B;
-//     type ::MyType = ::MyEnum;
 //     constraint (::y1 == true);
 //     constraint (::y2 == 5);
 //     constraint (::y3 == 0x0000111100001111000011110000111100001111000011110000111100001111);
@@ -81,21 +82,21 @@ predicate Foo {
 //
 // typecheck_failure <<<
 // compiler internal error: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
-// @145..147: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
+// @137..139: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
 // compiler internal error: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
-// @224..226: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
+// @216..218: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
 // compiler internal error: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
-// @248..250: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
+// @240..242: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
 // compiler internal error: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
-// @418..420: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
+// @410..412: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
 // compiler internal error: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
-// @538..540: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
+// @530..532: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
 // compiler internal error: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
-// @574..576: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
+// @566..568: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
 // compiler internal error: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
-// @739..741: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
+// @731..733: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
 // compiler internal error: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
-// @828..830: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
+// @820..822: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
 // compiler internal error: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
-// @856..858: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
+// @848..850: only `bool`, b256`, `int`, tuple, and array pub vars are currently supported
 // >>>

--- a/pintc/tests/basic_tests/use_let_name_clash.pnt
+++ b/pintc/tests/basic_tests/use_let_name_clash.pnt
@@ -1,11 +1,13 @@
 use a::b;
 
-var b: int;
+predicate test {
+    var b: int;
+}
 
 // parse_failure <<<
-// symbol `b` has already been declared
-// @7..8: previous declaration of the symbol `b` here
-// @15..16: `b` redeclared here
-// `b` must be declared or imported only once in this scope
+// symbol `::b` has already been declared
+// @7..8: previous declaration of the symbol `::b` here
+// @36..37: `::b` redeclared here
+// `::b` must be declared or imported only once in this scope
 // >>>
 

--- a/pintc/tests/basic_tests/use_use_name_clash.pnt
+++ b/pintc/tests/basic_tests/use_use_name_clash.pnt
@@ -1,7 +1,9 @@
 use a::b;
 use c::b;
 
-var d: int;
+predicate test {
+    var d: int;
+}
 
 // parse_failure <<<
 // symbol `b` has already been declared

--- a/pintc/tests/basic_tests/var_order.pnt
+++ b/pintc/tests/basic_tests/var_order.pnt
@@ -1,5 +1,6 @@
+enum MyEnum = A | B;
+
 predicate test {
-    enum MyEnum = A | B;
     var y: bool;
     var t: { int, bool, { b256, { int, bool } }, b256 };
     var a: int[4][2];
@@ -11,6 +12,8 @@ predicate test {
 }
 
 // parsed <<<
+// enum ::MyEnum = A | B;
+//
 // predicate ::test {
 //     var ::y: bool;
 //     var ::t: {int, bool, {b256, {int, bool}}, b256};
@@ -20,11 +23,12 @@ predicate test {
 //     var ::x: int;
 //     var ::z: string;
 //     var ::e: {::MyEnum, bool};
-//     enum ::MyEnum = A | B;
 // }
 // >>>
 
 // flattened <<<
+// enum ::MyEnum = A | B;
+//
 // predicate ::test {
 //     var ::y: bool;
 //     var ::t: {int, bool, {b256, {int, bool}}, b256};
@@ -34,6 +38,5 @@ predicate test {
 //     var ::x: int;
 //     var ::z: string;
 //     var ::e: {::MyEnum, bool};
-//     enum ::MyEnum = A | B;
 // }
 // >>>

--- a/pintc/tests/cli.rs
+++ b/pintc/tests/cli.rs
@@ -69,7 +69,7 @@ fn err() {
 #[test]
 fn compile_errors() {
     let mut input_file = tempfile::NamedTempFile::new().unwrap();
-    let code = r#"var t: {} = {}; var a = a[];"#;
+    let code = r#"predicate test { var t: {} = {}; var a = a[]; }"#;
     write!(input_file.as_file_mut(), "{code}").unwrap();
 
     let output = pintc_command(input_file.path().to_str().unwrap());
@@ -84,25 +84,25 @@ fn compile_errors() {
             .replace(input_file.path().to_str().unwrap(), "filepath"),
         expect_test::expect![[r#"
             Error: empty tuple types are not allowed
-               ╭─[filepath:1:8]
-               │
-             1 │ var t: {} = {}; var a = a[];
-               │        ─┬  
-               │         ╰── empty tuple type found
-            ───╯
-            Error: empty tuple expressions are not allowed
-               ╭─[filepath:1:13]
-               │
-             1 │ var t: {} = {}; var a = a[];
-               │             ─┬  
-               │              ╰── empty tuple expression found
-            ───╯
-            Error: missing array or map index
                ╭─[filepath:1:25]
                │
-             1 │ var t: {} = {}; var a = a[];
-               │                         ─┬─  
-               │                          ╰─── missing array or map element index
+             1 │ predicate test { var t: {} = {}; var a = a[]; }
+               │                         ─┬  
+               │                          ╰── empty tuple type found
+            ───╯
+            Error: empty tuple expressions are not allowed
+               ╭─[filepath:1:30]
+               │
+             1 │ predicate test { var t: {} = {}; var a = a[]; }
+               │                              ─┬  
+               │                               ╰── empty tuple expression found
+            ───╯
+            Error: missing array or map index
+               ╭─[filepath:1:42]
+               │
+             1 │ predicate test { var t: {} = {}; var a = a[]; }
+               │                                          ─┬─  
+               │                                           ╰─── missing array or map element index
             ───╯
             Error: could not compile `filepath` due to 3 previous errors
         "#]],

--- a/pintc/tests/consts/bad_pos.pnt
+++ b/pintc/tests/consts/bad_pos.pnt
@@ -9,6 +9,6 @@ predicate A {
 }
 
 // parse_failure <<<
-// expected `::`, `an identifier`, `constraint`, `enum`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `type`, `use`, `var`, or `}`, found `const`
-// @53..58: expected `::`, `an identifier`, `constraint`, `enum`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `type`, `use`, `var`, or `}`
+// expected `::`, `an identifier`, `constraint`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `use`, `var`, or `}`, found `const`
+// @53..58: expected `::`, `an identifier`, `constraint`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `use`, `var`, or `}`
 // >>>

--- a/pintc/tests/consts/simple.pnt
+++ b/pintc/tests/consts/simple.pnt
@@ -45,7 +45,6 @@ predicate test {
 //     var ::q: int;
 //     var ::r: b256;
 //     var ::v: ::JacketColour;
-//     enum ::JacketColour = Cream | Bone | White | OffWhite | Ivory | Beige;
 //     constraint ((::q > ::a) && (::q < ::c));
 //     constraint ((::r != ::b) && (::r != ::d));
 //     constraint ((::v != ::j) && (::v != ::k));
@@ -66,7 +65,6 @@ predicate test {
 //     var ::q: int;
 //     var ::r: b256;
 //     var ::v: int;
-//     enum ::JacketColour = Cream | Bone | White | OffWhite | Ivory | Beige;
 //     constraint ((::q > 11) && (::q < 33));
 //     constraint ((::r != 0x2222222222222222222222222222222222222222222222222222222222222222) && (::r != 0x4444444444444444444444444444444444444444444444444444444444444444));
 //     constraint ((::v != 5) && (::v != 1));

--- a/pintc/tests/contracts/bad_stateful.pnt
+++ b/pintc/tests/contracts/bad_stateful.pnt
@@ -16,52 +16,10 @@ predicate BamPredicateInstance =
 
 predicate Baz {}
 
-// parsed <<<
-// interface ::Bam {
-//     storage {
-//     }
-// }
-// interface ::BamInstance = ::Bam(0x0000000000000000000000000000000000000000000000000000000000000000)
-// predicate ::BamPredicateInstance = ::BamInstance::BamPredicate(0x0000000000000000000000000000000000000000000000000000000000000000)
-// var ::x: int;
-// var __::BamPredicateInstance_pathway: int;
-// state ::y: int = __foo();
-// enum ::Foo = A | B;
-// type ::Boo = ::Foo;
-// constraint (::x == 3);
-// if true {
-// }
+// The parser changed to simply disallow these decls outside of predicates.  So it barfs on the
+// first `var`.
 //
-// predicate ::Baz {
-//     interface ::Bam {
-//         storage {
-//         }
-//     }
-//     enum ::Foo = A | B;
-//     type ::Boo = ::Foo;
-// }
-// >>>
-
-// typecheck_failure <<<
-// invalid declaration outside a predicate
-// @26..27: invalid variable declaration outside a predicate
-// only `enum` and `type` declarations are allowed outside a predicate
-// invalid declaration outside a predicate
-// @271..401: invalid variable declaration outside a predicate
-// only `enum` and `type` declarations are allowed outside a predicate
-// invalid declaration outside a predicate
-// @34..56: invalid state declaration outside a predicate
-// only `enum` and `type` declarations are allowed outside a predicate
-// invalid declaration outside a predicate
-// @58..75: invalid constraint declaration outside a predicate
-// only `enum` and `type` declarations are allowed outside a predicate
-// invalid declaration outside a predicate
-// @78..89: invalid `if` statement declaration outside a predicate
-// only `enum` and `type` declarations are allowed outside a predicate
-// invalid declaration outside a predicate
-// @174..269: invalid interface instance declaration outside a predicate
-// only `enum` and `type` declarations are allowed outside a predicate
-// invalid declaration outside a predicate
-// @271..401: invalid predicate instance declaration outside a predicate
-// only `enum` and `type` declarations are allowed outside a predicate
+// parse_failure <<<
+// expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`, found `var`
+// @22..25: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`
 // >>>

--- a/pintc/tests/contracts/multifile/main.pnt
+++ b/pintc/tests/contracts/multifile/main.pnt
@@ -22,8 +22,6 @@ predicate Bar {
 //     var ::f1;
 //     var ::e2;
 //     var ::f2;
-//     enum ::baz::MyEnum = A | B;
-//     type ::baz::MyType = ::baz::MyEnum;
 //     constraint (::y == 4);
 //     constraint (::e1 == ::baz::MyEnum::A);
 //     constraint (::f1 == ::baz::MyType::B);
@@ -43,8 +41,6 @@ predicate Bar {
 //     var ::f1: int;
 //     var ::e2: int;
 //     var ::f2: int;
-//     enum ::baz::MyEnum = A | B;
-//     type ::baz::MyType = ::baz::MyEnum;
 //     constraint (::y == 4);
 //     constraint (::e1 == 0);
 //     constraint (::f1 == 1);

--- a/pintc/tests/contracts/name_clash/main.pnt
+++ b/pintc/tests/contracts/name_clash/main.pnt
@@ -14,13 +14,14 @@ predicate Bar {
     constraint y == 4;
 }
 
+type Foo = int;
+
 predicate Boo {
-    type Foo = int;
 }
 
-predicate Boo {
-    enum Baz = P | Q;
+enum Baz = P | Q;
 
+predicate Boo {
     var Bar = 5;
 }
 
@@ -33,20 +34,20 @@ predicate Boo {
 // @97..100: previous declaration of the symbol `Bar` here
 // @109..122: `Bar` redeclared here
 // `Bar` must be declared or imported only once in this scope
+// symbol `Foo` has already been declared
+// @20..23: previous declaration of the symbol `Foo` here
+// @172..175: `Foo` redeclared here
+// `Foo` must be declared or imported only once in this scope
+// symbol `Baz` has already been declared
+// @9..12: previous declaration of the symbol `Baz` here
+// @208..211: `Baz` redeclared here
+// `Baz` must be declared or imported only once in this scope
 // symbol `Boo` has already been declared
-// @167..180: previous declaration of the symbol `Boo` here
-// @206..219: `Boo` redeclared here
+// @184..197: previous declaration of the symbol `Boo` here
+// @222..235: `Boo` redeclared here
 // `Boo` must be declared or imported only once in this scope
-// symbol `::Foo` has already been declared
-// @20..23: previous declaration of the symbol `::Foo` here
-// @192..195: `::Foo` redeclared here
-// `::Foo` must be declared or imported only once in this scope
 // symbol `::Bar` has already been declared
 // @97..100: previous declaration of the symbol `::Bar` here
-// @253..256: `::Bar` redeclared here
+// @246..249: `::Bar` redeclared here
 // `::Bar` must be declared or imported only once in this scope
-// symbol `::Baz` has already been declared
-// @9..12: previous declaration of the symbol `::Baz` here
-// @231..234: `::Baz` redeclared here
-// `::Baz` must be declared or imported only once in this scope
 // >>>

--- a/pintc/tests/contracts/simple.pnt
+++ b/pintc/tests/contracts/simple.pnt
@@ -21,8 +21,6 @@ predicate Bar {
 // predicate ::Foo {
 //     var ::x: int;
 //     var ::y: ::MyEnum;
-//     enum ::MyEnum = A | B;
-//     type ::MyType = ::MyEnum;
 //     constraint (::y == ::MyEnum::A);
 //     constraint (::x == 3);
 // }
@@ -30,8 +28,6 @@ predicate Bar {
 // predicate ::Bar {
 //     var ::x: int;
 //     var ::y: ::MyType;
-//     enum ::MyEnum = A | B;
-//     type ::MyType = ::MyEnum;
 //     constraint (::y == ::MyType::A);
 //     constraint (::x < 2);
 // }
@@ -45,8 +41,6 @@ predicate Bar {
 // predicate ::Foo {
 //     var ::x: int;
 //     var ::y: int;
-//     enum ::MyEnum = A | B;
-//     type ::MyType = ::MyEnum;
 //     constraint (::y == 0);
 //     constraint (::x == 3);
 //     constraint (::y >= 0);
@@ -56,8 +50,6 @@ predicate Bar {
 // predicate ::Bar {
 //     var ::x: int;
 //     var ::y: int;
-//     enum ::MyEnum = A | B;
-//     type ::MyType = ::MyEnum;
 //     constraint (::y == 0);
 //     constraint (::x < 2);
 //     constraint (::y >= 0);

--- a/pintc/tests/evaluator/simple.pnt
+++ b/pintc/tests/evaluator/simple.pnt
@@ -1,3 +1,5 @@
+enum Egg = Ovum | Oeuf | Uovo | HuaManu;
+
 predicate test {
     // The generators tests are already testing most of the basics.  Here's some wacky stuff.
 
@@ -15,13 +17,14 @@ predicate test {
     //   compile time equivalence checks between expressions for `in [...]` which can be a future task.
     // constraint forall g in 0..2, g in 0..2 where f in 1..3, g in [1, 2, 3] { true };
 
-    enum Egg = Ovum | Oeuf | Uovo | HuaManu;
     var h: int[Egg::Uovo as int];   // Redundant but still valid.
 
     var i: int[3 as int];   // Also redundant.
 }
 
 // parsed <<<
+// enum ::Egg = Ovum | Oeuf | Uovo | HuaManu;
+//
 // predicate ::test {
 //     var ::a: int[[1, 2, 3][1]];
 //     var ::b0: int[{1, 2, 3}.1];
@@ -30,7 +33,6 @@ predicate test {
 //     var ::f: int[true as int];
 //     var ::h: int[::Egg::Uovo as int];
 //     var ::i: int[3 as int];
-//     enum ::Egg = Ovum | Oeuf | Uovo | HuaManu;
 //     constraint forall d in 0..2, where (0x1111111111111111111111111111111111111111111111111111111111111111 != 0x2222222222222222222222222222222222222222222222222222222222222222) { (::d == ::d) };
 //     constraint forall e in 0..2, where (0x1111111111111111111111111111111111111111111111111111111111111111 == 0x2222222222222222222222222222222222222222222222222222222222222222) { (::e == ::e) };
 // }
@@ -40,6 +42,8 @@ predicate test {
 // d is expanded, e is not.
 //
 // flattened <<<
+// enum ::Egg = Ovum | Oeuf | Uovo | HuaManu;
+//
 // predicate ::test {
 //     var ::a: int[[1, 2, 3][1]];
 //     var ::b0: int[{1, 2, 3}.1];
@@ -48,7 +52,6 @@ predicate test {
 //     var ::f: int[true as int];
 //     var ::h: int[::Egg::Uovo as int];
 //     var ::i: int[3 as int];
-//     enum ::Egg = Ovum | Oeuf | Uovo | HuaManu;
 //     constraint (((true && (0 == 0)) && (1 == 1)) && (2 == 2));
 //     constraint true;
 // }

--- a/pintc/tests/intrinsics/incorrect_args.pnt
+++ b/pintc/tests/intrinsics/incorrect_args.pnt
@@ -46,9 +46,6 @@ predicate test {
 // }
 //
 // predicate ::test {
-//     storage {
-//         x: int,
-//     }
 //     var ::hash0: b256;
 //     var ::mut_keys_len;
 //     var ::mut_keys_contains_0: bool;

--- a/pintc/tests/intrinsics/state_len.pnt
+++ b/pintc/tests/intrinsics/state_len.pnt
@@ -29,12 +29,6 @@ predicate test {
 // enum ::MyEnum = A | B;
 //
 // predicate ::test {
-//     storage {
-//         a: int,
-//         b: bool,
-//         c: b256,
-//         d: {int, bool},
-//     }
 //     var ::a_len;
 //     var ::b_len;
 //     var ::c_len;
@@ -61,12 +55,6 @@ predicate test {
 // enum ::MyEnum = A | B;
 //
 // predicate ::test {
-//     storage {
-//         a: int,
-//         b: bool,
-//         c: b256,
-//         d: {int, bool},
-//     }
 //     var ::a_len: int;
 //     var ::b_len: int;
 //     var ::c_len: int;

--- a/pintc/tests/intrinsics/state_len.pnt
+++ b/pintc/tests/intrinsics/state_len.pnt
@@ -20,13 +20,13 @@ predicate test {
 }
 
 // parsed <<<,
+// enum ::MyEnum = A | B;
 // storage {
 //     a: int,
 //     b: bool,
 //     c: b256,
 //     d: {int, bool},
 // }
-// enum ::MyEnum = A | B;
 //
 // predicate ::test {
 //     var ::a_len;
@@ -37,7 +37,6 @@ predicate test {
 //     state ::b = storage::b;
 //     state ::c = storage::c;
 //     state ::d = storage::d;
-//     enum ::MyEnum = A | B;
 //     constraint (::a_len == __state_len(::a));
 //     constraint (::b_len == __state_len(::b));
 //     constraint (::c_len == __state_len(::c));
@@ -46,13 +45,13 @@ predicate test {
 // >>>
 
 // flattened <<<,
+// enum ::MyEnum = A | B;
 // storage {
 //     a: int,
 //     b: bool,
 //     c: b256,
 //     d: {int, bool},
 // }
-// enum ::MyEnum = A | B;
 //
 // predicate ::test {
 //     var ::a_len: int;
@@ -63,7 +62,6 @@ predicate test {
 //     state ::b: bool = storage::b;
 //     state ::c: b256 = storage::c;
 //     state ::d: {int, bool} = storage::d;
-//     enum ::MyEnum = A | B;
 //     constraint (::a_len == __state_len(::a));
 //     constraint (::b_len == __state_len(::b));
 //     constraint (::c_len == __state_len(::c));

--- a/pintc/tests/macros/bad_splicing.pnt
+++ b/pintc/tests/macros/bad_splicing.pnt
@@ -19,7 +19,7 @@ predicate test {
 // a macro named `::@add` found with a different signature
 // spliced variable `::b` must be an array
 // @157..158: unable to splice non-array variable `::b`
-// expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `type`, `use`, `var`, `{`, or `}`, found `b`
-// @157..158: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `type`, `use`, `var`, `{`, or `}`
+// expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`, found `b`
+// @157..158: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`
 // @151..163: when making macro call to '::@add'
 // >>>

--- a/pintc/tests/macros/macro_errors_in_modules/c.pnt
+++ b/pintc/tests/macros/macro_errors_in_modules/c.pnt
@@ -1,1 +1,1 @@
-var c: int = 33;
+const c: int = 33;

--- a/pintc/tests/macros/splicing_enums.pnt
+++ b/pintc/tests/macros/splicing_enums.pnt
@@ -25,9 +25,9 @@ macro @find_max_feeling($feeling, $max_feeling, $counts_name, $last_idx) {
     $feeling == $last_idx && $counts_name[$last_idx] == $max_feeling
 }
 
-predicate test {
-    enum Feeling = Uneasy | Queasy | Awkward | Anxious;
+enum Feeling = Uneasy | Queasy | Awkward | Anxious;
 
+predicate test {
     var counts: int[Feeling];
     constraint counts[Feeling::Uneasy] == 33;
     constraint counts[Feeling::Queasy] == 22;
@@ -47,11 +47,12 @@ predicate test {
 }
 
 // parsed <<<
+// enum ::Feeling = Uneasy | Queasy | Awkward | Anxious;
+//
 // predicate ::test {
 //     var ::counts: int[::Feeling];
 //     var ::max_feeling: int;
 //     var ::feeling: ::Feeling;
-//     enum ::Feeling = Uneasy | Queasy | Awkward | Anxious;
 //     constraint (::counts[::Feeling::Uneasy] == 33);
 //     constraint (::counts[::Feeling::Queasy] == 22);
 //     constraint (::counts[::Feeling::Awkward] == 44);
@@ -66,11 +67,12 @@ predicate test {
 // >>>
 
 // flattened <<<
+// enum ::Feeling = Uneasy | Queasy | Awkward | Anxious;
+//
 // predicate ::test {
 //     var ::counts: int[4];
 //     var ::max_feeling: int;
 //     var ::feeling: int;
-//     enum ::Feeling = Uneasy | Queasy | Awkward | Anxious;
 //     constraint (::counts[0] == 33);
 //     constraint (::counts[1] == 22);
 //     constraint (::counts[2] == 44);

--- a/pintc/tests/macros/splicing_expression_size.pnt
+++ b/pintc/tests/macros/splicing_expression_size.pnt
@@ -16,7 +16,7 @@ predicate test {
 // unable to determine spliced array size
 // @137..140: unable to determine spliced array size for `::ary` while parsing
 // macro array splicing is currently limited to immediate integer sizes or enums
-// expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `type`, `use`, `var`, `{`, or `}`, found `ary`
-// @137..140: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `type`, `use`, `var`, `{`, or `}`
+// expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`, found `ary`
+// @137..140: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`
 // @131..141: when making macro call to '::@sum'
 // >>>

--- a/pintc/tests/modules/04/main.pnt
+++ b/pintc/tests/modules/04/main.pnt
@@ -1,9 +1,9 @@
+enum Skill = Nunchuck | BowHunting | ComputerHacking;
+
 predicate test {
     // A bunch of enums *with the same name* all in different files should all have unique paths.
 
     var debbie_skill = debbie::Skill::GlamourShots;
-
-    enum Skill = Nunchuck | BowHunting | ComputerHacking;
 
     var pedro_skill: Skill;
     constraint pedro_skill == Skill::Nunchuck || pedro_skill == Skill::BowHunting;
@@ -14,6 +14,7 @@ predicate test {
 }
 
 // parsed <<<
+// enum ::Skill = Nunchuck | BowHunting | ComputerHacking;
 // enum ::kip::Skill = ChattingOnlineWithBabes | CageFighting;
 // enum ::debbie::Skill = GlamourShots | Handicrafts;
 //
@@ -21,9 +22,6 @@ predicate test {
 //     var ::debbie_skill;
 //     var ::pedro_skill: ::Skill;
 //     var ::kip_skill: ::kip::Skill;
-//     enum ::Skill = Nunchuck | BowHunting | ComputerHacking;
-//     enum ::kip::Skill = ChattingOnlineWithBabes | CageFighting;
-//     enum ::debbie::Skill = GlamourShots | Handicrafts;
 //     constraint (::debbie_skill == ::debbie::Skill::GlamourShots);
 //     constraint ((::pedro_skill == ::Skill::Nunchuck) || (::pedro_skill == ::Skill::BowHunting));
 //     constraint ((::debbie_skill == ::debbie::Skill::Handicrafts) && (::kip_skill == ::kip::Skill::CageFighting));
@@ -31,6 +29,7 @@ predicate test {
 // >>>
 
 // flattened <<<
+// enum ::Skill = Nunchuck | BowHunting | ComputerHacking;
 // enum ::kip::Skill = ChattingOnlineWithBabes | CageFighting;
 // enum ::debbie::Skill = GlamourShots | Handicrafts;
 //
@@ -38,9 +37,6 @@ predicate test {
 //     var ::debbie_skill: int;
 //     var ::pedro_skill: int;
 //     var ::kip_skill: int;
-//     enum ::Skill = Nunchuck | BowHunting | ComputerHacking;
-//     enum ::kip::Skill = ChattingOnlineWithBabes | CageFighting;
-//     enum ::debbie::Skill = GlamourShots | Handicrafts;
 //     constraint (::debbie_skill == 0);
 //     constraint ((::pedro_skill == 0) || (::pedro_skill == 1));
 //     constraint ((::debbie_skill == 1) && (::kip_skill == 1));

--- a/pintc/tests/modules/06/main.pnt
+++ b/pintc/tests/modules/06/main.pnt
@@ -1,6 +1,8 @@
 use b_mod::c_mod::A::{C, D};
 use ::b_mod::c_mod::{A, A::B};
 
+enum U = V | W;
+
 predicate test {
     var s0 = B;
     var s1 = C;
@@ -13,11 +15,10 @@ predicate test {
     constraint s2 == A::B;
     constraint s3 == b_mod::c_mod::A::C;
     constraint s4 == ::b_mod::c_mod::A::B;
-
-    enum U = V | W;
 }
 
 // parsed <<<
+// enum ::U = V | W;
 // enum ::b_mod::c_mod::A = B | C | D;
 //
 // predicate ::test {
@@ -26,8 +27,6 @@ predicate test {
 //     var ::s2;
 //     var ::s3;
 //     var ::s4;
-//     enum ::U = V | W;
-//     enum ::b_mod::c_mod::A = B | C | D;
 //     constraint (::s0 == ::b_mod::c_mod::A::B);
 //     constraint (::s1 == ::b_mod::c_mod::A::C);
 //     constraint (::s2 == ::b_mod::c_mod::A::B);
@@ -42,6 +41,7 @@ predicate test {
 // >>>
 
 // flattened <<<
+// enum ::U = V | W;
 // enum ::b_mod::c_mod::A = B | C | D;
 //
 // predicate ::test {
@@ -50,8 +50,6 @@ predicate test {
 //     var ::s2: int;
 //     var ::s3: int;
 //     var ::s4: int;
-//     enum ::U = V | W;
-//     enum ::b_mod::c_mod::A = B | C | D;
 //     constraint (::s0 == 0);
 //     constraint (::s1 == 1);
 //     constraint (::s2 == 0);

--- a/pintc/tests/modules/08/main.pnt
+++ b/pintc/tests/modules/08/main.pnt
@@ -23,7 +23,6 @@ predicate test {
 //     var ::c4;
 //     var ::a_variant;
 //     var ::b_variant;
-//     enum ::d::MyEnum = A | B;
 //     constraint (::c1 == ::b::c);
 //     constraint (::c2 == ::b::c);
 //     constraint (::c3 == ::b::c);
@@ -44,7 +43,6 @@ predicate test {
 //     var ::c4: int;
 //     var ::a_variant: int;
 //     var ::b_variant: int;
-//     enum ::d::MyEnum = A | B;
 //     constraint (::c1 == 5);
 //     constraint (::c2 == 5);
 //     constraint (::c3 == 5);

--- a/pintc/tests/modules/09/a_mod.pnt
+++ b/pintc/tests/modules/09/a_mod.pnt
@@ -1,2 +1,2 @@
-var a1 = 3;
-var a2 = 3;
+const a1 = 3;
+const a2 = 3;

--- a/pintc/tests/modules/09/b_mod/b_mod.pnt
+++ b/pintc/tests/modules/09/b_mod/b_mod.pnt
@@ -1,4 +1,4 @@
 use c_mod::{c1 as c1_alias, c2 as c1_alias}; // Clash because of the alias
 
-var c1_alias = 5; // Clash because of the alias
-var c1 = 5; // No Clash
+const c1_alias = 5; // Clash because of the alias
+const c1 = 5; // No Clash

--- a/pintc/tests/modules/09/b_mod/c_mod.pnt
+++ b/pintc/tests/modules/09/b_mod/c_mod.pnt
@@ -1,1 +1,1 @@
-var c = 6;
+const c = 6;

--- a/pintc/tests/modules/09/main.pnt
+++ b/pintc/tests/modules/09/main.pnt
@@ -19,7 +19,7 @@ predicate test {
 // `c1_alias` must be declared or imported only once in this scope
 // symbol `c1_alias` has already been declared
 // @12..26: previous declaration of the symbol `c1_alias` here
-// @80..88: `c1_alias` redeclared here
+// @82..90: `c1_alias` redeclared here
 // `c1_alias` must be declared or imported only once in this scope
 // symbol `::a1_alias` has already been declared
 // @11..25: previous declaration of the symbol `::a1_alias` here

--- a/pintc/tests/modules/10/a.pnt
+++ b/pintc/tests/modules/10/a.pnt
@@ -1,11 +1,7 @@
-var F = 1;
+const F = 1;
 
 enum F = A | B;
 
 type F = string;
 
-var F = 4;
-
-state F = __foo();
-
-interface F { storage { } }
+const F = 4;

--- a/pintc/tests/modules/10/main.pnt
+++ b/pintc/tests/modules/10/main.pnt
@@ -2,7 +2,7 @@ use a::E;
 
 use a::F;
 
-var b = F;
+const b = F;
 
 enum E = A | B;
 
@@ -17,38 +17,30 @@ predicate test {
 // parse_failure <<<
 // symbol `E` has already been declared
 // @7..8: previous declaration of the symbol `E` here
-// @39..40: `E` redeclared here
+// @41..42: `E` redeclared here
 // `E` must be declared or imported only once in this scope
 // symbol `E` has already been declared
 // @7..8: previous declaration of the symbol `E` here
-// @56..57: `E` redeclared here
+// @58..59: `E` redeclared here
 // `E` must be declared or imported only once in this scope
 // symbol `E` has already been declared
-// @94..95: previous declaration of the symbol `E` here
-// @112..113: `E` redeclared here
+// @96..97: previous declaration of the symbol `E` here
+// @114..115: `E` redeclared here
 // `E` must be declared or imported only once in this scope
 // symbol `F` has already been declared
-// @4..5: previous declaration of the symbol `F` here
-// @17..18: `F` redeclared here
+// @6..7: previous declaration of the symbol `F` here
+// @19..20: `F` redeclared here
 // `F` must be declared or imported only once in this scope
 // symbol `F` has already been declared
-// @4..5: previous declaration of the symbol `F` here
-// @34..35: `F` redeclared here
+// @6..7: previous declaration of the symbol `F` here
+// @36..37: `F` redeclared here
 // `F` must be declared or imported only once in this scope
 // symbol `F` has already been declared
-// @4..5: previous declaration of the symbol `F` here
-// @51..52: `F` redeclared here
-// `F` must be declared or imported only once in this scope
-// symbol `F` has already been declared
-// @4..5: previous declaration of the symbol `F` here
-// @65..66: `F` redeclared here
-// `F` must be declared or imported only once in this scope
-// symbol `F` has already been declared
-// @4..5: previous declaration of the symbol `F` here
-// @89..90: `F` redeclared here
+// @6..7: previous declaration of the symbol `F` here
+// @55..56: `F` redeclared here
 // `F` must be declared or imported only once in this scope
 // symbol `::E` has already been declared
 // @7..8: previous declaration of the symbol `::E` here
-// @94..95: `::E` redeclared here
+// @96..97: `::E` redeclared here
 // `::E` must be declared or imported only once in this scope
 // >>>

--- a/pintc/tests/root_types/arrays.pnt
+++ b/pintc/tests/root_types/arrays.pnt
@@ -16,12 +16,6 @@ predicate Foo {}
 // type ::myNestedArrayTuple = {y: {z: int[{4, 1}.0]}};
 //
 // predicate ::Foo {
-//     type ::myArray = int[2];
-//     type ::myMultiDimArray = int[2][2];
-//     type ::myArrayTuple = int[{3, 1}.0];
-//     type ::myTuple = {x: int};
-//     type ::myTupleArray = {x: int[5]};
-//     type ::myNestedArrayTuple = {y: {z: int[{4, 1}.0]}};
 // }
 // >>>
 
@@ -34,11 +28,5 @@ predicate Foo {}
 // type ::myNestedArrayTuple = {y: {z: int[{4, 1}.0]}};
 //
 // predicate ::Foo {
-//     type ::myArray = int[2];
-//     type ::myMultiDimArray = int[2][2];
-//     type ::myArrayTuple = int[{3, 1}.0];
-//     type ::myTuple = {x: int};
-//     type ::myTupleArray = {x: int[5]};
-//     type ::myNestedArrayTuple = {y: {z: int[{4, 1}.0]}};
 // }
 // >>>

--- a/pintc/tests/root_types/custom.pnt
+++ b/pintc/tests/root_types/custom.pnt
@@ -8,8 +8,6 @@ predicate Foo {}
 // type ::myCustom = ::myAlias (int);
 //
 // predicate ::Foo {
-//     type ::myAlias = int;
-//     type ::myCustom = ::myAlias (int);
 // }
 // >>>
 
@@ -18,7 +16,5 @@ predicate Foo {}
 // type ::myCustom = ::myAlias;
 //
 // predicate ::Foo {
-//     type ::myAlias = int;
-//     type ::myCustom = ::myAlias;
 // }
 // >>>

--- a/pintc/tests/root_types/exprs.pnt
+++ b/pintc/tests/root_types/exprs.pnt
@@ -20,14 +20,6 @@ predicate Foo {}
 // type ::complexType = {::myNestedCast, ::myNestedSelect}[2 in {1, 2, 3} as int];
 //
 // predicate ::Foo {
-//     type ::myAliasForCast = int;
-//     type ::myNestedCast = int[4 as ::myAliasForCast];
-//     type ::myNestedUnaryOp = int[--3];
-//     type ::myNestedBinaryOp = int[(1 + 2)];
-//     type ::myNestedSelect = int[((1 > 0) ? 5 : 6)];
-//     type ::myNestedTuple = int[{2, 1}.0];
-//     type ::myNestedArray = int[[2, 1][1]];
-//     type ::complexType = {::myNestedCast, ::myNestedSelect}[2 in {1, 2, 3} as int];
 // }
 // >>>
 
@@ -42,13 +34,5 @@ predicate Foo {}
 // type ::complexType = {::myNestedCast (int[4 as int]), ::myNestedSelect (int[((1 > 0) ? 5 : 6)])}[2 in {1, 2, 3} as int];
 //
 // predicate ::Foo {
-//     type ::myAliasForCast = int;
-//     type ::myNestedCast = int[4 as int];
-//     type ::myNestedUnaryOp = int[--3];
-//     type ::myNestedBinaryOp = int[(1 + 2)];
-//     type ::myNestedSelect = int[((1 > 0) ? 5 : 6)];
-//     type ::myNestedTuple = int[{2, 1}.0];
-//     type ::myNestedArray = int[[2, 1][1]];
-//     type ::complexType = {::myNestedCast (int[4 as int]), ::myNestedSelect (int[((1 > 0) ? 5 : 6)])}[2 in {1, 2, 3} as int];
 // }
 // >>>

--- a/pintc/tests/storage/erc20.pnt
+++ b/pintc/tests/storage/erc20.pnt
@@ -52,10 +52,6 @@ predicate Burn {
 // }
 //
 // predicate ::Transfer {
-//     storage {
-//         balances: ( b256 => int ),
-//         total_supply: int,
-//     }
 //     var ::from: b256;
 //     var ::to: b256;
 //     var ::value: int;
@@ -69,10 +65,6 @@ predicate Burn {
 // }
 //
 // predicate ::Mint {
-//     storage {
-//         balances: ( b256 => int ),
-//         total_supply: int,
-//     }
 //     var ::account: b256;
 //     var ::value: int;
 //     state ::total_supply = storage::total_supply;
@@ -82,10 +74,6 @@ predicate Burn {
 // }
 //
 // predicate ::Burn {
-//     storage {
-//         balances: ( b256 => int ),
-//         total_supply: int,
-//     }
 //     var ::account: b256;
 //     var ::value: int;
 //     state ::account_balance = storage::balances[::account];
@@ -103,10 +91,6 @@ predicate Burn {
 // }
 //
 // predicate ::Transfer {
-//     storage {
-//         balances: ( b256 => int ),
-//         total_supply: int,
-//     }
 //     var ::from: b256;
 //     var ::to: b256;
 //     var ::value: int;
@@ -120,10 +104,6 @@ predicate Burn {
 // }
 //
 // predicate ::Mint {
-//     storage {
-//         balances: ( b256 => int ),
-//         total_supply: int,
-//     }
 //     var ::account: b256;
 //     var ::value: int;
 //     state ::total_supply: int = storage::total_supply;
@@ -133,10 +113,6 @@ predicate Burn {
 // }
 //
 // predicate ::Burn {
-//     storage {
-//         balances: ( b256 => int ),
-//         total_supply: int,
-//     }
 //     var ::account: b256;
 //     var ::value: int;
 //     state ::account_balance: int = storage::balances[::account];

--- a/pintc/tests/storage/external_storage/main.pnt
+++ b/pintc/tests/storage/external_storage/main.pnt
@@ -94,11 +94,6 @@ predicate Bar {
 // }
 //
 // predicate ::Foo {
-//     storage {
-//         x: int,
-//         y: bool,
-//         map: ( int => ( int => b256 ) ),
-//     }
 //     interface ::ERC20_0 {
 //         storage {
 //             x: int,
@@ -138,11 +133,6 @@ predicate Bar {
 // }
 //
 // predicate ::Bar {
-//     storage {
-//         x: int,
-//         y: bool,
-//         map: ( int => ( int => b256 ) ),
-//     }
 //     interface ::ERC20_0 {
 //         storage {
 //             x: int,
@@ -211,11 +201,6 @@ predicate Bar {
 // }
 //
 // predicate ::Foo {
-//     storage {
-//         x: int,
-//         y: bool,
-//         map: ( int => ( int => b256 ) ),
-//     }
 //     interface ::ERC20_0 {
 //         storage {
 //             x: int,
@@ -255,11 +240,6 @@ predicate Bar {
 // }
 //
 // predicate ::Bar {
-//     storage {
-//         x: int,
-//         y: bool,
-//         map: ( int => ( int => b256 ) ),
-//     }
 //     interface ::ERC20_0 {
 //         storage {
 //             x: int,

--- a/pintc/tests/storage/indexing_primes.pnt
+++ b/pintc/tests/storage/indexing_primes.pnt
@@ -50,13 +50,6 @@ predicate test {
 // }
 //
 // predicate ::test {
-//     storage {
-//         v: int,
-//         w: int[2],
-//         x: {int, int},
-//         y: {int[2], int[2]},
-//         z: {int, int}[2],
-//     }
 //     state ::a = storage::v;
 //     state ::b = storage::w;
 //     state ::c = storage::x;
@@ -97,13 +90,6 @@ predicate test {
 // }
 //
 // predicate ::test {
-//     storage {
-//         v: int,
-//         w: int[2],
-//         x: {int, int},
-//         y: {int[2], int[2]},
-//         z: {int, int}[2],
-//     }
 //     state ::a: int = storage::v;
 //     state ::b: int[2] = storage::w;
 //     state ::c: {int, int} = storage::x;

--- a/pintc/tests/storage/missing_storage.pnt
+++ b/pintc/tests/storage/missing_storage.pnt
@@ -12,9 +12,6 @@ predicate Foo {
 // }
 //
 // predicate ::Foo {
-//     storage {
-//         x: int,
-//     }
 //     state ::y = storage::y;
 // }
 // >>>

--- a/pintc/tests/storage/multi_file/lib.pnt
+++ b/pintc/tests/storage/multi_file/lib.pnt
@@ -4,4 +4,4 @@ storage {
     x: int,
 }
 
-state x = storage::x;
+//state x = storage::x;

--- a/pintc/tests/storage/multi_file/main.pnt
+++ b/pintc/tests/storage/multi_file/main.pnt
@@ -7,6 +7,4 @@ predicate test {
 // parse_failure <<<
 // a `storage` block can only appear in the top level module
 // @22..45: a `storage` block can only appear in the top level module
-// `storage` access expressions can only appear in the top level module
-// @57..67: `storage` access expressions can only appear in the top level module
 // >>>

--- a/pintc/tests/storage/new_type_map.pnt
+++ b/pintc/tests/storage/new_type_map.pnt
@@ -9,23 +9,23 @@ storage {
 }
 
 // parsed <<<
+// type ::MyMap = ( int => int );
+// type ::MyInt = int;
+// type ::MyNestMap = ( ::MyInt => int );
 // storage {
 //     m: ::MyMap,
 //     n: ::MyInt,
 //     o: ::MyNestMap,
 // }
-// type ::MyMap = ( int => int );
-// type ::MyInt = int;
-// type ::MyNestMap = ( ::MyInt => int );
 // >>>
 
 // flattened <<<
+// type ::MyMap = ( int => int );
+// type ::MyInt = int;
+// type ::MyNestMap = ( ::MyInt (int) => int );
 // storage {
 //     m: ( int => int ),
 //     n: int,
 //     o: ( ::MyInt (int) => int ),
 // }
-// type ::MyMap = ( int => int );
-// type ::MyInt = int;
-// type ::MyNestMap = ( ::MyInt (int) => int );
 // >>>

--- a/pintc/tests/storage/new_types.pnt
+++ b/pintc/tests/storage/new_types.pnt
@@ -19,22 +19,19 @@ predicate test {
 }
 
 // parsed <<<
+// type ::OneOrTheOther = bool;
+// type ::Count = int;
+// type ::Haaash = b256;
 // storage {
 //     m: ( ::OneOrTheOther => int ),
 //     n: ( bool => ::Count ),
 //     o: ( ::OneOrTheOther => ::Haaash ),
 // }
-// type ::OneOrTheOther = bool;
-// type ::Count = int;
-// type ::Haaash = b256;
 //
 // predicate ::test {
 //     state ::x = storage::m[true];
 //     state ::y = storage::n[false];
 //     state ::z = storage::o[false];
-//     type ::OneOrTheOther = bool;
-//     type ::Count = int;
-//     type ::Haaash = b256;
 //     constraint (::x == 11);
 //     constraint (::y' < 22);
 //     constraint (::z != 0x3333333333333333333333333333333333333333333333333333333333333333);
@@ -42,22 +39,19 @@ predicate test {
 // >>>
 
 // flattened <<<
+// type ::OneOrTheOther = bool;
+// type ::Count = int;
+// type ::Haaash = b256;
 // storage {
 //     m: ( bool => int ),
 //     n: ( bool => int ),
 //     o: ( bool => b256 ),
 // }
-// type ::OneOrTheOther = bool;
-// type ::Count = int;
-// type ::Haaash = b256;
 //
 // predicate ::test {
 //     state ::x: int = storage::m[true];
 //     state ::y: int = storage::n[false];
 //     state ::z: b256 = storage::o[false];
-//     type ::OneOrTheOther = bool;
-//     type ::Count = int;
-//     type ::Haaash = b256;
 //     constraint (::x == 11);
 //     constraint (::y' < 22);
 //     constraint (::z != 0x3333333333333333333333333333333333333333333333333333333333333333);

--- a/pintc/tests/storage/new_types.pnt
+++ b/pintc/tests/storage/new_types.pnt
@@ -29,11 +29,6 @@ predicate test {
 // type ::Haaash = b256;
 //
 // predicate ::test {
-//     storage {
-//         m: ( ::OneOrTheOther => int ),
-//         n: ( bool => ::Count ),
-//         o: ( ::OneOrTheOther => ::Haaash ),
-//     }
 //     state ::x = storage::m[true];
 //     state ::y = storage::n[false];
 //     state ::z = storage::o[false];
@@ -57,11 +52,6 @@ predicate test {
 // type ::Haaash = b256;
 //
 // predicate ::test {
-//     storage {
-//         m: ( bool => int ),
-//         n: ( bool => int ),
-//         o: ( bool => b256 ),
-//     }
 //     state ::x: int = storage::m[true];
 //     state ::y: int = storage::n[false];
 //     state ::z: b256 = storage::o[false];

--- a/pintc/tests/storage/storage_array.pnt
+++ b/pintc/tests/storage/storage_array.pnt
@@ -73,10 +73,6 @@ predicate Bar {
 // }
 //
 // predicate ::Bar {
-//     storage {
-//         v: int[3][2],
-//         map_to_arrays: ( int => int[3] ),
-//     }
 //     interface ::Foo {
 //         storage {
 //             v: int[3][2],
@@ -126,12 +122,8 @@ predicate Bar {
 //         map_to_arrays: ( int => int[3] ),
 //     }
 // }
-// 
+//
 // predicate ::Bar {
-//     storage {
-//         v: int[3][2],
-//         map_to_arrays: ( int => int[3] ),
-//     }
 //     interface ::Foo {
 //         storage {
 //             v: int[3][2],

--- a/pintc/tests/storage/storage_multi_intent.pnt
+++ b/pintc/tests/storage/storage_multi_intent.pnt
@@ -62,13 +62,6 @@ predicate Bar {
 // }
 //
 // predicate ::Foo {
-//     storage {
-//         i: int,
-//         b: bool,
-//         map1: ( int => int ),
-//         map2: ( b256 => bool ),
-//         map3: ( int => ( int => b256 ) ),
-//     }
 //     var ::x;
 //     var ::address;
 //     var ::and;
@@ -90,13 +83,6 @@ predicate Bar {
 // }
 //
 // predicate ::Bar {
-//     storage {
-//         i: int,
-//         b: bool,
-//         map1: ( int => int ),
-//         map2: ( b256 => bool ),
-//         map3: ( int => ( int => b256 ) ),
-//     }
 //     var ::x;
 //     var ::address;
 //     var ::and;
@@ -128,13 +114,6 @@ predicate Bar {
 // }
 //
 // predicate ::Foo {
-//     storage {
-//         i: int,
-//         b: bool,
-//         map1: ( int => int ),
-//         map2: ( b256 => bool ),
-//         map3: ( int => ( int => b256 ) ),
-//     }
 //     var ::x: int;
 //     var ::address: b256;
 //     var ::and: bool;
@@ -156,13 +135,6 @@ predicate Bar {
 // }
 //
 // predicate ::Bar {
-//     storage {
-//         i: int,
-//         b: bool,
-//         map1: ( int => int ),
-//         map2: ( b256 => bool ),
-//         map3: ( int => ( int => b256 ) ),
-//     }
 //     var ::x: int;
 //     var ::address: b256;
 //     var ::and: bool;

--- a/pintc/tests/storage/storage_tuple.pnt
+++ b/pintc/tests/storage/storage_tuple.pnt
@@ -71,14 +71,8 @@ predicate Bar {
 //         map_to_tuples: ( int => {b256, {int, int}} ),
 //     }
 // }
-// 
+//
 // predicate ::Bar {
-//     storage {
-//         u: {b256, int},
-//         t: {b256, {int, int}},
-//         w: {addr: b256, inner: {x: int, int}},
-//         map_to_tuples: ( int => {b256, {int, int}} ),
-//     }
 //     interface ::Foo {
 //         storage {
 //             u: {b256, int},
@@ -136,14 +130,8 @@ predicate Bar {
 //         map_to_tuples: ( int => {b256, {int, int}} ),
 //     }
 // }
-// 
+//
 // predicate ::Bar {
-//     storage {
-//         u: {b256, int},
-//         t: {b256, {int, int}},
-//         w: {addr: b256, inner: {x: int, int}},
-//         map_to_tuples: ( int => {b256, {int, int}} ),
-//     }
 //     interface ::Foo {
 //         storage {
 //             u: {b256, int},

--- a/pintc/tests/types/bad_array_range_expr.pnt
+++ b/pintc/tests/types/bad_array_range_expr.pnt
@@ -1,3 +1,5 @@
+enum MyEnum = A | B;
+
 predicate test {
     // Bad
     var a: int[true];
@@ -9,12 +11,13 @@ predicate test {
     var h: int[10.0];
 
     // Ok
-    enum MyEnum = A | B;
     var i: int[10];
     var j: int[MyEnum];
 }
 
 // parsed <<<
+// enum ::MyEnum = A | B;
+//
 // predicate ::test {
 //     var ::a: int[true];
 //     var ::b: int[false];
@@ -25,30 +28,29 @@ predicate test {
 //     var ::h: int[1e1];
 //     var ::i: int[10];
 //     var ::j: int[::MyEnum];
-//     enum ::MyEnum = A | B;
 // }
 // >>>
 
 // typecheck_failure <<<
 // invalid array range type bool
-// @43..47: array access must be of type `int` or `enum`
+// @65..69: array access must be of type `int` or `enum`
 // found range type `bool`
 // invalid array range type bool
-// @65..70: array access must be of type `int` or `enum`
+// @87..92: array access must be of type `int` or `enum`
 // found range type `bool`
 // invalid array range type b256
-// @88..154: array access must be of type `int` or `enum`
+// @110..176: array access must be of type `int` or `enum`
 // found range type `b256`
 // invalid array range type {int, int}
-// @172..178: array access must be of type `int` or `enum`
+// @194..200: array access must be of type `int` or `enum`
 // found range type `{int, int}`
 // invalid array range type int[2]
-// @196..202: array access must be of type `int` or `enum`
+// @218..224: array access must be of type `int` or `enum`
 // found range type `int[2]`
 // invalid array range type string
-// @220..225: array access must be of type `int` or `enum`
+// @242..247: array access must be of type `int` or `enum`
 // found range type `string`
 // invalid array range type real
-// @243..247: array access must be of type `int` or `enum`
+// @265..269: array access must be of type `int` or `enum`
 // found range type `real`
 // >>>

--- a/pintc/tests/types/bad_in_expr.pnt
+++ b/pintc/tests/types/bad_in_expr.pnt
@@ -1,3 +1,5 @@
+enum SupperGuest = Bartholomew | JamesL | Andrew | Judas | Peter | John | Thomas | JamesG | Philip | Matthew | Jude | Simon;
+
 predicate test {
     var x: int;
 
@@ -7,18 +9,18 @@ predicate test {
     var y: bool;
     constraint y in "foo"..false;
 
-    enum SupperGuest = Bartholomew | JamesL | Andrew | Judas | Peter | John | Thomas | JamesG | Philip | Matthew | Jude | Simon;
     var z: SupperGuest;
     constraint z in [1, 4, 7];
     constraint x in [SupperGuest::Andrew, SupperGuest::Philip];
 }
 
 // parsed <<<
+// enum ::SupperGuest = Bartholomew | JamesL | Andrew | Judas | Peter | John | Thomas | JamesG | Philip | Matthew | Jude | Simon;
+//
 // predicate ::test {
 //     var ::x: int;
 //     var ::y: bool;
 //     var ::z: ::SupperGuest;
-//     enum ::SupperGuest = Bartholomew | JamesL | Andrew | Judas | Peter | John | Thomas | JamesG | Philip | Matthew | Jude | Simon;
 //     constraint ::x in 11..22 in 13..20;
 //     constraint ::x in 1.55e1..1.83e1;
 //     constraint ::y in "foo"..false;
@@ -29,28 +31,28 @@ predicate test {
 
 // typecheck_failure <<<
 // value type and range type differ
-// @64..66: range type mismatch; expecting `bool` type, found `int` type
+// @190..192: range type mismatch; expecting `bool` type, found `int` type
 // value type and range type differ
-// @92..96: range type mismatch; expecting `int` type, found `real` type
+// @218..222: range type mismatch; expecting `int` type, found `real` type
 // left and right types in range differ
-// @149..154: expecting `string` type , found `bool` type
+// @275..280: expecting `string` type , found `bool` type
 // value type and array element type in range differ
-// @331..332: array element type mismatch; expecting `::SupperGuest` type, found `int` type
+// @328..329: array element type mismatch; expecting `::SupperGuest` type, found `int` type
 // value type and array element type in range differ
-// @161..284: array element type mismatch; expecting `int` type, found `::SupperGuest` type
+// @0..123: array element type mismatch; expecting `int` type, found `::SupperGuest` type
 // constraint expression type error
-// @38..70: constraint expression has unknown type
-// @38..70: expecting type `bool`
+// @164..196: constraint expression has unknown type
+// @164..196: expecting type `bool`
 // constraint expression type error
-// @76..102: constraint expression has unknown type
-// @76..102: expecting type `bool`
+// @202..228: constraint expression has unknown type
+// @202..228: expecting type `bool`
 // constraint expression type error
-// @126..154: constraint expression has unknown type
-// @126..154: expecting type `bool`
+// @252..280: constraint expression has unknown type
+// @252..280: expecting type `bool`
 // constraint expression type error
-// @314..339: constraint expression has unknown type
-// @314..339: expecting type `bool`
+// @311..336: constraint expression has unknown type
+// @311..336: expecting type `bool`
 // constraint expression type error
-// @345..403: constraint expression has unknown type
-// @345..403: expecting type `bool`
+// @342..400: constraint expression has unknown type
+// @342..400: expecting type `bool`
 // >>>

--- a/pintc/tests/types/bad_state_type.pnt
+++ b/pintc/tests/types/bad_state_type.pnt
@@ -20,10 +20,6 @@ predicate Foo {
 // }
 //
 // predicate ::Foo {
-//     storage {
-//         map1: ( int => bool ),
-//         map2: ( int => ( bool => b256 ) ),
-//     }
 //     state ::map1 = storage::map1;
 //     state ::map2_inner = storage::map2[69];
 //     state ::entry = storage::map1[42];

--- a/pintc/tests/types/bad_var_map_type.pnt
+++ b/pintc/tests/types/bad_var_map_type.pnt
@@ -1,21 +1,22 @@
-predicate test {
-    type MyMap = (int => int);
+type MyMap = (int => int);
 
+predicate test {
     var y: MyMap;
     var x: ( int => int );
 }
 
 // parsed <<<
+// type ::MyMap = ( int => int );
+//
 // predicate ::test {
 //     var ::y: ::MyMap;
 //     var ::x: ( int => int );
-//     type ::MyMap = ( int => int );
 // }
 // >>>
 
 // typecheck_failure <<<
 // variables cannot have storage map type
-// @57..58: found variable of type storage map here
+// @53..54: found variable of type storage map here
 // variables cannot have storage map type
-// @75..76: found variable of type storage map here
+// @71..72: found variable of type storage map here
 // >>>

--- a/pintc/tests/types/binary_ops.pnt
+++ b/pintc/tests/types/binary_ops.pnt
@@ -1,10 +1,11 @@
+enum T = FortyTwo | FleventyFive;
+
 predicate test {
     var a = 11 + false;
     var b = 22 - true;
     var c = [1,2] * 33;
     var d = "four" / 44;
 
-    enum T = FortyTwo | FleventyFive;
     var e = 55 % T::FortyTwo;
 
     // Numerics are allowed, but they must match.
@@ -32,6 +33,8 @@ predicate test {
 }
 
 // parsed <<<
+// enum ::T = FortyTwo | FleventyFive;
+//
 // predicate ::test {
 //     var ::a;
 //     var ::b;
@@ -53,7 +56,6 @@ predicate test {
 //     var ::r;
 //     var ::s;
 //     var ::t;
-//     enum ::T = FortyTwo | FleventyFive;
 //     constraint (::a == (11 + false));
 //     constraint (::b == (22 - true));
 //     constraint (::c == ([1, 2] * 33));
@@ -79,207 +81,207 @@ predicate test {
 
 // typecheck_failure <<<
 // binary operator type error
-// @34..39: operator `+` argument has unexpected type `bool`
+// @69..74: operator `+` argument has unexpected type `bool`
 // binary operator type error
-// @58..62: operator `-` argument has unexpected type `bool`
+// @93..97: operator `-` argument has unexpected type `bool`
 // binary operator type error
-// @76..81: operator `*` argument has unexpected type `int[2]`
+// @111..116: operator `*` argument has unexpected type `int[2]`
 // binary operator type error
-// @100..106: operator `/` argument has unexpected type `string`
+// @135..141: operator `/` argument has unexpected type `string`
 // binary operator type error
-// @169..180: operator `%` argument has unexpected type `::T`
+// @166..177: operator `%` argument has unexpected type `::T`
 // binary operator type error
-// @250..254: operator `+` argument has unexpected type `real`
-// @245..247: expecting type `int`
+// @247..251: operator `+` argument has unexpected type `real`
+// @242..244: expecting type `int`
 // binary operator type error
-// @273..277: operator `-` argument has unexpected type `real`
-// @268..270: expecting type `int`
+// @270..274: operator `-` argument has unexpected type `real`
+// @265..267: expecting type `int`
 // binary operator type error
-// @299..301: operator `*` argument has unexpected type `int`
-// @291..296: expecting type `real`
+// @296..298: operator `*` argument has unexpected type `int`
+// @288..293: expecting type `real`
 // binary operator type error
-// @320..325: operator `/` argument has unexpected type `real`
-// @315..317: expecting type `int`
+// @317..322: operator `/` argument has unexpected type `real`
+// @312..314: expecting type `int`
 // binary operator type error
-// @347..349: operator `%` argument has unexpected type `int`
-// @339..344: expecting type `real`
+// @344..346: operator `%` argument has unexpected type `int`
+// @336..341: expecting type `real`
 // binary operator type error
-// @434..449: operator `==` argument has unexpected type `::T`
-// @428..430: expecting type `int`
+// @431..446: operator `==` argument has unexpected type `::T`
+// @425..427: expecting type `int`
 // binary operator type error
-// @469..473: operator `!=` argument has unexpected type `bool`
-// @463..465: expecting type `int`
+// @466..470: operator `!=` argument has unexpected type `bool`
+// @460..462: expecting type `int`
 // binary operator type error
-// @488..492: operator `>` argument has unexpected type `bool`
+// @485..489: operator `>` argument has unexpected type `bool`
 // binary operator type error
-// @520..525: operator `>=` argument has unexpected type `real`
-// @514..516: expecting type `int`
+// @517..522: operator `>=` argument has unexpected type `real`
+// @511..513: expecting type `int`
 // binary operator type error
-// @544..548: operator `<` argument has unexpected type `string`
+// @541..545: operator `<` argument has unexpected type `string`
 // binary operator type error
-// @568..576: operator `<=` argument has unexpected type `int[2]`
+// @565..573: operator `<=` argument has unexpected type `int[2]`
 // binary operator type error
-// @599..601: operator `&&` argument has unexpected type `int`
-// @591..601: expecting type `bool`
+// @596..598: operator `&&` argument has unexpected type `int`
+// @588..598: expecting type `bool`
 // binary operator type error
-// @615..620: operator `||` argument has unexpected type `real`
-// @615..629: expecting type `bool`
+// @612..617: operator `||` argument has unexpected type `real`
+// @612..626: expecting type `bool`
 // binary operator type error
-// @707..718: operator `==` argument has unexpected type `{int, bool}`
-// @693..703: expecting type `{bool, int}`
+// @704..715: operator `==` argument has unexpected type `{int, bool}`
+// @690..700: expecting type `{bool, int}`
 // binary operator type error
-// @747..755: operator `!=` argument has unexpected type `{int, int}`
-// @732..743: expecting type `{real, int}`
+// @744..752: operator `!=` argument has unexpected type `{int, int}`
+// @729..740: expecting type `{real, int}`
 // binary operator type error
-// @34..39: operator `+` argument has unexpected type `bool`
+// @69..74: operator `+` argument has unexpected type `bool`
 // binary operator type error
-// @58..62: operator `-` argument has unexpected type `bool`
+// @93..97: operator `-` argument has unexpected type `bool`
 // binary operator type error
-// @76..81: operator `*` argument has unexpected type `int[2]`
+// @111..116: operator `*` argument has unexpected type `int[2]`
 // binary operator type error
-// @100..106: operator `/` argument has unexpected type `string`
+// @135..141: operator `/` argument has unexpected type `string`
 // binary operator type error
-// @169..180: operator `%` argument has unexpected type `::T`
+// @166..177: operator `%` argument has unexpected type `::T`
 // binary operator type error
-// @250..254: operator `+` argument has unexpected type `real`
-// @245..247: expecting type `int`
+// @247..251: operator `+` argument has unexpected type `real`
+// @242..244: expecting type `int`
 // binary operator type error
-// @273..277: operator `-` argument has unexpected type `real`
-// @268..270: expecting type `int`
+// @270..274: operator `-` argument has unexpected type `real`
+// @265..267: expecting type `int`
 // binary operator type error
-// @299..301: operator `*` argument has unexpected type `int`
-// @291..296: expecting type `real`
+// @296..298: operator `*` argument has unexpected type `int`
+// @288..293: expecting type `real`
 // binary operator type error
-// @320..325: operator `/` argument has unexpected type `real`
-// @315..317: expecting type `int`
+// @317..322: operator `/` argument has unexpected type `real`
+// @312..314: expecting type `int`
 // binary operator type error
-// @347..349: operator `%` argument has unexpected type `int`
-// @339..344: expecting type `real`
+// @344..346: operator `%` argument has unexpected type `int`
+// @336..341: expecting type `real`
 // binary operator type error
-// @434..449: operator `==` argument has unexpected type `::T`
-// @428..430: expecting type `int`
+// @431..446: operator `==` argument has unexpected type `::T`
+// @425..427: expecting type `int`
 // binary operator type error
-// @469..473: operator `!=` argument has unexpected type `bool`
-// @463..465: expecting type `int`
+// @466..470: operator `!=` argument has unexpected type `bool`
+// @460..462: expecting type `int`
 // binary operator type error
-// @488..492: operator `>` argument has unexpected type `bool`
+// @485..489: operator `>` argument has unexpected type `bool`
 // binary operator type error
-// @520..525: operator `>=` argument has unexpected type `real`
-// @514..516: expecting type `int`
+// @517..522: operator `>=` argument has unexpected type `real`
+// @511..513: expecting type `int`
 // binary operator type error
-// @544..548: operator `<` argument has unexpected type `string`
+// @541..545: operator `<` argument has unexpected type `string`
 // binary operator type error
-// @568..576: operator `<=` argument has unexpected type `int[2]`
+// @565..573: operator `<=` argument has unexpected type `int[2]`
 // binary operator type error
-// @599..601: operator `&&` argument has unexpected type `int`
-// @591..601: expecting type `bool`
+// @596..598: operator `&&` argument has unexpected type `int`
+// @588..598: expecting type `bool`
 // binary operator type error
-// @615..620: operator `||` argument has unexpected type `real`
-// @615..629: expecting type `bool`
+// @612..617: operator `||` argument has unexpected type `real`
+// @612..626: expecting type `bool`
 // binary operator type error
-// @707..718: operator `==` argument has unexpected type `{int, bool}`
-// @693..703: expecting type `{bool, int}`
+// @704..715: operator `==` argument has unexpected type `{int, bool}`
+// @690..700: expecting type `{bool, int}`
 // binary operator type error
-// @747..755: operator `!=` argument has unexpected type `{int, int}`
-// @732..743: expecting type `{real, int}`
+// @744..752: operator `!=` argument has unexpected type `{int, int}`
+// @729..740: expecting type `{real, int}`
 // unable to determine expression type
-// @25..26: type of this expression is ambiguous
+// @60..61: type of this expression is ambiguous
 // unable to determine expression type
-// @49..50: type of this expression is ambiguous
+// @84..85: type of this expression is ambiguous
 // unable to determine expression type
-// @72..73: type of this expression is ambiguous
+// @107..108: type of this expression is ambiguous
 // unable to determine expression type
-// @96..97: type of this expression is ambiguous
+// @131..132: type of this expression is ambiguous
 // unable to determine expression type
-// @160..161: type of this expression is ambiguous
+// @157..158: type of this expression is ambiguous
 // unable to determine expression type
-// @241..242: type of this expression is ambiguous
+// @238..239: type of this expression is ambiguous
 // unable to determine expression type
-// @264..265: type of this expression is ambiguous
+// @261..262: type of this expression is ambiguous
 // unable to determine expression type
-// @287..288: type of this expression is ambiguous
+// @284..285: type of this expression is ambiguous
 // unable to determine expression type
-// @311..312: type of this expression is ambiguous
+// @308..309: type of this expression is ambiguous
 // unable to determine expression type
-// @335..336: type of this expression is ambiguous
+// @332..333: type of this expression is ambiguous
 // unable to determine expression type
-// @424..425: type of this expression is ambiguous
+// @421..422: type of this expression is ambiguous
 // unable to determine expression type
-// @459..460: type of this expression is ambiguous
+// @456..457: type of this expression is ambiguous
 // unable to determine expression type
-// @484..485: type of this expression is ambiguous
+// @481..482: type of this expression is ambiguous
 // unable to determine expression type
-// @510..511: type of this expression is ambiguous
+// @507..508: type of this expression is ambiguous
 // unable to determine expression type
-// @535..536: type of this expression is ambiguous
+// @532..533: type of this expression is ambiguous
 // unable to determine expression type
-// @558..559: type of this expression is ambiguous
+// @555..556: type of this expression is ambiguous
 // unable to determine expression type
-// @587..588: type of this expression is ambiguous
+// @584..585: type of this expression is ambiguous
 // unable to determine expression type
-// @611..612: type of this expression is ambiguous
+// @608..609: type of this expression is ambiguous
 // unable to determine expression type
-// @689..690: type of this expression is ambiguous
+// @686..687: type of this expression is ambiguous
 // unable to determine expression type
-// @728..729: type of this expression is ambiguous
+// @725..726: type of this expression is ambiguous
 // constraint expression type error
-// @21..39: constraint expression has unknown type
-// @21..39: expecting type `bool`
+// @56..74: constraint expression has unknown type
+// @56..74: expecting type `bool`
 // constraint expression type error
-// @45..62: constraint expression has unknown type
-// @45..62: expecting type `bool`
+// @80..97: constraint expression has unknown type
+// @80..97: expecting type `bool`
 // constraint expression type error
-// @68..86: constraint expression has unknown type
-// @68..86: expecting type `bool`
+// @103..121: constraint expression has unknown type
+// @103..121: expecting type `bool`
 // constraint expression type error
-// @92..111: constraint expression has unknown type
-// @92..111: expecting type `bool`
+// @127..146: constraint expression has unknown type
+// @127..146: expecting type `bool`
 // constraint expression type error
-// @156..180: constraint expression has unknown type
-// @156..180: expecting type `bool`
+// @153..177: constraint expression has unknown type
+// @153..177: expecting type `bool`
 // constraint expression type error
-// @237..254: constraint expression has unknown type
-// @237..254: expecting type `bool`
+// @234..251: constraint expression has unknown type
+// @234..251: expecting type `bool`
 // constraint expression type error
-// @260..277: constraint expression has unknown type
-// @260..277: expecting type `bool`
+// @257..274: constraint expression has unknown type
+// @257..274: expecting type `bool`
 // constraint expression type error
-// @283..301: constraint expression has unknown type
-// @283..301: expecting type `bool`
+// @280..298: constraint expression has unknown type
+// @280..298: expecting type `bool`
 // constraint expression type error
-// @307..325: constraint expression has unknown type
-// @307..325: expecting type `bool`
+// @304..322: constraint expression has unknown type
+// @304..322: expecting type `bool`
 // constraint expression type error
-// @331..349: constraint expression has unknown type
-// @331..349: expecting type `bool`
+// @328..346: constraint expression has unknown type
+// @328..346: expecting type `bool`
 // constraint expression type error
-// @420..449: constraint expression has unknown type
-// @420..449: expecting type `bool`
+// @417..446: constraint expression has unknown type
+// @417..446: expecting type `bool`
 // constraint expression type error
-// @455..473: constraint expression has unknown type
-// @455..473: expecting type `bool`
+// @452..470: constraint expression has unknown type
+// @452..470: expecting type `bool`
 // constraint expression type error
-// @480..500: constraint expression has unknown type
-// @480..500: expecting type `bool`
+// @477..497: constraint expression has unknown type
+// @477..497: expecting type `bool`
 // constraint expression type error
-// @506..525: constraint expression has unknown type
-// @506..525: expecting type `bool`
+// @503..522: constraint expression has unknown type
+// @503..522: expecting type `bool`
 // constraint expression type error
-// @531..548: constraint expression has unknown type
-// @531..548: expecting type `bool`
+// @528..545: constraint expression has unknown type
+// @528..545: expecting type `bool`
 // constraint expression type error
-// @554..576: constraint expression has unknown type
-// @554..576: expecting type `bool`
+// @551..573: constraint expression has unknown type
+// @551..573: expecting type `bool`
 // constraint expression type error
-// @583..601: constraint expression has unknown type
-// @583..601: expecting type `bool`
+// @580..598: constraint expression has unknown type
+// @580..598: expecting type `bool`
 // constraint expression type error
-// @607..629: constraint expression has unknown type
-// @607..629: expecting type `bool`
+// @604..626: constraint expression has unknown type
+// @604..626: expecting type `bool`
 // constraint expression type error
-// @685..718: constraint expression has unknown type
-// @685..718: expecting type `bool`
+// @682..715: constraint expression has unknown type
+// @682..715: expecting type `bool`
 // constraint expression type error
-// @724..755: constraint expression has unknown type
-// @724..755: expecting type `bool`
+// @721..752: constraint expression has unknown type
+// @721..752: expecting type `bool`
 // >>>

--- a/pintc/tests/types/clashing_enums.pnt
+++ b/pintc/tests/types/clashing_enums.pnt
@@ -1,33 +1,35 @@
 macro @panicked_response($bird) {
+    // There's no such thing as just `Duck` or `Kick`, they must be fully qualified.
     $bird != ::AttackingBird::Goose ? Duck : Kick
 }
 
-predicate test {
-    enum AttackingBird = Goose | Duck | Chicken;
-    enum AppropriateDefence = Kick | Runaway | Duck | StareDown;
+enum AttackingBird = Goose | Duck | Chicken;
+enum AppropriateDefence = Kick | Runaway | Duck | StareDown;
 
+predicate test {
     var unfortunate_action = @panicked_response(AttackingBird::Goose);
 }
 
 // parsed <<<
+// enum ::AttackingBird = Goose | Duck | Chicken;
+// enum ::AppropriateDefence = Kick | Runaway | Duck | StareDown;
+//
 // predicate ::test {
 //     var ::unfortunate_action;
-//     enum ::AttackingBird = Goose | Duck | Chicken;
-//     enum ::AppropriateDefence = Kick | Runaway | Duck | StareDown;
 //     constraint (::unfortunate_action == ((::AttackingBird::Goose != ::AttackingBird::Goose) ? ::Duck : ::Kick));
 // }
 // >>>
 
 // typecheck_failure <<<
 // cannot find value `::Duck` in this scope
-// @72..76: not found in this scope
+// @157..161: not found in this scope
 // this symbol is a variant of enums `::AttackingBird` and `::AppropriateDefence` and may need a fully qualified path
 // cannot find value `::Duck` in this scope
-// @72..76: not found in this scope
+// @157..161: not found in this scope
 // this symbol is a variant of enums `::AttackingBird` and `::AppropriateDefence` and may need a fully qualified path
 // unable to determine expression type
-// @227..245: type of this expression is ambiguous
+// @304..322: type of this expression is ambiguous
 // constraint expression type error
-// @223..288: constraint expression has unknown type
-// @223..288: expecting type `bool`
+// @300..365: constraint expression has unknown type
+// @300..365: expecting type `bool`
 // >>>

--- a/pintc/tests/types/constraint_non_bool_types.pnt
+++ b/pintc/tests/types/constraint_non_bool_types.pnt
@@ -1,6 +1,7 @@
+enum Colour = Red | Green | Blue;
+
 predicate test {
     var a: b256;
-    enum Colour = Red | Green | Blue;
 
     constraint 1 + 2;
     constraint a;
@@ -10,9 +11,10 @@ predicate test {
 }
 
 // parsed <<<
+// enum ::Colour = Red | Green | Blue;
+//
 // predicate ::test {
 //     var ::a: b256;
-//     enum ::Colour = Red | Green | Blue;
 //     constraint (1 + 2);
 //     constraint ::a;
 //     constraint {1, 2};
@@ -23,18 +25,18 @@ predicate test {
 
 // typecheck_failure <<<
 // constraint expression type error
-// @77..93: constraint expression has unexpected type `int`
-// @77..93: expecting type `bool`
+// @74..90: constraint expression has unexpected type `int`
+// @74..90: expecting type `bool`
 // constraint expression type error
-// @99..111: constraint expression has unexpected type `b256`
-// @99..111: expecting type `bool`
+// @96..108: constraint expression has unexpected type `b256`
+// @96..108: expecting type `bool`
 // constraint expression type error
-// @117..136: constraint expression has unexpected type `{int, int}`
-// @117..136: expecting type `bool`
+// @114..133: constraint expression has unexpected type `{int, int}`
+// @114..133: expecting type `bool`
 // constraint expression type error
-// @142..162: constraint expression has unexpected type `int[3]`
-// @142..162: expecting type `bool`
+// @139..159: constraint expression has unexpected type `int[3]`
+// @139..159: expecting type `bool`
 // constraint expression type error
-// @168..190: constraint expression has unexpected type `::Colour`
-// @168..190: expecting type `bool`
+// @165..187: constraint expression has unexpected type `::Colour`
+// @165..187: expecting type `bool`
 // >>>

--- a/pintc/tests/types/enum_variant_unqualified.pnt
+++ b/pintc/tests/types/enum_variant_unqualified.pnt
@@ -1,29 +1,30 @@
-predicate test {
-    enum Foo = Bar | Baz;
-    enum Bar = Baz | Xyzzy;
+enum Foo = Bar | Baz;
+enum Bar = Baz | Xyzzy;
 
+predicate test {
     var a = Baz;
 }
 
 // parsed <<<
+// enum ::Foo = Bar | Baz;
+// enum ::Bar = Baz | Xyzzy;
+//
 // predicate ::test {
 //     var ::a;
-//     enum ::Foo = Bar | Baz;
-//     enum ::Bar = Baz | Xyzzy;
 //     constraint (::a == ::Baz);
 // }
 // >>>
 
 // typecheck_failure <<<
 // cannot find value `::Baz` in this scope
-// @84..87: not found in this scope
+// @76..79: not found in this scope
 // this symbol is a variant of enums `::Foo` and `::Bar` and may need a fully qualified path
 // cannot find value `::Baz` in this scope
-// @84..87: not found in this scope
+// @76..79: not found in this scope
 // this symbol is a variant of enums `::Foo` and `::Bar` and may need a fully qualified path
 // unable to determine expression type
-// @80..81: type of this expression is ambiguous
+// @72..73: type of this expression is ambiguous
 // constraint expression type error
-// @76..87: constraint expression has unknown type
-// @76..87: expecting type `bool`
+// @68..79: constraint expression has unknown type
+// @68..79: expecting type `bool`
 // >>>

--- a/pintc/tests/types/new_type.pnt
+++ b/pintc/tests/types/new_type.pnt
@@ -1,30 +1,24 @@
+enum TheLetterA = T | U | V;
+type Hooray = int[3];
+type Point = { x: real, y: real };
+enum Experience = Real | Unreal;
+type A = TheLetterA;
+type I = int;
+type Real = real;
+
 predicate test {
-    enum TheLetterA = T | U | V;
-
-    type A = TheLetterA;
-
     var t: A = A::T;
     var u: TheLetterA = A::U;
     var v: A = TheLetterA::V;
 
-    type I = int;
-
     var i: I = 11;
     var j: {I, real} = {22, 33.3};
-
-    enum Experience = Real | Unreal;
-
-    type Real = real;
 
     var r: Real = 44.4;
     var e: Experience = Experience::Real;
 
-    type Hooray = int[3];
-
     var h: Hooray;
     constraint h[1] == 55;
-
-    type Point = { x: real, y: real };
 
     var p: Point = { 66.6, 77.7 };
     constraint r < p.y;
@@ -35,6 +29,14 @@ predicate test {
 }
 
 // parsed <<<
+// enum ::TheLetterA = T | U | V;
+// enum ::Experience = Real | Unreal;
+// type ::Hooray = int[3];
+// type ::Point = {x: real, y: real};
+// type ::A = ::TheLetterA;
+// type ::I = int;
+// type ::Real = real;
+//
 // predicate ::test {
 //     var ::t: ::A;
 //     var ::u: ::TheLetterA;
@@ -47,13 +49,6 @@ predicate test {
 //     var ::p: ::Point;
 //     var ::q: real;
 //     state ::x: ::I = __storage_get(0);
-//     enum ::TheLetterA = T | U | V;
-//     enum ::Experience = Real | Unreal;
-//     type ::A = ::TheLetterA;
-//     type ::I = int;
-//     type ::Real = real;
-//     type ::Hooray = int[3];
-//     type ::Point = {x: real, y: real};
 //     constraint (::t == ::A::T);
 //     constraint (::u == ::A::U);
 //     constraint (::v == ::TheLetterA::V);
@@ -69,6 +64,14 @@ predicate test {
 // >>>
 
 // flattened <<<
+// enum ::TheLetterA = T | U | V;
+// enum ::Experience = Real | Unreal;
+// type ::Hooray = int[3];
+// type ::Point = {x: real, y: real};
+// type ::A = ::TheLetterA;
+// type ::I = int;
+// type ::Real = real;
+//
 // predicate ::test {
 //     var ::t: int;
 //     var ::u: int;
@@ -81,13 +84,6 @@ predicate test {
 //     var ::p: {x: real, y: real};
 //     var ::q: real;
 //     state ::x: int = __storage_get(0);
-//     enum ::TheLetterA = T | U | V;
-//     enum ::Experience = Real | Unreal;
-//     type ::A = ::TheLetterA;
-//     type ::I = int;
-//     type ::Real = real;
-//     type ::Hooray = int[3];
-//     type ::Point = {x: real, y: real};
 //     constraint (::t == 0);
 //     constraint (::u == 1);
 //     constraint (::v == 2);

--- a/pintc/tests/types/new_type_in_new_type.pnt
+++ b/pintc/tests/types/new_type_in_new_type.pnt
@@ -1,9 +1,9 @@
-predicate test {
-    type A = int;
-    type B = A[2];
-    type C = { A, A };
-    type D = { C, C };
+type A = int;
+type B = A[2];
+type C = { A, A };
+type D = { C, C };
 
+predicate test {
     var x: B;
     var y: D;
     constraint x[1] == 11;
@@ -11,26 +11,28 @@ predicate test {
 }
 
 // parsed <<<
+// type ::A = int;
+// type ::B = ::A[2];
+// type ::C = {::A, ::A};
+// type ::D = {::C, ::C};
+//
 // predicate ::test {
 //     var ::x: ::B;
 //     var ::y: ::D;
-//     type ::A = int;
-//     type ::B = ::A[2];
-//     type ::C = {::A, ::A};
-//     type ::D = {::C, ::C};
 //     constraint (::x[1] == 11);
 //     constraint (::y.1.0 == 22);
 // }
 // >>>
 
 // flattened <<<
+// type ::A = int;
+// type ::B = ::A (int)[2];
+// type ::C = {::A (int), ::A (int)};
+// type ::D = {::C ({::A (int), ::A (int)}), ::C ({::A (int), ::A (int)})};
+//
 // predicate ::test {
 //     var ::x: ::A (int)[2];
 //     var ::y: {::C ({::A (int), ::A (int)}), ::C ({::A (int), ::A (int)})};
-//     type ::A = int;
-//     type ::B = ::A (int)[2];
-//     type ::C = {::A (int), ::A (int)};
-//     type ::D = {::C ({::A (int), ::A (int)}), ::C ({::A (int), ::A (int)})};
 //     constraint (::x[1] == 11);
 //     constraint (::y.1.0 == 22);
 // }

--- a/pintc/tests/types/new_type_in_tuple.pnt
+++ b/pintc/tests/types/new_type_in_tuple.pnt
@@ -1,8 +1,8 @@
-predicate test {
-    type A = int;
-    type B = { x: A, y: A };
-    type C = A[3];
+type A = int;
+type B = { x: A, y: A };
+type C = A[3];
 
+predicate test {
     var a: A;
     var b: B = { a, a };
     var c: A = b.1;
@@ -13,6 +13,10 @@ predicate test {
 }
 
 // parsed <<<
+// type ::A = int;
+// type ::B = {x: ::A, y: ::A};
+// type ::C = ::A[3];
+//
 // predicate ::test {
 //     var ::a: ::A;
 //     var ::b: ::B;
@@ -21,9 +25,6 @@ predicate test {
 //     var ::e: ::C;
 //     var ::f: ::A;
 //     var ::g: ::A;
-//     type ::A = int;
-//     type ::B = {x: ::A, y: ::A};
-//     type ::C = ::A[3];
 //     constraint (::b == {::a, ::a});
 //     constraint (::c == ::b.1);
 //     constraint (::d == ::b.x);
@@ -34,6 +35,10 @@ predicate test {
 // >>>
 
 // flattened <<<
+// type ::A = int;
+// type ::B = {x: ::A (int), y: ::A (int)};
+// type ::C = ::A (int)[3];
+//
 // predicate ::test {
 //     var ::a: int;
 //     var ::b: {x: ::A (int), y: ::A (int)};
@@ -42,9 +47,6 @@ predicate test {
 //     var ::e: ::A (int)[3];
 //     var ::f: int;
 //     var ::g: int;
-//     type ::A = int;
-//     type ::B = {x: ::A (int), y: ::A (int)};
-//     type ::C = ::A (int)[3];
 //     constraint (::b == {::a, ::a});
 //     constraint (::c == ::b.1);
 //     constraint (::d == ::b.x);

--- a/pintc/tests/types/new_type_mismatch.pnt
+++ b/pintc/tests/types/new_type_mismatch.pnt
@@ -1,15 +1,16 @@
-predicate test {
-    type I = int;
+type I = int;
 
+predicate test {
     var i: I = 11;
     var j: I = 22.2;
 }
 
 // parsed <<<
+// type ::I = int;
+//
 // predicate ::test {
 //     var ::i: ::I;
 //     var ::j: ::I;
-//     type ::I = int;
 //     constraint (::i == 11);
 //     constraint (::j == 2.22e1);
 // }
@@ -17,6 +18,6 @@ predicate test {
 
 // typecheck_failure <<<
 // variable initialization type error
-// @70..74: variable initializer has unexpected type `real`
-// @21..33: expecting type `::I (int)`
+// @66..70: variable initializer has unexpected type `real`
+// @0..12: expecting type `::I (int)`
 // >>>

--- a/pintc/tests/types/new_type_recursion.pnt
+++ b/pintc/tests/types/new_type_recursion.pnt
@@ -1,37 +1,38 @@
-predicate test {
-    type A = { A };
-    type B = C[2];
-    type C = { B, B };
-    type D = A;
+type A = { A };
+type B = C[2];
+type C = { B, B };
+type D = A;
 
+predicate test {
     var x: A;
     var y: B;
     var z: C;
 }
 
 // parsed <<<
+// type ::A = {::A};
+// type ::B = ::C[2];
+// type ::C = {::B, ::B};
+// type ::D = ::A;
+//
 // predicate ::test {
 //     var ::x: ::A;
 //     var ::y: ::B;
 //     var ::z: ::C;
-//     type ::A = {::A};
-//     type ::B = ::C[2];
-//     type ::C = {::B, ::B};
-//     type ::D = ::A;
 // }
 // >>>
 
 // typecheck_failure <<<
 // type alias refers to itself
-// @32..33: type alias `::A` is used recursively in declaration
-// @21..35: `::A` is declared here
+// @11..12: type alias `::A` is used recursively in declaration
+// @0..14: `::A` is declared here
 // type alias refers to itself
-// @71..72: type alias `::B` is used recursively in declaration
-// @41..54: `::B` is declared here
+// @42..43: type alias `::B` is used recursively in declaration
+// @16..29: `::B` is declared here
 // type alias refers to itself
-// @50..51: type alias `::C` is used recursively in declaration
-// @60..77: `::C` is declared here
+// @25..26: type alias `::C` is used recursively in declaration
+// @31..48: `::C` is declared here
 // type alias refers to itself
-// @32..33: type alias `::A` is used recursively in declaration
-// @21..35: `::A` is declared here
+// @11..12: type alias `::A` is used recursively in declaration
+// @0..14: `::A` is declared here
 // >>>

--- a/pintc/tests/types/new_type_unknown.pnt
+++ b/pintc/tests/types/new_type_unknown.pnt
@@ -1,25 +1,26 @@
-predicate test {
-    type Ambiguous = NonExistentEnum;
+type Ambiguous = NonExistentEnum;
 
+predicate test {
     var a = Ambiguous::MissingVariant;
 }
 
 // parsed <<<
+// type ::Ambiguous = ::NonExistentEnum;
+//
 // predicate ::test {
 //     var ::a;
-//     type ::Ambiguous = ::NonExistentEnum;
 //     constraint (::a == ::Ambiguous::MissingVariant);
 // }
 // >>>
 
 // typecheck_failure <<<
 // cannot find value `::Ambiguous::MissingVariant` in this scope
-// @68..93: not found in this scope
+// @64..89: not found in this scope
 // cannot find value `::Ambiguous::MissingVariant` in this scope
-// @68..93: not found in this scope
+// @64..89: not found in this scope
 // unable to determine expression type
-// @64..65: type of this expression is ambiguous
+// @60..61: type of this expression is ambiguous
 // constraint expression type error
-// @60..93: constraint expression has unknown type
-// @60..93: expecting type `bool`
+// @56..89: constraint expression has unknown type
+// @56..89: expecting type `bool`
 // >>>

--- a/pintc/tests/types/state_in_ops.pnt
+++ b/pintc/tests/types/state_in_ops.pnt
@@ -17,10 +17,6 @@ predicate test {
 // }
 //
 // predicate ::test {
-//     storage {
-//         i: int,
-//         b: bool,
-//     }
 //     var ::bad_and;
 //     state ::i1 = storage::i;
 //     state ::b1 = storage::b;

--- a/pintc/tests/types/storage_mismatch.pnt
+++ b/pintc/tests/types/storage_mismatch.pnt
@@ -27,12 +27,6 @@ predicate test {
 // }
 //
 // predicate ::test {
-//     storage {
-//         i: int,
-//         b: bool,
-//         map1: ( int => int ),
-//         map2: ( b256 => bool ),
-//     }
 //     var ::x;
 //     var ::address;
 //     state ::i1: bool = storage::i;

--- a/pintc/tests/types/undefined_types.pnt
+++ b/pintc/tests/types/undefined_types.pnt
@@ -1,7 +1,7 @@
-predicate test {
-    enum Baz = X | Y;
-    type Xyzzy = int;
+enum Baz = X | Y;
+type Xyzzy = int;
 
+predicate test {
     var a: int;
     var b: Foo;
     var c = a as Bar;
@@ -11,14 +11,15 @@ predicate test {
 }
 
 // parsed <<<
+// enum ::Baz = X | Y;
+// type ::Xyzzy = int;
+//
 // predicate ::test {
 //     var ::a: int;
 //     var ::b: ::Foo;
 //     var ::c;
 //     var ::d: ::Baz;
 //     var ::e;
-//     enum ::Baz = X | Y;
-//     type ::Xyzzy = int;
 //     constraint (::c == ::a as ::Bar);
 //     constraint (::e == ::a as ::Xyzzy);
 // }
@@ -26,7 +27,7 @@ predicate test {
 
 // typecheck_failure <<<
 // undefined type
-// @89..92: type is undefined
+// @81..84: type is undefined
 // undefined type
-// @111..114: type is undefined
+// @103..106: type is undefined
 // >>>


### PR DESCRIPTION
And per #774 move them from `Predicate` to `Contract`.  And move `storage` too, but that's fairly trivial.