### PR TITLE
Some more `Contract` / `Predicate` refactoring.

### DIFF
--- a/pintc/src/asm_gen.rs
+++ b/pintc/src/asm_gen.rs
@@ -368,7 +368,7 @@ impl AsmBuilder {
                 s_asm.extend(asm.iter().map(|op| StateRead::Constraint(*op)));
 
                 // Get the `interface` declaration that the storage access refers to
-                let interface = &pred
+                let interface = &contract
                     .interfaces
                     .iter()
                     .find(|e| e.name.to_string() == *interface_instance.interface)
@@ -1076,7 +1076,7 @@ impl AsmBuilder {
                     continue;
                 };
 
-                let Some(interface) = pred
+                let Some(interface) = contract
                     .interfaces
                     .iter()
                     .find(|e| e.name.to_string() == *interface_instance.interface)

--- a/pintc/src/expr.rs
+++ b/pintc/src/expr.rs
@@ -1,5 +1,5 @@
 use crate::{
-    predicate::{CallKey, ExprKey, VarKey},
+    predicate::{CallKey, ExprKey},
     span::{empty_span, Span, Spanned},
     types::{Path, PrimitiveKind, Type},
 };
@@ -25,8 +25,7 @@ pub enum Expr {
         fields: Vec<(Option<Ident>, ExprKey)>,
         span: Span,
     },
-    PathByKey(VarKey, Span),
-    PathByName(Path, Span),
+    Path(Path, Span),
     StorageAccess(String, Span),
     ExternalStorageAccess {
         interface_instance: Path,
@@ -232,8 +231,7 @@ impl Spanned for Expr {
             | Expr::Immediate { span, .. }
             | Expr::Array { span, .. }
             | Expr::Tuple { span, .. }
-            | Expr::PathByKey(_, span)
-            | Expr::PathByName(_, span)
+            | Expr::Path(_, span)
             | Expr::StorageAccess(_, span)
             | Expr::ExternalStorageAccess { span, .. }
             | Expr::UnaryOp { span, .. }
@@ -318,10 +316,9 @@ impl Expr {
             }
 
             Expr::MacroCall { .. }
-            | Expr::PathByName(_, _)
+            | Expr::Path(_, _)
             | Expr::StorageAccess(_, _)
             | Expr::ExternalStorageAccess { .. }
-            | Expr::PathByKey(_, _)
             | Expr::Error(_) => {}
         }
     }

--- a/pintc/src/expr.rs
+++ b/pintc/src/expr.rs
@@ -45,6 +45,7 @@ pub enum Expr {
     },
     MacroCall {
         call: CallKey,
+        path: Path,
         span: Span,
     },
     IntrinsicCall {

--- a/pintc/src/expr/display.rs
+++ b/pintc/src/expr/display.rs
@@ -44,8 +44,7 @@ impl DisplayWithPred for &super::Expr {
                 write!(f, "}}")
             }
 
-            super::Expr::PathByName(p, _) => write!(f, "{p}"),
-            super::Expr::PathByKey(k, _) => write!(f, "{}", k.get(pred).name),
+            super::Expr::Path(p, _) => write!(f, "{p}"),
             super::Expr::StorageAccess(p, _) => write!(f, "storage::{p}"),
             super::Expr::ExternalStorageAccess {
                 interface_instance,

--- a/pintc/src/expr/display.rs
+++ b/pintc/src/expr/display.rs
@@ -8,7 +8,7 @@ use crate::{
 
 impl DisplayWithPred for super::ExprKey {
     fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> Result {
-        if contract.removed_macro_calls.contains_key(*self) {
+        if contract.is_removed_macro_call(*self) {
             write!(f, "<REMOVED MACRO CALL>")
         } else {
             write!(f, "{}", pred.with_pred(contract, &self.get(contract)))

--- a/pintc/src/expr/display.rs
+++ b/pintc/src/expr/display.rs
@@ -2,29 +2,29 @@ use std::fmt::{Display, Formatter, Result};
 
 use crate::{
     expr,
-    predicate::{Contract, DisplayWithPred, Predicate},
-    util::{write_many_iter, write_many_with_pred},
+    predicate::{Contract, DisplayWithContract},
+    util::{write_many_iter, write_many_with_ctrct},
 };
 
-impl DisplayWithPred for super::ExprKey {
-    fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> Result {
+impl DisplayWithContract for super::ExprKey {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract) -> Result {
         if contract.is_removed_macro_call(*self) {
             write!(f, "<REMOVED MACRO CALL>")
         } else {
-            write!(f, "{}", pred.with_pred(contract, &self.get(contract)))
+            write!(f, "{}", contract.with_ctrct(&self.get(contract)))
         }
     }
 }
 
-impl DisplayWithPred for &super::Expr {
-    fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> Result {
+impl DisplayWithContract for &super::Expr {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract) -> Result {
         match self {
             super::Expr::Error(..) => write!(f, "Error"),
-            super::Expr::Immediate { value, .. } => value.fmt(f, contract, pred),
+            super::Expr::Immediate { value, .. } => value.fmt(f, contract),
 
             super::Expr::Array { elements, .. } => {
                 write!(f, "[")?;
-                write_many_with_pred!(f, elements, ", ", contract, pred);
+                write_many_with_ctrct!(f, elements, ", ", contract);
                 write!(f, "]")
             }
 
@@ -37,7 +37,7 @@ impl DisplayWithPred for &super::Expr {
                         "{}{}",
                         name.as_ref()
                             .map_or(String::new(), |name| format!("{}: ", name.name)),
-                        pred.with_pred(contract, val)
+                        contract.with_ctrct(val)
                     )
                 });
                 write_many_iter!(f, i, ", ");
@@ -54,7 +54,7 @@ impl DisplayWithPred for &super::Expr {
 
             super::Expr::UnaryOp { op, expr, .. } => {
                 if matches!(op, expr::UnaryOp::NextState) {
-                    write!(f, "{}'", pred.with_pred(contract, expr))
+                    write!(f, "{}'", contract.with_ctrct(expr))
                 } else {
                     match op {
                         expr::UnaryOp::Error => write!(f, "error"),
@@ -62,7 +62,7 @@ impl DisplayWithPred for &super::Expr {
                         expr::UnaryOp::Not => write!(f, "!"),
                         expr::UnaryOp::NextState => unreachable!(),
                     }?;
-                    expr.fmt(f, contract, pred)
+                    expr.fmt(f, contract)
                 }
             }
 
@@ -70,9 +70,9 @@ impl DisplayWithPred for &super::Expr {
                 write!(
                     f,
                     "({} {} {})",
-                    pred.with_pred(contract, lhs),
+                    contract.with_ctrct(lhs),
                     op,
-                    pred.with_pred(contract, rhs)
+                    contract.with_ctrct(rhs)
                 )
             }
 
@@ -81,45 +81,39 @@ impl DisplayWithPred for &super::Expr {
             } => write!(
                 f,
                 "{} in {}",
-                pred.with_pred(contract, value),
-                pred.with_pred(contract, collection)
+                contract.with_ctrct(value),
+                contract.with_ctrct(collection)
             ),
 
             super::Expr::Cast { value, ty, .. } => {
                 write!(
                     f,
                     "{} as {}",
-                    pred.with_pred(contract, value),
-                    pred.with_pred(contract, ty.as_ref())
+                    contract.with_ctrct(value),
+                    contract.with_ctrct(ty.as_ref())
                 )
             }
 
             super::Expr::TupleFieldAccess { tuple, field, .. } => {
-                write!(f, "{}.{field}", pred.with_pred(contract, tuple))
+                write!(f, "{}.{field}", contract.with_ctrct(tuple))
             }
 
             super::Expr::Index { expr, index, .. } => {
                 write!(
                     f,
                     "{}[{}]",
-                    pred.with_pred(contract, expr),
-                    pred.with_pred(contract, index)
+                    contract.with_ctrct(expr),
+                    contract.with_ctrct(index)
                 )
             }
 
-            super::Expr::MacroCall { call, .. } => {
-                write!(
-                    f,
-                    "{}(...)",
-                    pred.calls
-                        .get(*call)
-                        .unwrap_or(&"<CALL NOT FOUND>".to_owned())
-                )
+            super::Expr::MacroCall { path, .. } => {
+                write!(f, "{path}(...)",)
             }
 
             super::Expr::IntrinsicCall { name, args, .. } => {
                 write!(f, "{name}(")?;
-                write_many_with_pred!(f, args, ", ", contract, pred);
+                write_many_with_ctrct!(f, args, ", ", contract);
                 write!(f, ")")
             }
 
@@ -131,17 +125,17 @@ impl DisplayWithPred for &super::Expr {
             } => write!(
                 f,
                 "({} ? {} : {})",
-                pred.with_pred(contract, condition),
-                pred.with_pred(contract, then_expr),
-                pred.with_pred(contract, else_expr)
+                contract.with_ctrct(condition),
+                contract.with_ctrct(then_expr),
+                contract.with_ctrct(else_expr)
             ),
 
             super::Expr::Range { lb, ub, .. } => {
                 write!(
                     f,
                     "{}..{}",
-                    pred.with_pred(contract, lb),
-                    pred.with_pred(contract, ub)
+                    contract.with_ctrct(lb),
+                    contract.with_ctrct(ub)
                 )
             }
 
@@ -154,20 +148,20 @@ impl DisplayWithPred for &super::Expr {
             } => {
                 write!(f, "{kind}")?;
                 for (ident, range) in gen_ranges {
-                    write!(f, " {} in {},", ident, pred.with_pred(contract, range))?;
+                    write!(f, " {} in {},", ident, contract.with_ctrct(range))?;
                 }
                 if !conditions.is_empty() {
                     write!(f, " where ")?;
-                    write_many_with_pred!(f, conditions, ", ", contract, pred);
+                    write_many_with_ctrct!(f, conditions, ", ", contract);
                 }
-                write!(f, " {{ {} }}", pred.with_pred(contract, body))
+                write!(f, " {{ {} }}", contract.with_ctrct(body))
             }
         }
     }
 }
 
-impl DisplayWithPred for super::Immediate {
-    fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> Result {
+impl DisplayWithContract for super::Immediate {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract) -> Result {
         match self {
             super::Immediate::Error => write!(f, "Error"),
             super::Immediate::Nil => write!(f, "nil"),
@@ -184,7 +178,7 @@ impl DisplayWithPred for super::Immediate {
             }
             super::Immediate::Array(elements) => {
                 write!(f, "[")?;
-                write_many_with_pred!(f, elements, ", ", contract, pred);
+                write_many_with_ctrct!(f, elements, ", ", contract);
                 write!(f, "]")
             }
             super::Immediate::Tuple(fields) => {
@@ -194,19 +188,13 @@ impl DisplayWithPred for super::Immediate {
                         "{}{}",
                         name.as_ref()
                             .map_or(String::new(), |name| format!("{}: ", name.name)),
-                        pred.with_pred(contract, val)
+                        contract.with_ctrct(val)
                     )
                 });
                 write_many_iter!(f, i, ", ");
                 write!(f, "}}")
             }
         }
-    }
-}
-
-impl DisplayWithPred for super::Ident {
-    fn fmt(&self, f: &mut Formatter, _: &Contract, _: &Predicate) -> Result {
-        write!(f, "{self}")
     }
 }
 

--- a/pintc/src/expr/evaluate.rs
+++ b/pintc/src/expr/evaluate.rs
@@ -97,7 +97,7 @@ impl Evaluator {
                 Ok(Imm::Tuple(imm_fields))
             }
 
-            Expr::PathByName(path, span) => self
+            Expr::Path(path, span) => self
                 .scope_values
                 .get(path)
                 .or_else(|| self.enum_values.get(path))
@@ -393,7 +393,6 @@ impl Evaluator {
             }
 
             Expr::Error(_)
-            | Expr::PathByKey(_, _)
             | Expr::StorageAccess(_, _)
             | Expr::ExternalStorageAccess { .. }
             | Expr::MacroCall { .. }
@@ -480,21 +479,12 @@ impl ExprKey {
             | Expr::ExternalStorageAccess { .. }
             | Expr::MacroCall { .. }
             | Expr::Error(_) => expr,
-            Expr::PathByName(ref path, ref span) => {
+            Expr::Path(ref path, ref span) => {
                 let span = span.clone();
                 values_map.get(path).map_or(expr, |value| Expr::Immediate {
                     value: value.clone(),
                     span,
                 })
-            }
-            Expr::PathByKey(key, ref span) => {
-                let span = span.clone();
-                values_map
-                    .get(&key.get(&contract.preds[pred_key]).name)
-                    .map_or(expr, |value| Expr::Immediate {
-                        value: value.clone(),
-                        span,
-                    })
             }
             Expr::UnaryOp { op, expr, span } => {
                 let expr = expr.plug_in(contract, pred_key, values_map);

--- a/pintc/src/expr/evaluate.rs
+++ b/pintc/src/expr/evaluate.rs
@@ -435,7 +435,6 @@ impl ExprKey {
     pub(crate) fn plug_in(
         self,
         contract: &mut Contract,
-        pred_key: PredKey,
         values_map: &FxHashMap<Path, Imm>,
     ) -> ExprKey {
         let expr = self.get(contract).clone();
@@ -450,9 +449,9 @@ impl ExprKey {
             } => {
                 let elements = elements
                     .iter()
-                    .map(|element| element.plug_in(contract, pred_key, values_map))
+                    .map(|element| element.plug_in(contract, values_map))
                     .collect::<Vec<_>>();
-                let range_expr = range_expr.plug_in(contract, pred_key, values_map);
+                let range_expr = range_expr.plug_in(contract, values_map);
 
                 Expr::Array {
                     elements,
@@ -465,7 +464,7 @@ impl ExprKey {
                 let fields = fields
                     .iter()
                     .map(|(name, value)| {
-                        (name.clone(), value.plug_in(contract, pred_key, values_map))
+                        (name.clone(), value.plug_in(contract, values_map))
                     })
                     .collect::<Vec<_>>();
 
@@ -487,20 +486,20 @@ impl ExprKey {
                 })
             }
             Expr::UnaryOp { op, expr, span } => {
-                let expr = expr.plug_in(contract, pred_key, values_map);
+                let expr = expr.plug_in(contract, values_map);
 
                 Expr::UnaryOp { op, expr, span }
             }
             Expr::BinaryOp { op, lhs, rhs, span } => {
-                let lhs = lhs.plug_in(contract, pred_key, values_map);
-                let rhs = rhs.plug_in(contract, pred_key, values_map);
+                let lhs = lhs.plug_in(contract, values_map);
+                let rhs = rhs.plug_in(contract, values_map);
 
                 Expr::BinaryOp { op, lhs, rhs, span }
             }
             Expr::IntrinsicCall { name, args, span } => {
                 let args = args
                     .iter()
-                    .map(|arg| arg.plug_in(contract, pred_key, values_map))
+                    .map(|arg| arg.plug_in(contract, values_map))
                     .collect::<Vec<_>>();
 
                 Expr::IntrinsicCall { name, args, span }
@@ -511,9 +510,9 @@ impl ExprKey {
                 else_expr,
                 span,
             } => {
-                let condition = condition.plug_in(contract, pred_key, values_map);
-                let then_expr = then_expr.plug_in(contract, pred_key, values_map);
-                let else_expr = else_expr.plug_in(contract, pred_key, values_map);
+                let condition = condition.plug_in(contract, values_map);
+                let then_expr = then_expr.plug_in(contract, values_map);
+                let else_expr = else_expr.plug_in(contract, values_map);
 
                 Expr::Select {
                     condition,
@@ -523,18 +522,18 @@ impl ExprKey {
                 }
             }
             Expr::Index { expr, index, span } => {
-                let expr = expr.plug_in(contract, pred_key, values_map);
-                let index = index.plug_in(contract, pred_key, values_map);
+                let expr = expr.plug_in(contract, values_map);
+                let index = index.plug_in(contract, values_map);
 
                 Expr::Index { expr, index, span }
             }
             Expr::TupleFieldAccess { tuple, field, span } => {
-                let tuple = tuple.plug_in(contract, pred_key, values_map);
+                let tuple = tuple.plug_in(contract, values_map);
 
                 Expr::TupleFieldAccess { tuple, field, span }
             }
             Expr::Cast { value, ty, span } => {
-                let value = value.plug_in(contract, pred_key, values_map);
+                let value = value.plug_in(contract, values_map);
 
                 Expr::Cast { value, ty, span }
             }
@@ -543,8 +542,8 @@ impl ExprKey {
                 collection,
                 span,
             } => {
-                let value = value.plug_in(contract, pred_key, values_map);
-                let collection = collection.plug_in(contract, pred_key, values_map);
+                let value = value.plug_in(contract, values_map);
+                let collection = collection.plug_in(contract, values_map);
 
                 Expr::In {
                     value,
@@ -553,8 +552,8 @@ impl ExprKey {
                 }
             }
             Expr::Range { lb, ub, span } => {
-                let lb = lb.plug_in(contract, pred_key, values_map);
-                let ub = ub.plug_in(contract, pred_key, values_map);
+                let lb = lb.plug_in(contract, values_map);
+                let ub = ub.plug_in(contract, values_map);
 
                 Expr::Range { lb, ub, span }
             }
@@ -568,14 +567,14 @@ impl ExprKey {
                 let gen_ranges = gen_ranges
                     .iter()
                     .map(|(index, range)| {
-                        (index.clone(), range.plug_in(contract, pred_key, values_map))
+                        (index.clone(), range.plug_in(contract, values_map))
                     })
                     .collect::<Vec<_>>();
                 let conditions = conditions
                     .iter()
-                    .map(|condition| condition.plug_in(contract, pred_key, values_map))
+                    .map(|condition| condition.plug_in(contract, values_map))
                     .collect::<Vec<_>>();
-                let body = body.plug_in(contract, pred_key, values_map);
+                let body = body.plug_in(contract, values_map);
 
                 Expr::Generator {
                     kind,

--- a/pintc/src/expr/evaluate.rs
+++ b/pintc/src/expr/evaluate.rs
@@ -258,8 +258,6 @@ impl Evaluator {
 
             Expr::TupleFieldAccess { tuple, field, span } => {
                 // If the expr is a tuple...
-                let pred = contract.preds.get(pred_key).unwrap();
-
                 let tup = self.evaluate_key(tuple, handler, contract, pred_key)?;
                 if let Imm::Tuple(fields) = tup {
                     // And the field can be found...
@@ -282,7 +280,7 @@ impl Evaluator {
                         handler.emit_err(Error::Compile {
                             error: CompileError::InvalidTupleAccessor {
                                 accessor: field.to_string(),
-                                tuple_type: pred.with_pred(contract, tuple_ty).to_string(),
+                                tuple_type: contract.with_ctrct(tuple_ty).to_string(),
                                 span: span.clone(),
                             },
                         })
@@ -290,9 +288,7 @@ impl Evaluator {
                 } else {
                     Err(handler.emit_err(Error::Compile {
                         error: CompileError::TupleAccessNonTuple {
-                            non_tuple_type: pred
-                                .with_pred(contract, tuple.get_ty(contract))
-                                .to_string(),
+                            non_tuple_type: contract.with_ctrct(tuple.get_ty(contract)).to_string(),
                             span: span.clone(),
                         },
                     }))
@@ -321,11 +317,9 @@ impl Evaluator {
                         }
                     }
 
-                    let pred = contract.preds.get(pred_key).unwrap();
-
                     Err(handler.emit_err(Error::Compile {
                         error: CompileError::NonBoolConditional {
-                            ty: pred.with_pred(contract, cond_ty).to_string(),
+                            ty: contract.with_ctrct(cond_ty).to_string(),
                             conditional: "select expression".to_owned(),
                             span: span.clone(),
                         },
@@ -340,11 +334,9 @@ impl Evaluator {
                         value_ty = imm.get_ty(Some(span));
                     }
 
-                    let pred = contract.preds.get(pred_key).unwrap();
-
                     Err(handler.emit_err(Error::Compile {
                         error: CompileError::BadCastFrom {
-                            ty: pred.with_pred(contract, value_ty).to_string(),
+                            ty: contract.with_ctrct(value_ty).to_string(),
                             span: span.clone(),
                         },
                     }))
@@ -463,9 +455,7 @@ impl ExprKey {
             Expr::Tuple { fields, span } => {
                 let fields = fields
                     .iter()
-                    .map(|(name, value)| {
-                        (name.clone(), value.plug_in(contract, values_map))
-                    })
+                    .map(|(name, value)| (name.clone(), value.plug_in(contract, values_map)))
                     .collect::<Vec<_>>();
 
                 Expr::Tuple {
@@ -566,9 +556,7 @@ impl ExprKey {
             } => {
                 let gen_ranges = gen_ranges
                     .iter()
-                    .map(|(index, range)| {
-                        (index.clone(), range.plug_in(contract, values_map))
-                    })
+                    .map(|(index, range)| (index.clone(), range.plug_in(contract, values_map)))
                     .collect::<Vec<_>>();
                 let conditions = conditions
                     .iter()

--- a/pintc/src/macros.rs
+++ b/pintc/src/macros.rs
@@ -285,7 +285,7 @@ fn splice_get_array_range_size(
                 value: Immediate::Int(size),
                 ..
             } => Some((*size as usize, None)),
-            Expr::PathByName(path, _) => {
+            Expr::Path(path, _) => {
                 contract
                     .enums
                     .iter()

--- a/pintc/src/parser.rs
+++ b/pintc/src/parser.rs
@@ -235,15 +235,12 @@ impl<'a> ProjectParser<'a> {
         // symbol inside an `predicate { .. }` that was already used in the root Pred.
 
         let root_symbols = self.contract.root_pred().top_level_symbols.clone();
-        let interfaces = self.contract.root_pred().interfaces.clone();
 
         self.contract
             .preds
             .values_mut()
             .filter(|pred| pred.name != Contract::ROOT_PRED_NAME)
             .for_each(|pred| {
-                pred.interfaces.extend_from_slice(&interfaces);
-
                 for (symbol, span) in &root_symbols {
                     // We could call `pred.add_top_level_symbol_with_name` directly here, but then
                     // the spans would be reversed so I decided to do this manually. We want the

--- a/pintc/src/parser.rs
+++ b/pintc/src/parser.rs
@@ -3,7 +3,7 @@ use crate::{
     expr::Ident,
     lexer,
     macros::{self, MacroCall, MacroDecl, MacroExpander},
-    predicate::{CallKey, Contract, ExprKey, PredKey, Predicate},
+    predicate::{CallKey, Contract, ExprKey, PredKey},
     span::{empty_span, Span},
     types::*,
 };
@@ -539,18 +539,13 @@ impl TestWrapper {
     }
 }
 
-impl crate::predicate::DisplayWithPred for TestWrapper {
-    fn fmt(
-        &self,
-        f: &mut std::fmt::Formatter,
-        contract: &Contract,
-        pred: &Predicate,
-    ) -> std::fmt::Result {
+impl crate::predicate::DisplayWithContract for TestWrapper {
+    fn fmt(&self, f: &mut std::fmt::Formatter, contract: &Contract) -> std::fmt::Result {
         match self {
-            TestWrapper::Expr(e) => e.fmt(f, contract, pred),
-            TestWrapper::Type(t) => t.fmt(f, contract, pred),
-            TestWrapper::Ident(i) => i.fmt(f, contract, pred),
-            TestWrapper::UseTree(_) => panic!("DisplayWithPred not avilable for UseTree"),
+            TestWrapper::Expr(e) => e.fmt(f, contract),
+            TestWrapper::Type(t) => t.fmt(f, contract),
+            TestWrapper::Ident(i) => std::fmt::Display::fmt(i, f),
+            TestWrapper::UseTree(_) => panic!("DisplayWithContract not avilable for UseTree"),
         }
     }
 }

--- a/pintc/src/parser/context.rs
+++ b/pintc/src/parser/context.rs
@@ -33,7 +33,7 @@ impl<'a> ParserContext<'a> {
         mut ident: Ident,
         prefix: &str,
     ) -> Ident {
-        if let Ok(name) = self.current_pred().add_top_level_symbol(
+        if let Ok(name) = self.current_pred().symbols.add_symbol(
             handler,
             prefix,
             None,
@@ -615,7 +615,8 @@ impl<'a> ParserContext<'a> {
                 //
                 // use a::b::mod::my_mod::self;    // Inserted as ::local::mod::my_mod
                 self.current_pred()
-                    .add_top_level_symbol(
+                    .symbols
+                    .add_symbol(
                         &local_handler,
                         mod_prefix,
                         None,

--- a/pintc/src/parser/context.rs
+++ b/pintc/src/parser/context.rs
@@ -278,14 +278,14 @@ impl<'a> ParserContext<'a> {
             let _ = self
                 .current_pred()
                 .insert_var(handler, mod_prefix, name.1, is_pub, &name.0, ty)
-                .map(|var_key| {
+                .map(|(var_key, var_full_name)| {
                     if let Some(expr_key) = init {
                         self.current_pred().var_inits.insert(var_key, expr_key);
                         let span = (self.span_from)(l, r);
                         let var_span = name.0.span;
 
                         let var_expr_key = self.contract.exprs.insert(
-                            Expr::PathByKey(var_key, var_span.clone()),
+                            Expr::Path(var_full_name, var_span.clone()),
                             Type::Unknown(var_span.clone()),
                         );
 

--- a/pintc/src/parser/context.rs
+++ b/pintc/src/parser/context.rs
@@ -174,7 +174,7 @@ impl<'a> ParserContext<'a> {
             }
         }
 
-        self.current_pred().interfaces.push(interface);
+        self.contract.interfaces.push(interface);
     }
 
     /// Given a predicate instance name as an `Predicate`, a list `els` of `Ident`s forming a path, an

--- a/pintc/src/parser/tests.rs
+++ b/pintc/src/parser/tests.rs
@@ -2,7 +2,7 @@ use crate::{
     error::{Error, Handler, ReportableError},
     lexer::{self, KEYWORDS},
     parser::ParserContext,
-    predicate::{Contract, DisplayWithPred, Predicate},
+    predicate::{Contract, DisplayWithContract},
     span::Span,
 };
 use std::{collections::BTreeMap, path::Path, rc::Rc};
@@ -100,7 +100,7 @@ macro_rules! run_parser {
                 let result =
                     format!("{}{}",
                         context.contract,
-                        context.contract.root_pred().with_pred(context.contract, &item)
+                        context.contract.with_ctrct(&item)
                     );
                 format!("{}{}",
                     use_paths
@@ -119,13 +119,8 @@ macro_rules! run_parser {
 
 /// Many parsers return () which we may need to print. Just do nothing!
 #[cfg(test)]
-impl DisplayWithPred for () {
-    fn fmt(
-        &self,
-        _f: &mut std::fmt::Formatter,
-        _contract: &Contract,
-        _pred: &Predicate,
-    ) -> std::fmt::Result {
+impl DisplayWithContract for () {
+    fn fmt(&self, _f: &mut std::fmt::Formatter, _contract: &Contract) -> std::fmt::Result {
         Ok(())
     }
 }
@@ -2204,11 +2199,7 @@ fn macro_call() {
     assert!(context.macro_calls.get(&root_pred_key).unwrap().len() == 1);
 
     check(
-        &context
-            .contract
-            .root_pred()
-            .with_pred(context.contract, &result.unwrap())
-            .to_string(),
+        &context.contract.with_ctrct(&result.unwrap()).to_string(),
         expect_test::expect!["::@foo(...)"],
     );
 

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -744,7 +744,7 @@ TermInner: Expr = {
     <IntrinsicCallExpr>,
     <ArrayExpr>,
     <TupleExpr>,
-    <l:@L> <path:Path> <r:@R> => Expr::PathByName(path, (context.span_from)(l, r)),
+    <l:@L> <path:Path> <r:@R> => Expr::Path(path, (context.span_from)(l, r)),
 };
 
 GeneratorRange: (Ident, ExprKey) = {

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -826,7 +826,7 @@ MacroCallExpr: ExprKey = {
         let call_key = context.current_pred().calls.insert(name.clone());
         let span = (context.span_from)(l, r);
         let call_data = MacroCall {
-            name,
+            name: name.clone(),
             mod_path: context.mod_path.to_vec(),
             args,
             span: span.clone(),
@@ -834,6 +834,7 @@ MacroCallExpr: ExprKey = {
         };
         let call_expr_key = context.contract.exprs.insert(
             Expr::MacroCall {
+                path: name,
                 call: call_key,
                 span: span.clone(),
             },

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -269,7 +269,7 @@ StateDecl: () = {
 ConstDecl: () = {
     <l:@L> "const" <name:Ident> <ty:(":" <Type>)?> "=" <init:Expr> <r:@R> => {
         // consts are all added to the root Pred.
-        if let Ok(full_name) = context.contract.root_pred_mut().add_top_level_symbol(
+        if let Ok(full_name) = context.contract.root_pred_mut().symbols.add_symbol(
             handler,
             context.mod_prefix,
             None,
@@ -753,7 +753,6 @@ GeneratorRange: (Ident, ExprKey) = {
         // list.
         let mod_prefix = context.mod_prefix;
         let _ = context.current_pred().insert_ephemeral(
-            handler,
             mod_prefix,
             &index,
             Type::Primitive {

--- a/pintc/src/predicate.rs
+++ b/pintc/src/predicate.rs
@@ -105,8 +105,7 @@ impl Contract {
 
         match expr {
             Expr::Error(_)
-            | Expr::PathByKey(_, _)
-            | Expr::PathByName(_, _)
+            | Expr::Path(_, _)
             | Expr::StorageAccess(_, _)
             | Expr::ExternalStorageAccess { .. }
             | Expr::MacroCall { .. }

--- a/pintc/src/predicate.rs
+++ b/pintc/src/predicate.rs
@@ -34,6 +34,7 @@ pub struct Contract {
     pub exprs: Exprs,
     pub consts: FxHashMap<String, Const>,
     pub storage: Option<(Vec<StorageVar>, Span)>,
+    pub interfaces: Vec<Interface>,
 
     pub enums: Vec<EnumDecl>,
     pub new_types: Vec<NewTypeDecl>,
@@ -53,6 +54,7 @@ impl Default for Contract {
             exprs: Default::default(),
             consts: Default::default(),
             storage: Default::default(),
+            interfaces: Default::default(),
             enums: Default::default(),
             new_types: Default::default(),
             removed_macro_calls: Default::default(),
@@ -300,9 +302,6 @@ pub struct Predicate {
 
     // CallKey is used in a secondary map in the parser context to access the actual call data.
     pub calls: slotmap::SlotMap<CallKey, Path>,
-
-    // A list of all availabe interfaces
-    pub interfaces: Vec<Interface>,
 
     // A list of all availabe interface instances
     pub interface_instances: Vec<InterfaceInstance>,

--- a/pintc/src/predicate.rs
+++ b/pintc/src/predicate.rs
@@ -39,8 +39,7 @@ pub struct Contract {
     pub enums: Vec<EnumDecl>,
     pub new_types: Vec<NewTypeDecl>,
 
-    // Keep track of obsolete expanded macro calls in case they're erroneously depended upon.
-    pub removed_macro_calls: slotmap::SecondaryMap<ExprKey, Span>,
+    removed_macro_calls: slotmap::SecondaryMap<ExprKey, Span>,
 }
 
 impl Default for Contract {
@@ -281,6 +280,14 @@ impl Contract {
             .map(|expr| expr.span().clone())
             .unwrap_or_else(empty_span)
     }
+
+    pub fn add_removed_macro_call(&mut self, expr_key: ExprKey, span: Span) {
+        self.removed_macro_calls.insert(expr_key, span);
+    }
+
+    pub fn is_removed_macro_call(&self, expr_key: ExprKey) -> bool {
+        self.removed_macro_calls.contains_key(expr_key)
+    }
 }
 
 /// An in-progress predicate, possibly malformed or containing redundant information.  Designed to
@@ -309,7 +316,7 @@ pub struct Predicate {
     // A list of all availabe predicate instances
     pub predicate_instances: Vec<PredicateInstance>,
 
-    pub top_level_symbols: FxHashMap<String, Span>,
+    pub symbols: SymbolTable,
 }
 
 impl Predicate {
@@ -363,75 +370,27 @@ impl Predicate {
 
     pub fn insert_ephemeral(
         &mut self,
-        handler: &Handler,
         mod_prefix: &str,
         name: &Ident,
         ty: Type,
     ) -> std::result::Result<(), ErrorEmitted> {
-        let full_name = Self::make_full_symbol(mod_prefix, None, name);
+        let full_name = self
+            .symbols
+            .add_symbol_no_clash(mod_prefix, None, name, name.span.clone());
+
         if !self
             .ephemerals
             .iter()
             .any(|eph_decl| eph_decl.name == full_name)
         {
-            self.add_top_level_symbol_with_name(
-                handler,
-                name,
-                full_name.clone(),
-                name.span.clone(),
-            )?;
             self.ephemerals.push(EphemeralDecl {
                 name: full_name,
                 ty,
                 span: name.span.clone(),
             });
         }
+
         Ok(())
-    }
-
-    fn make_full_symbol(mod_prefix: &str, local_scope: Option<&str>, name: &Ident) -> String {
-        let local_scope_str = local_scope
-            .map(|ls| ls.to_owned() + "::")
-            .unwrap_or_default();
-        mod_prefix.to_owned() + &local_scope_str + &name.name
-    }
-
-    fn add_top_level_symbol_with_name(
-        &mut self,
-        handler: &Handler,
-        short_name: &Ident,
-        full_name: String,
-        span: Span,
-    ) -> std::result::Result<String, ErrorEmitted> {
-        self.top_level_symbols
-            .get(&full_name)
-            .map(|prev_span| {
-                // Name clash.
-                Err(handler.emit_err(Error::Parse {
-                    error: ParseError::NameClash {
-                        sym: short_name.name.clone(),
-                        span: short_name.span.clone(),
-                        prev_span: prev_span.clone(),
-                    },
-                }))
-            })
-            .unwrap_or_else(|| {
-                // Not found in the symbol table.
-                self.top_level_symbols.insert(full_name.clone(), span);
-                Ok(full_name)
-            })
-    }
-
-    pub fn add_top_level_symbol(
-        &mut self,
-        handler: &Handler,
-        mod_prefix: &str,
-        local_scope: Option<&str>,
-        name: &Ident,
-        span: Span,
-    ) -> std::result::Result<String, ErrorEmitted> {
-        let full_name = Self::make_full_symbol(mod_prefix, local_scope, name);
-        self.add_top_level_symbol_with_name(handler, name, full_name, span)
     }
 
     pub fn replace_exprs(&mut self, old_expr: ExprKey, new_expr: ExprKey) {
@@ -708,5 +667,84 @@ impl<T: DisplayWithPred> fmt::Display for WithPred<'_, T> {
 impl<T: DisplayWithPred> DisplayWithPred for &T {
     fn fmt(&self, f: &mut fmt::Formatter, contract: &Contract, pred: &Predicate) -> fmt::Result {
         (*self).fmt(f, contract, pred)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SymbolTable {
+    symbols: FxHashMap<String, Span>,
+}
+
+impl SymbolTable {
+    pub fn add_symbol_no_clash(
+        &mut self,
+        mod_prefix: &str,
+        local_scope: Option<&str>,
+        name: &Ident,
+        span: Span,
+    ) -> String {
+        let full_name = Self::make_full_symbol(mod_prefix, local_scope, name);
+        self.symbols.entry(full_name.clone()).or_insert(span);
+        full_name
+    }
+
+    pub fn add_symbol(
+        &mut self,
+        handler: &Handler,
+        mod_prefix: &str,
+        local_scope: Option<&str>,
+        name: &Ident,
+        span: Span,
+    ) -> std::result::Result<String, ErrorEmitted> {
+        let full_name = Self::make_full_symbol(mod_prefix, local_scope, name);
+        self.symbols
+            .get(&full_name)
+            .map(|prev_span| {
+                // Name clash.
+                Err(handler.emit_err(Error::Parse {
+                    error: ParseError::NameClash {
+                        sym: name.name.clone(),
+                        span: name.span.clone(),
+                        prev_span: prev_span.clone(),
+                    },
+                }))
+            })
+            .unwrap_or_else(|| {
+                // Not found in the symbol table.
+                self.symbols.insert(full_name.clone(), span);
+                Ok(full_name)
+            })
+    }
+
+    pub fn check_for_clash(
+        &self,
+        handler: &Handler,
+        other: &SymbolTable,
+    ) -> std::result::Result<(), ErrorEmitted> {
+        // Self has the original symbols, `other` has the new potentially clashing symbols.
+        for (symbol, span) in &other.symbols {
+            if let Some(prev_span) = self.symbols.get(symbol) {
+                handler.emit_err(Error::Parse {
+                    error: ParseError::NameClash {
+                        sym: symbol.clone(),
+                        span: span.clone(),
+                        prev_span: prev_span.clone(),
+                    },
+                });
+            }
+        }
+
+        if handler.has_errors() {
+            Err(handler.cancel())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn make_full_symbol(mod_prefix: &str, local_scope: Option<&str>, name: &Ident) -> String {
+        let local_scope_str = local_scope
+            .map(|ls| ls.to_owned() + "::")
+            .unwrap_or_default();
+        mod_prefix.to_owned() + &local_scope_str + &name.name
     }
 }

--- a/pintc/src/predicate/analyse.rs
+++ b/pintc/src/predicate/analyse.rs
@@ -198,7 +198,7 @@ impl Contract {
                 if let Some(imm_value) = all_const_immediates.get(path) {
                     // Check the type is valid.
                     let span = self.expr_key_to_span(*expr);
-                    match self.infer_immediate(self.root_pred(), imm_value, &span) {
+                    match self.infer_immediate(imm_value, &span) {
                         Ok(inferred) => match inferred {
                             Inference::Type(new_ty) => {
                                 type_replacements.push((path.clone(), new_ty))

--- a/pintc/src/predicate/analyse.rs
+++ b/pintc/src/predicate/analyse.rs
@@ -158,7 +158,7 @@ impl Contract {
                 let mut preserved_enum_type = None;
                 if let Some(Const { expr, decl_ty }) = self.consts.get(&new_path) {
                     if decl_ty.is_unknown() {
-                        if let Expr::PathByName(path, _) = expr.get(self) {
+                        if let Expr::Path(path, _) = expr.get(self) {
                             // We have an unknown-typed const initialised with a path.  E.g.,
                             // const a = MyEnum::MyVariant;
                             if let Ok(Inference::Type(variant_ty)) =

--- a/pintc/src/predicate/analyse/intrinsics.rs
+++ b/pintc/src/predicate/analyse/intrinsics.rs
@@ -485,16 +485,7 @@ fn infer_intrinsic_state_len(
 
     // First argument must be a path to a state variable
     match args[0].try_get(contract) {
-        Some(Expr::PathByName(name, _)) if pred.states().any(|(_, state)| state.name == *name) => {
-            Ok(())
-        }
-        Some(Expr::PathByKey(var_key, _))
-            if pred
-                .states()
-                .any(|(_, state)| state.name == var_key.get(pred).name) =>
-        {
-            Ok(())
-        }
+        Some(Expr::Path(name, _)) if pred.states().any(|(_, state)| state.name == *name) => Ok(()),
         Some(Expr::UnaryOp {
             op: UnaryOp::NextState,
             ..

--- a/pintc/src/predicate/analyse/intrinsics.rs
+++ b/pintc/src/predicate/analyse/intrinsics.rs
@@ -25,19 +25,15 @@ impl Contract {
             match &name.name[..] {
                 // Access ops
                 "__mut_keys_len" => infer_intrinsic_mut_keys_len(args, span),
-                "__mut_keys_contains" => {
-                    infer_intrinsic_mut_keys_contains(self, pred, name, args, span)
-                }
+                "__mut_keys_contains" => infer_intrinsic_mut_keys_contains(self, name, args, span),
                 "__this_address" => infer_intrinsic_this_address(args, span),
                 "__this_set_address" => infer_intrinsic_this_set_address(args, span),
                 "__this_pathway" => infer_intrinsic_this_pathway(args, span),
 
                 // Crypto ops
                 "__sha256" => infer_intrinsic_sha256(args, span),
-                "__verify_ed25519" => infer_intrinsic_verify_ed25519(self, pred, name, args, span),
-                "__recover_secp256k1" => {
-                    infer_intrinsic_recover_secp256k1(self, pred, name, args, span)
-                }
+                "__verify_ed25519" => infer_intrinsic_verify_ed25519(self, name, args, span),
+                "__recover_secp256k1" => infer_intrinsic_recover_secp256k1(self, name, args, span),
 
                 "__state_len" => infer_intrinsic_state_len(self, pred, args, span),
 
@@ -101,7 +97,6 @@ fn infer_intrinsic_mut_keys_len(args: &[ExprKey], span: &Span) -> Result<Inferen
 //
 fn infer_intrinsic_mut_keys_contains(
     contract: &Contract,
-    pred: &Predicate,
     name: &Ident,
     args: &[ExprKey],
     span: &Span,
@@ -136,7 +131,7 @@ fn infer_intrinsic_mut_keys_contains(
         if !ty.is_int() {
             return arg_type_error(
                 "int[..]".to_string(),
-                pred.with_pred(contract, mut_key_type).to_string(),
+                contract.with_ctrct(mut_key_type).to_string(),
                 name.span.clone(),
                 mut_key_span.clone(),
             );
@@ -144,7 +139,7 @@ fn infer_intrinsic_mut_keys_contains(
     } else {
         return arg_type_error(
             "int[..]".to_string(),
-            pred.with_pred(contract, mut_key_type).to_string(),
+            contract.with_ctrct(mut_key_type).to_string(),
             name.span.clone(),
             mut_key_span.clone(),
         );
@@ -285,7 +280,6 @@ fn infer_intrinsic_sha256(args: &[ExprKey], span: &Span) -> Result<Inference, Er
 //
 fn infer_intrinsic_verify_ed25519(
     contract: &Contract,
-    pred: &Predicate,
     name: &Ident,
     args: &[ExprKey],
     span: &Span,
@@ -322,7 +316,7 @@ fn infer_intrinsic_verify_ed25519(
         if fields.len() != 2 || !fields[0].1.is_b256() || !fields[1].1.is_b256() {
             return arg_type_error(
                 "{ b256, b256 }".to_string(),
-                pred.with_pred(contract, sig_type).to_string(),
+                contract.with_ctrct(sig_type).to_string(),
                 name.span.clone(),
                 sig_span.clone(),
             );
@@ -330,7 +324,7 @@ fn infer_intrinsic_verify_ed25519(
     } else {
         return arg_type_error(
             "{ b256, b256 }".to_string(),
-            pred.with_pred(contract, sig_type).to_string(),
+            contract.with_ctrct(sig_type).to_string(),
             name.span.clone(),
             sig_span.clone(),
         );
@@ -342,7 +336,7 @@ fn infer_intrinsic_verify_ed25519(
     if !pub_key_type.is_b256() {
         return arg_type_error(
             "b256".to_string(),
-            pred.with_pred(contract, pub_key_type).to_string(),
+            contract.with_ctrct(pub_key_type).to_string(),
             name.span.clone(),
             pub_key_span.clone(),
         );
@@ -368,7 +362,6 @@ fn infer_intrinsic_verify_ed25519(
 //
 fn infer_intrinsic_recover_secp256k1(
     contract: &Contract,
-    pred: &Predicate,
     name: &Ident,
     args: &[ExprKey],
     span: &Span,
@@ -402,7 +395,7 @@ fn infer_intrinsic_recover_secp256k1(
     if !pub_key_type.is_b256() {
         return arg_type_error(
             "b256".to_string(),
-            pred.with_pred(contract, pub_key_type).to_string(),
+            contract.with_ctrct(pub_key_type).to_string(),
             name.span.clone(),
             pub_key_span.clone(),
         );
@@ -419,7 +412,7 @@ fn infer_intrinsic_recover_secp256k1(
         {
             return arg_type_error(
                 "{ b256, b256, int }".to_string(),
-                pred.with_pred(contract, sig_type).to_string(),
+                contract.with_ctrct(sig_type).to_string(),
                 name.span.clone(),
                 sig_span.clone(),
             );
@@ -427,7 +420,7 @@ fn infer_intrinsic_recover_secp256k1(
     } else {
         return arg_type_error(
             "{ b256, b256, int }".to_string(),
-            pred.with_pred(contract, sig_type).to_string(),
+            contract.with_ctrct(sig_type).to_string(),
             name.span.clone(),
             sig_span.clone(),
         );

--- a/pintc/src/predicate/analyse/type_check.rs
+++ b/pintc/src/predicate/analyse/type_check.rs
@@ -597,7 +597,7 @@ impl Contract {
                 ..
             } in &self.preds[pred_key].interface_instances
             {
-                if self.preds[pred_key]
+                if self
                     .interfaces
                     .iter()
                     .any(|e| e.name.to_string() == *interface)
@@ -637,7 +637,7 @@ impl Contract {
                     .iter()
                     .find(|e| e.name.to_string() == *interface_instance)
                 {
-                    if let Some(interface) = self.preds[pred_key]
+                    if let Some(interface) = self
                         .interfaces
                         .iter()
                         .find(|e| e.name.to_string() == *interface_instance.interface)
@@ -1091,7 +1091,7 @@ impl Contract {
         };
 
         // Find the interface declaration corresponding to the interface instance
-        let Some(interface) = pred
+        let Some(interface) = self
             .interfaces
             .iter()
             .find(|e| e.name.to_string() == *interface_instance.interface)
@@ -1137,7 +1137,7 @@ impl Contract {
                 .iter()
                 .find(|e| e.name.to_string() == *interface_instance)
             {
-                if let Some(interface) = pred
+                if let Some(interface) = self
                     .interfaces
                     .iter()
                     .find(|e| e.name.to_string() == *interface_instance.interface)

--- a/pintc/src/predicate/display.rs
+++ b/pintc/src/predicate/display.rs
@@ -1,23 +1,107 @@
+use super::*;
+
 use std::fmt::{Display, Formatter, Result};
 
-impl Display for super::Contract {
+#[derive(Clone, Copy)]
+pub struct WithContract<'a, T> {
+    pub thing: T,
+    pub contract: &'a Contract,
+}
+
+impl<'a, T> WithContract<'a, T> {
+    pub fn new(thing: T, contract: &'a Contract) -> Self {
+        WithContract { thing, contract }
+    }
+}
+
+impl Contract {
+    /// Helps out some `thing: T` by adding `self` as context.
+    pub fn with_ctrct<T>(&self, thing: T) -> WithContract<T> {
+        WithContract {
+            thing,
+            contract: self,
+        }
+    }
+}
+
+pub(crate) trait DisplayWithContract {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract) -> Result;
+}
+
+impl<T: DisplayWithContract> Display for WithContract<'_, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        self.thing.fmt(f, self.contract)
+    }
+}
+
+impl<T: DisplayWithContract> DisplayWithContract for &T {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract) -> Result {
+        (*self).fmt(f, contract)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct WithPred<'a, T> {
+    pub thing: T,
+    pub contract: &'a Contract,
+    pub pred: &'a Predicate,
+}
+
+impl<'a, T> WithPred<'a, T> {
+    pub fn new(thing: T, contract: &'a Contract, pred: &'a Predicate) -> Self {
+        WithPred {
+            thing,
+            contract,
+            pred,
+        }
+    }
+}
+
+impl Predicate {
+    /// Helps out some `thing: T` by adding `self` as context.
+    pub fn with_pred<'a, T>(&'a self, contract: &'a Contract, thing: T) -> WithPred<T> {
+        WithPred {
+            thing,
+            contract,
+            pred: self,
+        }
+    }
+}
+
+pub(crate) trait DisplayWithPred {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> Result;
+}
+
+impl<T: DisplayWithPred> Display for WithPred<'_, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        self.thing.fmt(f, self.contract, self.pred)
+    }
+}
+
+impl<T: DisplayWithPred> DisplayWithPred for &T {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> Result {
+        (*self).fmt(f, contract, pred)
+    }
+}
+
+impl Display for Contract {
     fn fmt(&self, f: &mut Formatter) -> Result {
         for (path, cnst) in &self.consts {
-            writeln!(f, "const {path}{};", self.root_pred().with_pred(self, cnst))?;
+            writeln!(f, "const {path}{};", self.with_ctrct(cnst))?;
         }
 
         for r#enum in &self.enums {
-            writeln!(f, "{};", self.root_pred().with_pred(self, r#enum))?;
+            writeln!(f, "{enum};")?;
         }
 
         for new_type in &self.new_types {
-            writeln!(f, "{};", self.root_pred().with_pred(self, new_type))?;
+            writeln!(f, "{};", self.with_ctrct(new_type))?;
         }
 
         if let Some(storage) = &self.storage {
             writeln!(f, "storage {{")?;
             for storage_var in &storage.0 {
-                writeln!(f, "    {}", self.root_pred().with_pred(self, storage_var))?;
+                writeln!(f, "    {}", self.with_ctrct(storage_var))?;
             }
             writeln!(f, "}}")?;
         }
@@ -38,9 +122,9 @@ impl Display for super::Contract {
     }
 }
 
-impl super::Contract {
+impl Contract {
     fn fmt_interfaces(&self, f: &mut Formatter) -> Result {
-        for super::Interface {
+        for Interface {
             name,
             storage,
             predicate_interfaces,
@@ -53,11 +137,7 @@ impl super::Contract {
             if let Some(storage) = &storage {
                 writeln!(f, "    storage {{")?;
                 for storage_var in &storage.0 {
-                    writeln!(
-                        f,
-                        "        {}",
-                        self.root_pred().with_pred(self, storage_var)
-                    )?;
+                    writeln!(f, "        {}", self.with_ctrct(storage_var))?;
                 }
                 writeln!(f, "    }}")?;
             }
@@ -75,7 +155,7 @@ impl super::Contract {
                             f,
                             "        pub var {}: {};",
                             var.name,
-                            self.root_pred().with_pred(self, var.ty.clone())
+                            self.with_ctrct(var.ty.clone())
                         )?;
                     }
                     writeln!(f, "    }}")?;
@@ -89,16 +169,11 @@ impl super::Contract {
     }
 }
 
-impl super::Predicate {
-    fn fmt_with_indent(
-        &self,
-        f: &mut Formatter,
-        contract: &super::Contract,
-        indent: usize,
-    ) -> Result {
+impl Predicate {
+    fn fmt_with_indent(&self, f: &mut Formatter, contract: &Contract, indent: usize) -> Result {
         let indentation = " ".repeat(4 * indent);
 
-        for super::InterfaceInstance {
+        for InterfaceInstance {
             name,
             interface,
             address,
@@ -108,11 +183,11 @@ impl super::Predicate {
             writeln!(
                 f,
                 "{indentation}interface {name} = {interface}({})",
-                self.with_pred(contract, address)
+                contract.with_ctrct(address)
             )?;
         }
 
-        for super::PredicateInstance {
+        for PredicateInstance {
             name,
             interface_instance,
             predicate,
@@ -123,7 +198,7 @@ impl super::Predicate {
             writeln!(
                 f,
                 "{indentation}predicate {name} = {interface_instance}::{predicate}({})",
-                self.with_pred(contract, address)
+                contract.with_ctrct(address)
             )?;
         }
 
@@ -136,7 +211,7 @@ impl super::Predicate {
         }
 
         for constraint in &self.constraints {
-            writeln!(f, "{indentation}{};", self.with_pred(contract, constraint))?;
+            writeln!(f, "{indentation}{};", contract.with_ctrct(constraint))?;
         }
 
         for if_decl in &self.if_decls {
@@ -144,5 +219,27 @@ impl super::Predicate {
         }
 
         Ok(())
+    }
+}
+
+impl DisplayWithContract for Const {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract) -> Result {
+        if !self.decl_ty.is_unknown() {
+            write!(f, ": {}", contract.with_ctrct(&self.decl_ty))?;
+        }
+
+        write!(f, " = {}", contract.with_ctrct(self.expr))
+    }
+}
+
+impl DisplayWithContract for ConstraintDecl {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract) -> Result {
+        write!(f, "constraint {}", contract.with_ctrct(self.expr))
+    }
+}
+
+impl DisplayWithContract for StorageVar {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract) -> Result {
+        write!(f, "{}: {},", self.name.name, contract.with_ctrct(&self.ty))
     }
 }

--- a/pintc/src/predicate/exprs.rs
+++ b/pintc/src/predicate/exprs.rs
@@ -82,12 +82,9 @@ impl ExprKey {
         contract.exprs.get(*self).map_or(false, |expr| match expr {
             Expr::StorageAccess(_, _) | Expr::ExternalStorageAccess { .. } => true,
 
-            Expr::PathByName(path, _) => pred.states().any(|(_, state)| &state.name == path),
+            Expr::Path(path, _) => pred.states().any(|(_, state)| &state.name == path),
 
-            Expr::Error(_)
-            | Expr::Immediate { .. }
-            | Expr::PathByKey(_, _)
-            | Expr::MacroCall { .. } => false,
+            Expr::Error(_) | Expr::Immediate { .. } | Expr::MacroCall { .. } => false,
 
             Expr::Array {
                 elements,
@@ -292,8 +289,7 @@ impl<'a> Iterator for ExprsIter<'a> {
             Expr::Error(_)
             | Expr::StorageAccess(..)
             | Expr::ExternalStorageAccess { .. }
-            | Expr::PathByKey(_, _)
-            | Expr::PathByName(_, _)
+            | Expr::Path(_, _)
             | Expr::MacroCall { .. } => {}
         };
 

--- a/pintc/src/predicate/states.rs
+++ b/pintc/src/predicate/states.rs
@@ -120,7 +120,7 @@ impl Predicate {
         expr: ExprKey,
         span: Span,
     ) -> std::result::Result<StateKey, ErrorEmitted> {
-        let name = self.add_top_level_symbol(handler, mod_prefix, None, name, span.clone())?;
+        let name = self.symbols.add_symbol(handler, mod_prefix, None, name, span.clone())?;
         let state_key = self.states.insert(
             State {
                 name,

--- a/pintc/src/predicate/states.rs
+++ b/pintc/src/predicate/states.rs
@@ -104,9 +104,9 @@ impl DisplayWithPred for StateKey {
         write!(f, "state {}", state.name)?;
         let ty = self.get_ty(pred);
         if !ty.is_unknown() {
-            write!(f, ": {}", pred.with_pred(contract, ty))?;
+            write!(f, ": {}", contract.with_ctrct(ty))?;
         }
-        write!(f, " = {}", pred.with_pred(contract, &state.expr))
+        write!(f, " = {}", contract.with_ctrct(&state.expr))
     }
 }
 

--- a/pintc/src/predicate/states.rs
+++ b/pintc/src/predicate/states.rs
@@ -120,7 +120,9 @@ impl Predicate {
         expr: ExprKey,
         span: Span,
     ) -> std::result::Result<StateKey, ErrorEmitted> {
-        let name = self.symbols.add_symbol(handler, mod_prefix, None, name, span.clone())?;
+        let name = self
+            .symbols
+            .add_symbol(handler, mod_prefix, None, name, span.clone())?;
         let state_key = self.states.insert(
             State {
                 name,

--- a/pintc/src/predicate/transform/unroll.rs
+++ b/pintc/src/predicate/transform/unroll.rs
@@ -189,7 +189,7 @@ fn unroll_generator(
         // If all conditions are satisifed (or if none are present), then update the resulting
         // expression by joining it with the newly unrolled generator body.
         if satisfied {
-            let rhs = body.plug_in(contract, pred_key, &values_map);
+            let rhs = body.plug_in(contract, &values_map);
             unrolled = contract.exprs.insert(
                 Expr::BinaryOp {
                     op: match kind {

--- a/pintc/src/predicate/transform/validate.rs
+++ b/pintc/src/predicate/transform/validate.rs
@@ -162,8 +162,7 @@ fn check_expr(
         Expr::Immediate { .. }
         | Expr::Array { .. }
         | Expr::Tuple { .. }
-        | Expr::PathByKey(..)
-        | Expr::PathByName(..)
+        | Expr::Path(..)
         | Expr::StorageAccess(..)
         | Expr::UnaryOp { .. }
         | Expr::BinaryOp { .. }

--- a/pintc/src/predicate/vars.rs
+++ b/pintc/src/predicate/vars.rs
@@ -123,7 +123,7 @@ impl DisplayWithPred for VarKey {
         write!(f, "var {}", var.name)?;
         let ty = self.get_ty(pred);
         if !ty.is_unknown() {
-            write!(f, ": {}", pred.with_pred(contract, ty))?;
+            write!(f, ": {}", contract.with_ctrct(ty))?;
         }
         Ok(())
     }

--- a/pintc/src/predicate/vars.rs
+++ b/pintc/src/predicate/vars.rs
@@ -138,12 +138,13 @@ impl Predicate {
         is_pub: bool,
         name: &Ident,
         ty: Option<Type>,
-    ) -> std::result::Result<VarKey, ErrorEmitted> {
+    ) -> std::result::Result<(VarKey, String), ErrorEmitted> {
         let full_name =
-            self.symbols.add_symbol(handler, mod_prefix, local_scope, name, name.span.clone())?;
+            self.symbols
+                .add_symbol(handler, mod_prefix, local_scope, name, name.span.clone())?;
         let var_key = self.vars.insert(
             Var {
-                name: full_name,
+                name: full_name.clone(),
                 is_pub,
                 span: name.span.clone(),
             },
@@ -154,7 +155,7 @@ impl Predicate {
             },
         );
 
-        Ok(var_key)
+        Ok((var_key, full_name))
     }
 
     pub(crate) fn vars(&self) -> impl Iterator<Item = (VarKey, &Var)> {

--- a/pintc/src/predicate/vars.rs
+++ b/pintc/src/predicate/vars.rs
@@ -140,7 +140,7 @@ impl Predicate {
         ty: Option<Type>,
     ) -> std::result::Result<VarKey, ErrorEmitted> {
         let full_name =
-            self.add_top_level_symbol(handler, mod_prefix, local_scope, name, name.span.clone())?;
+            self.symbols.add_symbol(handler, mod_prefix, local_scope, name, name.span.clone())?;
         let var_key = self.vars.insert(
             Var {
                 name: full_name,

--- a/pintc/src/types.rs
+++ b/pintc/src/types.rs
@@ -202,7 +202,7 @@ impl Type {
         contract: &Contract,
         pred_key: PredKey,
     ) -> Result<i64, ErrorEmitted> {
-        if let Expr::PathByName(path, _) = range_expr {
+        if let Expr::Path(path, _) = range_expr {
             // It's hopefully an enum for the range expression.
             if let Some(size) = contract.enums.iter().find_map(|enum_decl| {
                 (&enum_decl.name.name == path).then_some(enum_decl.variants.len() as i64)

--- a/pintc/src/types/display.rs
+++ b/pintc/src/types/display.rs
@@ -1,14 +1,14 @@
-use crate::predicate::{Contract, DisplayWithPred, Predicate};
-use std::fmt::{Formatter, Result};
+use crate::predicate::{Contract, DisplayWithContract};
+use std::fmt::{Display, Formatter, Result};
 
-impl DisplayWithPred for super::Path {
-    fn fmt(&self, f: &mut Formatter, _contract: &Contract, _pred: &Predicate) -> Result {
+impl DisplayWithContract for super::Path {
+    fn fmt(&self, f: &mut Formatter, _contract: &Contract) -> Result {
         write!(f, "{self}")
     }
 }
 
-impl DisplayWithPred for super::Type {
-    fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> Result {
+impl DisplayWithContract for super::Type {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract) -> Result {
         match self {
             super::Type::Error(..) => write!(f, "Error"),
 
@@ -27,33 +27,33 @@ impl DisplayWithPred for super::Type {
                 write!(
                     f,
                     "{}[{}]",
-                    pred.with_pred(contract, ty.as_ref()),
+                    contract.with_ctrct(ty.as_ref()),
                     range
-                        .map(|range| pred.with_pred(contract, range).to_string())
+                        .map(|range| contract.with_ctrct(range).to_string())
                         .unwrap_or("_".to_owned())
                 )
             }
 
             super::Type::Tuple { fields, .. } => {
                 macro_rules! write_field {
-                    ($f: expr, $field: expr, $comma: expr, $contract: ident, $pred: expr) => {{
+                    ($f: expr, $field: expr, $comma: expr, $contract: ident) => {{
                         if $comma {
                             write!($f, ", ")?;
                         };
                         if let Some(name) = &$field.0 {
                             write!($f, "{}: ", name.name)?;
                         }
-                        write!($f, "{}", $pred.with_pred($contract, &$field.1))?;
+                        write!($f, "{}", $contract.with_ctrct(&$field.1))?;
                     }};
                 }
 
                 write!(f, "{{")?;
                 let mut fields = fields.iter();
                 if let Some(first_field) = fields.next() {
-                    write_field!(f, first_field, false, contract, pred);
+                    write_field!(f, first_field, false, contract);
                 }
                 for field in fields {
-                    write_field!(f, field, true, contract, pred);
+                    write_field!(f, field, true, contract);
                 }
                 write!(f, "}}")
             }
@@ -61,36 +61,31 @@ impl DisplayWithPred for super::Type {
             super::Type::Custom { path, .. } => write!(f, "{path}"),
 
             super::Type::Alias { path, ty, .. } => {
-                write!(f, "{path} ({})", pred.with_pred(contract, ty.as_ref()))
+                write!(f, "{path} ({})", contract.with_ctrct(ty.as_ref()))
             }
 
             super::Type::Map { ty_from, ty_to, .. } => {
                 write!(
                     f,
                     "( {} => {} )",
-                    pred.with_pred(contract, ty_from.as_ref()),
-                    pred.with_pred(contract, ty_to.as_ref())
+                    contract.with_ctrct(ty_from.as_ref()),
+                    contract.with_ctrct(ty_to.as_ref())
                 )
             }
         }
     }
 }
 
-impl DisplayWithPred for super::EnumDecl {
-    fn fmt(&self, f: &mut Formatter, _contract: &Contract, _pred: &Predicate) -> Result {
+impl Display for super::EnumDecl {
+    fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "enum {} = ", self.name)?;
         crate::util::write_many!(f, self.variants, " | ");
         Ok(())
     }
 }
 
-impl DisplayWithPred for super::NewTypeDecl {
-    fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> Result {
-        write!(
-            f,
-            "type {} = {}",
-            self.name,
-            pred.with_pred(contract, &self.ty)
-        )
+impl DisplayWithContract for super::NewTypeDecl {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract) -> Result {
+        write!(f, "type {} = {}", self.name, contract.with_ctrct(&self.ty))
     }
 }

--- a/pintc/src/util.rs
+++ b/pintc/src/util.rs
@@ -1,20 +1,20 @@
 /// A place for small utility functions which can use used in various places throughout the crate.
 
-macro_rules! write_many_iter_with_pred {
-    ($f: expr, $i: ident, $sep: literal, $contract: ident, $pred: ident) => {
+macro_rules! write_many_iter_with_ctrct {
+    ($f: expr, $i: ident, $sep: literal, $contract: ident) => {
         if let Some(e) = $i.next() {
-            write!($f, "{}", $pred.with_pred($contract, e))?;
+            write!($f, "{}", $contract.with_ctrct(e))?;
         }
         for e in $i {
-            write!($f, "{}{}", $sep, $pred.with_pred($contract, e))?;
+            write!($f, "{}{}", $sep, $contract.with_ctrct(e))?;
         }
     };
 }
 
-macro_rules! write_many_with_pred {
-    ($f: expr, $vec: expr, $sep: literal, $contract: ident, $pred: ident) => {
+macro_rules! write_many_with_ctrct {
+    ($f: expr, $vec: expr, $sep: literal, $contract: ident) => {
         let mut i = $vec.iter();
-        crate::util::write_many_iter_with_pred!($f, i, $sep, $contract, $pred);
+        crate::util::write_many_iter_with_ctrct!($f, i, $sep, $contract);
     };
 }
 
@@ -38,5 +38,5 @@ macro_rules! write_many {
 
 pub(crate) use write_many;
 pub(crate) use write_many_iter;
-pub(crate) use write_many_iter_with_pred;
-pub(crate) use write_many_with_pred;
+pub(crate) use write_many_iter_with_ctrct;
+pub(crate) use write_many_with_ctrct;

--- a/pintc/tests/consts/instance_address.pnt
+++ b/pintc/tests/consts/instance_address.pnt
@@ -24,11 +24,6 @@ predicate Q {
 // }
 //
 // predicate ::Q {
-//     interface ::I {
-//         predicate P {
-//             pub var x: int;
-//         }
-//     }
 //     interface ::Iface = ::I(::i_addr)
 //     predicate ::PInstance = ::Iface::P(::p_addr)
 //     var __::PInstance_pathway: int;
@@ -46,11 +41,6 @@ predicate Q {
 // }
 //
 // predicate ::Q {
-//     interface ::I {
-//         predicate P {
-//             pub var x: int;
-//         }
-//     }
 //     interface ::Iface = ::I(0x0000000000000000000000000000000000000000000000000000000000000000)
 //     predicate ::PInstance = ::Iface::P(0x1111111111111111111111111111111111111111111111111111111111111111)
 //     var __::PInstance_pathway: int;

--- a/pintc/tests/consts/interface_address.pnt
+++ b/pintc/tests/consts/interface_address.pnt
@@ -20,11 +20,6 @@ predicate Foo {
 // }
 //
 // predicate ::Foo {
-//     interface ::Counter {
-//         storage {
-//             counter: int,
-//         }
-//     }
 //     interface ::CounterInstance = ::Counter(::ContractID)
 //     state ::counter = ::CounterInstance::storage::counter;
 // }
@@ -39,11 +34,6 @@ predicate Foo {
 // }
 //
 // predicate ::Foo {
-//     interface ::Counter {
-//         storage {
-//             counter: int,
-//         }
-//     }
 //     interface ::CounterInstance = ::Counter(0x0003000300030003000300030003000300030003000300030003000300030003)
 //     state ::counter: int = ::CounterInstance::storage::counter;
 // }

--- a/pintc/tests/interfaces/bad_address.pnt
+++ b/pintc/tests/interfaces/bad_address.pnt
@@ -31,18 +31,8 @@ predicate Simple {
 //         pub var y: b256;
 //     }
 // }
-// 
+//
 // predicate ::Simple {
-//     interface ::Foo {
-//         storage {
-//             x: int,
-//             y: int,
-//         }
-//         predicate I1 {
-//             pub var x: int;
-//             pub var y: b256;
-//         }
-//     }
 //     interface ::FooInstance1 = ::Foo((0 + true))
 //     interface ::FooInstance2 = ::Foo("bla")
 //     interface ::FooInstance = ::Foo(::addr)

--- a/pintc/tests/interfaces/bad_interfaces.pnt
+++ b/pintc/tests/interfaces/bad_interfaces.pnt
@@ -41,18 +41,8 @@ predicate Simple {
 //         pub var y: b256;
 //     }
 // }
-// 
+//
 // predicate ::Simple {
-//     interface ::Foo {
-//         storage {
-//             x: int,
-//             y: int,
-//         }
-//         predicate I1 {
-//             pub var x: int;
-//             pub var y: b256;
-//         }
-//     }
 //     interface ::Instance1 = ::MissingInterface(::addr1)
 //     interface ::FooInstance = ::Foo(::addr2)
 //     predicate ::Bad1 = ::MissingInterfaceInstance::Foo(::addr2)

--- a/pintc/tests/interfaces/simple.pnt
+++ b/pintc/tests/interfaces/simple.pnt
@@ -102,40 +102,6 @@ predicate Simple {
 // }
 //
 // predicate ::Simple {
-//     interface ::Foo {
-//         storage {
-//             x: int,
-//             y: int,
-//         }
-//         predicate I1 {
-//             pub var x1: int;
-//             pub var x2: b256;
-//             pub var x3: bool;
-//         }
-//         predicate I2 {
-//             pub var x1: int;
-//             pub var x2: b256;
-//             pub var x3: bool;
-//         }
-//         predicate I3;
-//     }
-//     interface ::Bar {
-//         storage {
-//             x: int,
-//             z: b256,
-//         }
-//         predicate I1 {
-//             pub var x1: int;
-//             pub var x2: b256;
-//             pub var x3: bool;
-//         }
-//         predicate I2 {
-//             pub var x1: int;
-//             pub var x2: b256;
-//             pub var x3: bool;
-//         }
-//         predicate I3;
-//     }
 //     interface ::FooInstance = ::Foo(::addr1)
 //     interface ::BarInstance = ::Bar(::addr2)
 //     predicate ::FooI1Instance1 = ::FooInstance::I1(::addr3)
@@ -201,40 +167,6 @@ predicate Simple {
 // }
 //
 // predicate ::Simple {
-//     interface ::Foo {
-//         storage {
-//             x: int,
-//             y: int,
-//         }
-//         predicate I1 {
-//             pub var x1: int;
-//             pub var x2: b256;
-//             pub var x3: bool;
-//         }
-//         predicate I2 {
-//             pub var x1: int;
-//             pub var x2: b256;
-//             pub var x3: bool;
-//         }
-//         predicate I3;
-//     }
-//     interface ::Bar {
-//         storage {
-//             x: int,
-//             z: b256,
-//         }
-//         predicate I1 {
-//             pub var x1: int;
-//             pub var x2: b256;
-//             pub var x3: bool;
-//         }
-//         predicate I2 {
-//             pub var x1: int;
-//             pub var x2: b256;
-//             pub var x3: bool;
-//         }
-//         predicate I3;
-//     }
 //     interface ::FooInstance = ::Foo(::addr1)
 //     interface ::BarInstance = ::Bar(::addr2)
 //     predicate ::FooI1Instance1 = ::FooInstance::I1(::addr3)

--- a/pintc/tests/storage/external_storage/main.pnt
+++ b/pintc/tests/storage/external_storage/main.pnt
@@ -94,27 +94,6 @@ predicate Bar {
 // }
 //
 // predicate ::Foo {
-//     interface ::ERC20_0 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::lib::ERC20_1 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::lib::ERC20_2 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
 //     interface ::ERC20_0_instance = ::ERC20_0(0x0000000000000000000000000000000000000000000000000000000000000000)
 //     interface ::ERC20_1_instance = ::lib::ERC20_1(0x1111111111111111111111111111111111111111111111111111111111111111)
 //     interface ::ERC20_2_instance = ::lib::ERC20_2(0x2222222222222222222222222222222222222222222222222222222222222222)
@@ -133,27 +112,6 @@ predicate Bar {
 // }
 //
 // predicate ::Bar {
-//     interface ::ERC20_0 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::lib::ERC20_1 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::lib::ERC20_2 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
 //     interface ::ERC20_0_instance = ::ERC20_0(0x0000000000000000000000000000000000000000000000000000000000000000)
 //     interface ::ERC20_1_instance = ::lib::ERC20_1(0x1111111111111111111111111111111111111111111111111111111111111111)
 //     interface ::ERC20_2_instance = ::ERC20_0(0x2222222222222222222222222222222222222222222222222222222222222222)
@@ -201,27 +159,6 @@ predicate Bar {
 // }
 //
 // predicate ::Foo {
-//     interface ::ERC20_0 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::lib::ERC20_1 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::lib::ERC20_2 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
 //     interface ::ERC20_0_instance = ::ERC20_0(0x0000000000000000000000000000000000000000000000000000000000000000)
 //     interface ::ERC20_1_instance = ::lib::ERC20_1(0x1111111111111111111111111111111111111111111111111111111111111111)
 //     interface ::ERC20_2_instance = ::lib::ERC20_2(0x2222222222222222222222222222222222222222222222222222222222222222)
@@ -240,27 +177,6 @@ predicate Bar {
 // }
 //
 // predicate ::Bar {
-//     interface ::ERC20_0 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::lib::ERC20_1 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
-//     interface ::lib::ERC20_2 {
-//         storage {
-//             x: int,
-//             y: bool,
-//             map: ( int => ( int => b256 ) ),
-//         }
-//     }
 //     interface ::ERC20_0_instance = ::ERC20_0(0x0000000000000000000000000000000000000000000000000000000000000000)
 //     interface ::ERC20_1_instance = ::lib::ERC20_1(0x1111111111111111111111111111111111111111111111111111111111111111)
 //     interface ::ERC20_2_instance = ::ERC20_0(0x2222222222222222222222222222222222222222222222222222222222222222)

--- a/pintc/tests/storage/missing_extern.pnt
+++ b/pintc/tests/storage/missing_extern.pnt
@@ -24,11 +24,6 @@ predicate Foo {
 // }
 //
 // predicate ::Foo {
-//     interface ::ERC20 {
-//         storage {
-//             x: int,
-//         }
-//     }
 //     interface ::ERC20Instance = ::ERC20Missing(0x1111111111111111111111111111111111111111111111111111111111111111)
 //     interface ::ERC20Instance2 = ::ERC20(0x2222222222222222222222222222222222222222222222222222222222222222)
 //     state ::x = ::ERC20Instance::storage::x;

--- a/pintc/tests/storage/storage_array.pnt
+++ b/pintc/tests/storage/storage_array.pnt
@@ -73,12 +73,6 @@ predicate Bar {
 // }
 //
 // predicate ::Bar {
-//     interface ::Foo {
-//         storage {
-//             v: int[3][2],
-//             map_to_arrays: ( int => int[3] ),
-//         }
-//     }
 //     interface ::FooInstance = ::Foo(0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE)
 //     state ::v = storage::v;
 //     state ::v1 = storage::v[1];
@@ -124,12 +118,6 @@ predicate Bar {
 // }
 //
 // predicate ::Bar {
-//     interface ::Foo {
-//         storage {
-//             v: int[3][2],
-//             map_to_arrays: ( int => int[3] ),
-//         }
-//     }
 //     interface ::FooInstance = ::Foo(0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE)
 //     state ::v: int[3][2] = storage::v;
 //     state ::v1: int[3] = storage::v[1];

--- a/pintc/tests/storage/storage_tuple.pnt
+++ b/pintc/tests/storage/storage_tuple.pnt
@@ -73,14 +73,6 @@ predicate Bar {
 // }
 //
 // predicate ::Bar {
-//     interface ::Foo {
-//         storage {
-//             u: {b256, int},
-//             t: {b256, {int, int}},
-//             w: {addr: b256, inner: {x: int, int}},
-//             map_to_tuples: ( int => {b256, {int, int}} ),
-//         }
-//     }
 //     interface ::FooInstance = ::Foo(0x1111111111111111111111111111111111111111111111111111111111111111)
 //     state ::u = storage::u;
 //     state ::u0 = storage::u.0;
@@ -132,14 +124,6 @@ predicate Bar {
 // }
 //
 // predicate ::Bar {
-//     interface ::Foo {
-//         storage {
-//             u: {b256, int},
-//             t: {b256, {int, int}},
-//             w: {addr: b256, inner: {x: int, int}},
-//             map_to_tuples: ( int => {b256, {int, int}} ),
-//         }
-//     }
 //     interface ::FooInstance = ::Foo(0x1111111111111111111111111111111111111111111111111111111111111111)
 //     state ::u: {b256, int} = storage::u;
 //     state ::u0: b256 = storage::u.0;


### PR DESCRIPTION
As per #774 this PR takes us a couple more steps towards not having a 'root' predicate.

- `interfaces` are now in `Contract`.
- `top_level_symbols` are now just `symbols` and have been wrapped in a struct.  The plan is to have an instance in `Contract` for all actual top-level symbols, and each predicate would have their own `symbols` which may not shadow the top-levels, but won't clash with other predicates.  TBC.
- `Expr::PathByKey` is gone, now we just have `Expr::PathByName` which is renamed to `Expr::Path`.  This removes the dependency between `Expr` (a globally used struct) and `VarKey` (only significant in predicates).  As a consequence there is now also no dependency between `Type` and predicates.
- Add `DisplayWithContract` which is the same as `DisplayWithPred` except just for contract contexts (like displaying `Expr` and `Type`).  This has simplified a bunch of code which needed a predicate just to generate a `Display` string, especially places like the type checker and its error messages, and has reduced the need for using `Contract::root_pred()` just as a stand-in for `DisplayWithPred`.

We're not quite there but I think pretty close to removing the 'root' predicate which will simplify things further.