### PR TITLE
fix: Add missing allow attribute in pint-abi-gen error variant

### DIFF
--- a/pint-abi-gen/src/vars.rs
+++ b/pint-abi-gen/src/vars.rs
@@ -147,6 +147,7 @@ fn decode_field_error_enum(vars: &[VarABI]) -> syn::ItemEnum {
     syn::parse_quote! {
         /// A type describing which field failed to decode.
         #[derive(Debug)]
+        #[allow(non_camel_case_types)]
         pub enum DecodeFieldError {
             #(
                 #field_idents,


### PR DESCRIPTION
This helps to address some warnings popping up in rust-analyser working downstream on essential-integration, as these error variants are named after the fields (and in turn are not camel case).