### PR TITLE
Storage vectors and `__vec_len` intrinsic

### DIFF
--- a/docs/book/src/appendix/intrinsics.md
+++ b/docs/book/src/appendix/intrinsics.md
@@ -67,6 +67,14 @@ variable or a "next state" expression but can have any type.
 ---
 
 ```pint
+__vec_len(<storage access>) -> int
+```
+
+**Description:** Returns the length of a storage vector.
+
+---
+
+```pint
 __verify_ed25519(data: <any>, sig: { b256, b256 }, pub_key: b256) -> bool
 ```
 

--- a/pintc/src/error/parse_error.rs
+++ b/pintc/src/error/parse_error.rs
@@ -32,8 +32,6 @@ pub enum ParseError {
     EmptyArrayExpr { span: Span },
     #[error("missing array or map index")]
     EmptyIndexAccess { span: Span },
-    #[error("empty array types are not allowed")]
-    EmptyArrayType { span: Span },
     #[error("invalid integer `{}` as tuple index", index)]
     InvalidIntegerTupleIndex { span: Span, index: String },
     #[error("invalid value `{}` as tuple index", index)]
@@ -73,6 +71,8 @@ pub enum ParseError {
     PathTooShort { path: String, span: Span },
     #[error("bad argument splice")]
     BadSplice(Span),
+    #[error("intrinsic can only be used in a state initializer")]
+    BadStorageIntrinsic(Span),
 }
 
 impl ReportableError for ParseError {
@@ -118,13 +118,6 @@ impl ReportableError for ParseError {
             EmptyIndexAccess { span } => {
                 vec![ErrorLabel {
                     message: "missing array or map element index".to_string(),
-                    span: span.clone(),
-                    color: Color::Red,
-                }]
-            }
-            EmptyArrayType { span } => {
-                vec![ErrorLabel {
-                    message: "empty array type found".to_string(),
                     span: span.clone(),
                     color: Color::Red,
                 }]
@@ -267,6 +260,11 @@ impl ReportableError for ParseError {
                 span: span.clone(),
                 color: Color::Red,
             }],
+            BadStorageIntrinsic(span) => vec![ErrorLabel {
+                message: "intrinsic can only be used in a state initializer".to_string(),
+                span: span.clone(),
+                color: Color::Red,
+            }],
         }
     }
 
@@ -364,7 +362,6 @@ impl Spanned for ParseError {
             | UntypedVariable { span, .. }
             | EmptyArrayExpr { span }
             | EmptyIndexAccess { span }
-            | EmptyArrayType { span }
             | InvalidIntegerTupleIndex { span, .. }
             | InvalidTupleIndex { span, .. }
             | EmptyTupleExpr { span, .. }
@@ -381,6 +378,7 @@ impl Spanned for ParseError {
             | StorageAccessMustBeTopLevel { span, .. }
             | PathTooShort { span, .. }
             | BadSplice(span)
+            | BadStorageIntrinsic(span)
             | Lex { span } => span,
 
             InvalidToken => unreachable!("The `InvalidToken` error is always wrapped in `Lex`."),

--- a/pintc/src/parser/tests.rs
+++ b/pintc/src/parser/tests.rs
@@ -255,6 +255,30 @@ fn storage_types() {
         &run_parser!(storage_var_type, "(int => (int => (b256 => b256)))"),
         expect_test::expect!["( int => ( int => ( b256 => b256 ) ) )"],
     );
+
+    check(
+        &run_parser!(storage_var_type, "int[]"),
+        expect_test::expect!["int[]"],
+    );
+
+    check(
+        &run_parser!(storage_var_type, "b256[]"),
+        expect_test::expect!["b256[]"],
+    );
+
+    check(
+        &run_parser!(storage_var_type, "bool[]"),
+        expect_test::expect!["bool[]"],
+    );
+
+    // Multi dimensional vectors are not yet supported
+    check(
+        &run_parser!(storage_var_type, "int[][]"),
+        expect_test::expect![[r#"
+            expected something else, found `[`
+            @18..19: expected something else
+        "#]],
+    );
 }
 
 #[test]
@@ -2270,15 +2294,17 @@ fn array_type() {
         expect_test::expect!["{int, {real, string}}[9][::N]"],
     );
 
+    // This should fail in type checking
     check(
         &run_parser!(
             (yp::PintParser::new(), ""),
             r#"predicate test { var a: int[]; }"#
         ),
         expect_test::expect![[r#"
-            empty array types are not allowed
-            @24..29: empty array type found
-        "#]],
+
+            predicate ::test {
+                var ::a: int[];
+            }"#]],
     );
 }
 
@@ -3122,8 +3148,6 @@ fn error_recovery() {
             @161..163: empty tuple type found
             empty tuple expressions are not allowed
             @166..168: empty tuple expression found
-            empty array types are not allowed
-            @199..204: empty array type found
             missing array or map index
             @241..244: missing array or map element index
             invalid integer `0x5` as tuple index

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -405,6 +405,7 @@ pub MacroBody: Option<ExprKey> = {
 
 Type: Type = {
     <ArrayType>,
+    <VectorType>,
     <TypeAtom>,
 };
 
@@ -448,15 +449,6 @@ ArrayType: Type = {
             span: (context.span_from)(l, r),
         })
     },
-    <l:@L> <ty:TypeAtom> "[" "]" <r:@R> => {
-        let span = (context.span_from)(l, r);
-        handler.emit_err(Error::Parse {
-            error: ParseError::EmptyArrayType { span: span.clone() },
-        });
-
-        // Recover with a malformed type
-        Type::Error(span)
-    },
 };
 
 PrimitiveType: PrimitiveKind = {
@@ -480,11 +472,18 @@ TupleField: (Option<Ident>, Type) = {
 /// Storage Types ///
 /////////////////////
 
-// Does not yet allow for maps inside maps
 MapType: Type = {
     <l:@L> "(" <ty_from:Type> "=>" <ty_to:Type> ")" <r:@R> => Type::Map {
         ty_from: Box::new(ty_from),
         ty_to: Box::new(ty_to),
+        span: (context.span_from)(l, r),
+    }
+}
+
+// This only allows single dimensional vectors for the time being
+VectorType: Type = {
+    <l:@L> <ty:TypeAtom> "[" "]" <r:@R> => Type::Vector {
+        ty: Box::new(ty),
         span: (context.span_from)(l, r),
     }
 }
@@ -747,7 +746,19 @@ TermInner: Expr = {
         }
     },
     <GeneratorExpr>,
-    <IntrinsicCallExpr>,
+    <l:@L> <call:IntrinsicCallExpr> <r:@R> => {
+        if let Expr::IntrinsicCall { ref name, .. } = call {
+            if name.name == "__vec_len"
+                || name.name == "__storage_get"
+                || name.name == "__storage_get_extern"
+            {
+                handler.emit_err(Error::Parse {
+                    error: ParseError::BadStorageIntrinsic((context.span_from)(l, r)),
+                });
+            }
+        }
+        call
+    },
     <ArrayExpr>,
     <TupleExpr>,
     <l:@L> <path:Path> <r:@R> => Expr::Path(path, (context.span_from)(l, r)),
@@ -855,15 +866,24 @@ MacroCallExpr: ExprKey = {
         );
         context
             .macro_calls
-            .get_mut(&context.current_pred_key.expect("adding a macro call to the predicate"))
+            .get_mut(
+                &context
+                    .current_pred_key
+                    .expect("adding a macro call to the predicate"),
+            )
             .unwrap()
             .insert(call_key, (call_expr_key, call_data));
         call_expr_key
     },
 };
 
+IntrinsicArg: ExprKey = {
+    <Expr>,
+    <StorageTupleFieldOp>,
+}
+
 IntrinsicCallExpr: Expr = {
-    <l:@L> <ident:IntrinsicName> "(" <args:SepList<Expr, ",">> ")" <r:@R> => {
+    <l:@L> <ident:IntrinsicName> "(" <args:SepList<IntrinsicArg, ",">> ")" <r:@R> => {
         Expr::IntrinsicCall {
             name: ident,
             args,
@@ -1021,8 +1041,6 @@ StorageTupleFieldOp: ExprKey = {
 }
 
 StorageIndexOp: ExprKey = {
-    // Even though we don't allow complex types in storage maps just yet, this does support indexing
-    // into a map of maps.
     <l:@L> <expr:StorageIndexOp> "[" <index:Expr> "]" <r:@R> => {
         let span = (context.span_from)(l, r);
         context.contract.exprs.insert(

--- a/pintc/src/predicate.rs
+++ b/pintc/src/predicate.rs
@@ -244,6 +244,45 @@ impl Contract {
     pub fn is_removed_macro_call(&self, expr_key: ExprKey) -> bool {
         self.removed_macro_calls.contains_key(expr_key)
     }
+
+    /// Returns a local `StorageVar` given a var name. Panics if anything goes wrong.
+    pub fn storage_var(&self, name: &String) -> (usize, &StorageVar) {
+        let storage = &self
+            .storage
+            .as_ref()
+            .expect("a storage block must have been declared")
+            .0;
+        let storage_index = storage
+            .iter()
+            .position(|var| var.name.name == *name)
+            .expect("storage access should have been checked before");
+        (storage_index, &storage[storage_index])
+    }
+
+    /// Returns an external `StorageVar` given an interface name and a var name. Panics if anything
+    /// goes wrong.
+    pub fn external_storage_var(&self, interface: &Path, name: &String) -> (usize, &StorageVar) {
+        // Get the `interface` declaration that the storage access refers to
+        let interface = &self
+            .interfaces
+            .iter()
+            .find(|e| e.name.to_string() == *interface)
+            .expect("missing interface");
+
+        // Get the index of the storage variable in the storage block declaration
+        let storage = &interface
+            .storage
+            .as_ref()
+            .expect("a storage block must have been declared")
+            .0;
+
+        let storage_index = storage
+            .iter()
+            .position(|var| var.name.name == *name)
+            .expect("storage access should have been checked before");
+
+        (storage_index, &storage[storage_index])
+    }
 }
 
 /// An in-progress predicate, possibly malformed or containing redundant information.  Designed to

--- a/pintc/src/predicate/analyse.rs
+++ b/pintc/src/predicate/analyse.rs
@@ -49,7 +49,7 @@ impl Contract {
         self.check_undefined_types(handler);
         self.lower_newtypes(handler)?;
         self.check_storage_types(handler);
-        self.check_for_map_type_vars(handler);
+        self.check_for_storage_types_vars(handler);
         self.type_check_all_exprs(handler);
         self.check_inits(handler);
         self.check_constraint_types(handler);

--- a/pintc/src/predicate/analyse/type_check.rs
+++ b/pintc/src/predicate/analyse/type_check.rs
@@ -75,6 +75,8 @@ impl Contract {
                     inspect_type_names(handler, new_types, seen_names, ty_to)
                 }
 
+                Type::Vector { ty, .. } => inspect_type_names(handler, new_types, seen_names, ty),
+
                 Type::Error(_) | Type::Unknown(_) | Type::Primitive { .. } => Ok(()),
             }
         }
@@ -111,6 +113,8 @@ impl Contract {
 
                 Type::Map { ty_from, ty_to, .. } => get_custom_type_mut_ref(custom_path, ty_from)
                     .or_else(|| get_custom_type_mut_ref(custom_path, ty_to)),
+
+                Type::Vector { ty, .. } => get_custom_type_mut_ref(custom_path, ty),
 
                 Type::Error(_) | Type::Unknown(_) | Type::Primitive { .. } => None,
             }
@@ -196,6 +200,10 @@ impl Contract {
                 Type::Map { ty_from, ty_to, .. } => {
                     replace_custom_type(new_types, ty_from);
                     replace_custom_type(new_types, ty_to);
+                }
+
+                Type::Vector { ty, .. } => {
+                    replace_custom_type(new_types, ty);
                 }
 
                 Type::Error(_) | Type::Unknown(_) | Type::Primitive { .. } => {}
@@ -340,6 +348,16 @@ impl Contract {
                                 },
                             });
                         }
+                    } else if let Type::Vector { ref ty, .. } = ty {
+                        if !(ty.is_bool() || ty.is_int() || ty.is_b256()) {
+                            // TODO: allow arbitrary types in storage vectors
+                            handler.emit_err(Error::Compile {
+                                error: CompileError::Internal {
+                                    msg: "storage vector can only contain int, bool, or b256",
+                                    span: span.clone(),
+                                },
+                            });
+                        }
                     } else {
                         // TODO: allow arbitrary types in storage blocks
                         handler.emit_err(Error::Compile {
@@ -355,14 +373,15 @@ impl Contract {
         }
     }
 
-    pub(super) fn check_for_map_type_vars(&self, handler: &Handler) {
+    pub(super) fn check_for_storage_types_vars(&self, handler: &Handler) {
         for pred in self.preds.values() {
             // Ex. var x: ( int => int ); is disallowed
             pred.vars().for_each(|(var_key, var)| {
                 let ty = var_key.get_ty(pred);
-                if ty.is_map() {
+                if ty.is_map() || ty.is_vector() {
                     handler.emit_err(Error::Compile {
-                        error: CompileError::VarTypeIsMap {
+                        error: CompileError::VarHasStorageType {
+                            ty: self.with_ctrct(ty).to_string(),
                             span: var.span.clone(),
                         },
                     });
@@ -499,9 +518,10 @@ impl Contract {
                             });
                         }
                         // State variables of type `Map` are not allowed
-                        if state_ty.is_map() {
+                        if state_ty.is_map() || state_ty.is_vector() {
                             handler.emit_err(Error::Compile {
-                                error: CompileError::StateVarTypeIsMap {
+                                error: CompileError::StateVarHasStorageType {
+                                    ty: self.with_ctrct(state_ty).to_string(),
                                     span: state.span.clone(),
                                 },
                             });
@@ -518,9 +538,10 @@ impl Contract {
                     if !expr_ty.is_unknown() {
                         state_key_to_new_type.insert(state_key, expr_ty.clone());
                         // State variables of type `Map` are not allowed
-                        if expr_ty.is_map() {
+                        if expr_ty.is_map() || expr_ty.is_vector() {
                             handler.emit_err(Error::Compile {
-                                error: CompileError::StateVarTypeIsMap {
+                                error: CompileError::StateVarHasStorageType {
+                                    ty: self.with_ctrct(expr_ty).to_string(),
                                     span: state.span.clone(),
                                 },
                             });
@@ -1894,6 +1915,18 @@ impl Contract {
                         span: span.clone(),
                     },
                 })
+            }
+        } else if let Some(ty) = ary_ty.get_vector_element_ty() {
+            if !index_ty.is_int() {
+                Err(Error::Compile {
+                    error: CompileError::ArrayAccessWithWrongType {
+                        found_ty: self.with_ctrct(index_ty).to_string(),
+                        expected_ty: "int".to_string(),
+                        span: self.expr_key_to_span(index_expr_key),
+                    },
+                })
+            } else {
+                Ok(Inference::Type(ty.clone()))
             }
         } else {
             Err(Error::Compile {

--- a/pintc/src/predicate/transform.rs
+++ b/pintc/src/predicate/transform.rs
@@ -1,8 +1,10 @@
+mod legalize;
 mod lower;
 mod unroll;
 mod validate;
 
 use crate::error::{ErrorEmitted, Handler};
+use legalize::legalize_vector_accesses;
 use lower::{
     coalesce_prime_ops, lower_aliases, lower_casts, lower_compares_to_nil, lower_enums, lower_ifs,
     lower_imm_accesses, lower_ins, replace_const_refs,
@@ -55,6 +57,9 @@ impl super::Contract {
         // Lower casts after aliases since we're leaving `int -> real` behind, but it's
         // much easier if the `real` isn't still an alias.
         let _ = lower_casts(handler, &mut self);
+
+        // Insert OOB checks for storage vector accesses
+        let _ = legalize_vector_accesses(handler, &mut self);
 
         // Ensure that the final contract is indeed final
         if !handler.has_errors() {

--- a/pintc/src/predicate/transform/lower.rs
+++ b/pintc/src/predicate/transform/lower.rs
@@ -307,6 +307,7 @@ pub(crate) fn lower_aliases(contract: &mut Contract) {
                 replace_alias(new_types_map, ty_from);
                 replace_alias(new_types_map, ty_to);
             }
+            Type::Vector { ty, .. } => replace_alias(new_types_map, ty),
 
             Type::Error(_) | Type::Unknown(_) | Type::Primitive { .. } => {}
         }

--- a/pintc/src/predicate/transform/validate.rs
+++ b/pintc/src/predicate/transform/validate.rs
@@ -121,7 +121,11 @@ fn check_expr(
         Type::Alias { span, .. } => {
             emit_illegal_type_error!(handler, span, "type alias", "expr_types");
         }
-        Type::Array { .. } | Type::Tuple { .. } | Type::Primitive { .. } | Type::Map { .. } => {}
+        Type::Array { .. }
+        | Type::Tuple { .. }
+        | Type::Primitive { .. }
+        | Type::Map { .. }
+        | Type::Vector { .. } => {}
     }
 
     // then check the expr variant and make sure legal

--- a/pintc/src/types/display.rs
+++ b/pintc/src/types/display.rs
@@ -72,6 +72,10 @@ impl DisplayWithContract for super::Type {
                     contract.with_ctrct(ty_to.as_ref())
                 )
             }
+
+            super::Type::Vector { ty, .. } => {
+                write!(f, "{}[]", contract.with_ctrct(ty.as_ref()),)
+            }
         }
     }
 }

--- a/pintc/tests/basic_tests/parse_failure.pnt
+++ b/pintc/tests/basic_tests/parse_failure.pnt
@@ -26,8 +26,6 @@ predicate test {
 // @112..114: empty tuple type found
 // empty tuple expressions are not allowed
 // @117..119: empty tuple expression found
-// empty array types are not allowed
-// @142..147: empty array type found
 // missing array or map index
 // @176..179: missing array or map element index
 // invalid integer `0x5` as tuple index

--- a/pintc/tests/intrinsics/bad_vec_len_arg.pnt
+++ b/pintc/tests/intrinsics/bad_vec_len_arg.pnt
@@ -1,0 +1,63 @@
+storage {
+    x: int,
+    y: b256,
+    z: ( int => int ),
+    w: { int, int },
+}
+
+predicate test {
+    state x_len = __vec_len(storage::x);
+    state y_len = __vec_len(storage::y);
+    state z_len = __vec_len(storage::z);
+    state w_len = __vec_len(storage::w);
+
+    var p: int;
+    state p_len = __vec_len(p);
+    state imm_len = __vec_len(0);
+}
+
+// parsed <<<
+// storage {
+//     x: int,
+//     y: b256,
+//     z: ( int => int ),
+//     w: {int, int},
+// }
+// 
+// predicate ::test {
+//     var ::p: int;
+//     state ::x_len = __vec_len(storage::x);
+//     state ::y_len = __vec_len(storage::y);
+//     state ::z_len = __vec_len(storage::z);
+//     state ::w_len = __vec_len(storage::w);
+//     state ::p_len = __vec_len(::p);
+//     state ::imm_len = __vec_len(0);
+// }
+// >>>
+
+// typecheck_failure <<<
+// intrinsic argument must be a storage access
+// @117..138: intrinsic argument must be a storage access
+// intrinsic argument must be a storage access
+// @158..179: intrinsic argument must be a storage access
+// intrinsic argument must be a storage access
+// @199..220: intrinsic argument must be a storage access
+// intrinsic argument must be a storage access
+// @240..261: intrinsic argument must be a storage access
+// intrinsic argument must be a storage access
+// @298..310: intrinsic argument must be a storage access
+// intrinsic argument must be a storage access
+// @332..344: intrinsic argument must be a storage access
+// unable to determine expression type
+// @103..138: type of this expression is ambiguous
+// unable to determine expression type
+// @144..179: type of this expression is ambiguous
+// unable to determine expression type
+// @185..220: type of this expression is ambiguous
+// unable to determine expression type
+// @226..261: type of this expression is ambiguous
+// unable to determine expression type
+// @284..310: type of this expression is ambiguous
+// unable to determine expression type
+// @316..344: type of this expression is ambiguous
+// >>>

--- a/pintc/tests/intrinsics/bad_vec_len_placement.pnt
+++ b/pintc/tests/intrinsics/bad_vec_len_placement.pnt
@@ -1,0 +1,15 @@
+storage {
+    v: int[],
+}
+
+predicate test {
+    var v_len = __vec_len(storage::v);
+    constraint __vec_len(storage::v) == 0;
+}
+
+// parse_failure <<<
+// intrinsic can only be used in a state initializer
+// @60..81: intrinsic can only be used in a state initializer
+// intrinsic can only be used in a state initializer
+// @98..119: intrinsic can only be used in a state initializer
+// >>>

--- a/pintc/tests/intrinsics/vec_len.pnt
+++ b/pintc/tests/intrinsics/vec_len.pnt
@@ -1,0 +1,53 @@
+storage {
+    v: int[],
+    x: int,
+}
+
+interface Foo {
+    storage {
+        v: int[],
+    }
+}
+
+predicate test {
+    state l = __vec_len(storage::v);
+
+    interface FooI = Foo(0x0000000000000000000000000000000000000000000000000000000000000000);
+    state l2 = __vec_len(FooI::storage::v);
+}
+
+// parsed <<<
+// storage {
+//     v: int[],
+//     x: int,
+// }
+// interface ::Foo {
+//     storage {
+//         v: int[],
+//     }
+// }
+// 
+// predicate ::test {
+//     interface ::FooI = ::Foo(0x0000000000000000000000000000000000000000000000000000000000000000)
+//     state ::l = __vec_len(storage::v);
+//     state ::l2 = __vec_len(::FooI::storage::v);
+// }
+// >>>
+
+// flattened <<<
+// storage {
+//     v: int[],
+//     x: int,
+// }
+// interface ::Foo {
+//     storage {
+//         v: int[],
+//     }
+// }
+// 
+// predicate ::test {
+//     interface ::FooI = ::Foo(0x0000000000000000000000000000000000000000000000000000000000000000)
+//     state ::l: int = __vec_len(storage::v);
+//     state ::l2: int = __vec_len(::FooI::storage::v);
+// }
+// >>>

--- a/pintc/tests/storage/storage_vector.pnt
+++ b/pintc/tests/storage/storage_vector.pnt
@@ -1,0 +1,111 @@
+storage {
+    v0: int[],
+    v1: bool[],
+    v2: b256[],
+}
+
+interface Bar {
+    storage {
+        u0: int[],
+        u1: bool[],
+        u2: b256[],
+    }
+}
+
+predicate Foo {
+    interface BarI = Bar(0x0000000000000000000000000000000000000000000000000000000000000000);
+    state v0_0 = storage::v0[0];
+    state v0_1 = storage::v0[1];
+    state v1_1 = storage::v1[1];
+    state v2_2 = storage::v2[2];
+
+    constraint v0_0 == 0;
+    constraint v0_1 == 0;
+    constraint v0_0' == 1;
+    constraint v0_1' == 1;
+
+    state u0_0 = BarI::storage::u0[0];
+    state u0_1 = BarI::storage::u0[1];
+    state u1_1 = BarI::storage::u1[1];
+    state u2_2 = BarI::storage::u2[2];
+
+    constraint u0_0 == 0;
+    constraint u0_1 == 0;
+    constraint u0_0' == 1;
+    constraint u0_1' == 1;
+}
+
+// parsed <<<
+// storage {
+//     v0: int[],
+//     v1: bool[],
+//     v2: b256[],
+// }
+// interface ::Bar {
+//     storage {
+//         u0: int[],
+//         u1: bool[],
+//         u2: b256[],
+//     }
+// }
+// 
+// predicate ::Foo {
+//     interface ::BarI = ::Bar(0x0000000000000000000000000000000000000000000000000000000000000000)
+//     state ::v0_0 = storage::v0[0];
+//     state ::v0_1 = storage::v0[1];
+//     state ::v1_1 = storage::v1[1];
+//     state ::v2_2 = storage::v2[2];
+//     state ::u0_0 = ::BarI::storage::u0[0];
+//     state ::u0_1 = ::BarI::storage::u0[1];
+//     state ::u1_1 = ::BarI::storage::u1[1];
+//     state ::u2_2 = ::BarI::storage::u2[2];
+//     constraint (::v0_0 == 0);
+//     constraint (::v0_1 == 0);
+//     constraint (::v0_0' == 1);
+//     constraint (::v0_1' == 1);
+//     constraint (::u0_0 == 0);
+//     constraint (::u0_1 == 0);
+//     constraint (::u0_0' == 1);
+//     constraint (::u0_1' == 1);
+// }
+// >>>
+
+// flattened <<<
+// storage {
+//     v0: int[],
+//     v1: bool[],
+//     v2: b256[],
+// }
+// interface ::Bar {
+//     storage {
+//         u0: int[],
+//         u1: bool[],
+//         u2: b256[],
+//     }
+// }
+// 
+// predicate ::Foo {
+//     interface ::BarI = ::Bar(0x0000000000000000000000000000000000000000000000000000000000000000)
+//     state ::v0_0: int = storage::v0[0];
+//     state ::v0_1: int = storage::v0[1];
+//     state ::v1_1: bool = storage::v1[1];
+//     state ::v2_2: b256 = storage::v2[2];
+//     state ::u0_0: int = ::BarI::storage::u0[0];
+//     state ::u0_1: int = ::BarI::storage::u0[1];
+//     state ::u1_1: bool = ::BarI::storage::u1[1];
+//     state ::u2_2: b256 = ::BarI::storage::u2[2];
+//     state __v0_len: int = __vec_len(storage::v0);
+//     constraint (::v0_0 == 0);
+//     constraint (::v0_1 == 0);
+//     constraint (::v0_0' == 1);
+//     constraint (::v0_1' == 1);
+//     constraint (::u0_0 == 0);
+//     constraint (::u0_1 == 0);
+//     constraint (::u0_0' == 1);
+//     constraint (::u0_1' == 1);
+//     constraint (1 < __v0_len);
+//     constraint (0 < __v0_len);
+//     constraint (1 < __v0_len');
+//     constraint (0 < __v0_len');
+// }
+// >>>

--- a/pintc/tests/types/bad_state_type.pnt
+++ b/pintc/tests/types/bad_state_type.pnt
@@ -28,8 +28,8 @@ predicate Foo {
 // >>>
 
 // typecheck_failure <<<
-// state variables cannot have storage map type
-// @104..130: found state variable of type storage map here
-// state variables cannot have storage map type
-// @136..172: found state variable of type storage map here
+// state variables cannot have storage types
+// @104..130: found state variable of storage type ( int => bool ) here
+// state variables cannot have storage types
+// @136..172: found state variable of storage type ( bool => b256 ) here
 // >>>

--- a/pintc/tests/types/bad_var_map_type.pnt
+++ b/pintc/tests/types/bad_var_map_type.pnt
@@ -15,8 +15,8 @@ predicate test {
 // >>>
 
 // typecheck_failure <<<
-// variables cannot have storage map type
-// @53..54: found variable of type storage map here
-// variables cannot have storage map type
-// @71..72: found variable of type storage map here
+// variables cannot have storage types
+// @53..54: found variable of storage type ::MyMap (( int => int )) here
+// variables cannot have storage types
+// @71..72: found variable of storage type ( int => int ) here
 // >>>

--- a/pintc/tests/types/empty_array.pnt
+++ b/pintc/tests/types/empty_array.pnt
@@ -2,19 +2,24 @@ predicate test {
     var ary: int[10];
 
     constraint ary != [];
+
+    var vector: int[];
 }
 
 // parsed <<<
 // predicate ::test {
 //     var ::ary: int[10];
+//     var ::vector: int[];
 //     constraint (::ary != []);
 // }
 // >>>
 
 // typecheck_failure <<<
-// illegal empty array value
-// @62..64: empty array values are illegal
-// constraint expression type error
-// @44..64: constraint expression has unknown type
-// @44..64: expecting type `bool`
+// variables cannot have storage types
+// @75..81: found variable of storage type int[] here
+//+illegal empty array value
+//+@62..64: empty array values are illegal
+//+constraint expression type error
+//+@44..64: constraint expression has unknown type
+//+@44..64: expecting type `bool`
 // >>>

--- a/tests/validation_tests/storage_vector.pnt
+++ b/tests/validation_tests/storage_vector.pnt
@@ -1,0 +1,124 @@
+// db <<<
+// 2, 3
+// 2 0, 13
+// 2 1, 14
+// 2 2, 15
+// 0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE, 2, 3
+// 0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE, 2 0, 13
+// 0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE, 2 1, 14
+// 0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE, 2 2, 15
+// >>>
+
+storage {
+    x: int,
+    v0: int[],
+    v1: int[],
+    v2: b256[],
+}
+
+interface Foo {
+    storage {
+        x: int,
+        v0: int[],
+        v1: int[],
+        v2: b256[],
+    }
+}
+
+predicate Bar {
+    // Test external storage vectors
+
+    // v0 starts empty
+    state v0_0 = storage::v0[0];
+    state v0_1 = storage::v0[1];
+    state v0_2 = storage::v0[2];
+    state v0_len = __vec_len(storage::v0);
+
+    constraint v0_len == nil || v0_len == 0;
+    constraint v0_len' == 3;
+    constraint v0_0' == 42;
+    constraint v0_1' == 43;
+    constraint v0_2' == 44;
+
+    // v1 starts with 3 elements and then expands to 5
+    state v1_0 = storage::v1[0];
+    state v1_1 = storage::v1[1];
+    state v1_2 = storage::v1[2];
+    state v1_len = __vec_len(storage::v1);
+
+    constraint v1_len == 3;
+    constraint v1_0 == 13;
+    constraint v1_1 == 14;
+    constraint v1_2 == 15;
+
+    state v1_3 = storage::v1[3];
+    state v1_4 = storage::v1[4];
+
+    constraint v1_len' == 5;
+    constraint v1_0' == 13; // did not change
+    constraint v1_1' == 14; // did not change
+    constraint v1_2' == 15; // did not change
+    constraint v1_3' == 16; // newly added
+    constraint v1_4' == 17; // newly added
+
+    // v2 starts empty
+    state v2_0 = storage::v2[0];
+    state v2_1 = storage::v2[1];
+    state v2_2 = storage::v2[2];
+    state v2_len = __vec_len(storage::v2);
+   
+    constraint v2_len == nil || v2_len == 0;
+    constraint v2_len' == 3;
+    constraint v2_0' == 0x0000000000000001000000000000000200000000000000030000000000000004;
+    constraint v2_1' == nil;
+    constraint v2_2' == 0x0000000000000009000000000000000A000000000000000B000000000000000C;
+
+
+    // Test external storage vectors
+    interface FooInstance = Foo(0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE);
+
+    // v0 starts empty
+    state foo_v0_0 = FooInstance::storage::v0[0];
+    state foo_v0_1 = FooInstance::storage::v0[1];
+    state foo_v0_2 = FooInstance::storage::v0[2];
+    state foo_v0_len = __vec_len(FooInstance::storage::v0);
+
+    constraint foo_v0_len == nil || foo_v0_len == 0;
+    constraint foo_v0_len' == 3;
+    constraint foo_v0_0' == 42;
+    constraint foo_v0_1' == 43;
+    constraint foo_v0_2' == 44;
+
+    // v1 starts with 3 elements and then expands to 5
+    state foo_v1_0 = FooInstance::storage::v1[0];
+    state foo_v1_1 = FooInstance::storage::v1[1];
+    state foo_v1_2 = FooInstance::storage::v1[2];
+    state foo_v1_len = __vec_len(FooInstance::storage::v1);
+
+    constraint foo_v1_len == 3;
+    constraint foo_v1_0 == 13;
+    constraint foo_v1_1 == 14;
+    constraint foo_v1_2 == 15;
+
+    state foo_v1_3 = FooInstance::storage::v1[3];
+    state foo_v1_4 = FooInstance::storage::v1[4];
+
+    constraint foo_v1_len' == 5;
+    constraint foo_v1_0' == 13; // did not change
+    constraint foo_v1_1' == 14; // did not change
+    constraint foo_v1_2' == 15; // did not change
+    constraint foo_v1_3' == 16; // newly added
+    constraint foo_v1_4' == 17; // newly added
+
+    // v2 starts empty
+    state foo_v2_0 = FooInstance::storage::v2[0];
+    state foo_v2_1 = FooInstance::storage::v2[1];
+    state foo_v2_2 = FooInstance::storage::v2[2];
+    state foo_v2_len = __vec_len(FooInstance::storage::v2);
+   
+    constraint foo_v2_len == nil || foo_v2_len == 0;
+    constraint foo_v2_len' == 3;
+    constraint foo_v2_0' == 0x0000000000000001000000000000000200000000000000030000000000000004;
+    constraint foo_v2_1' == nil;
+    constraint foo_v2_2' == 0x0000000000000009000000000000000A000000000000000B000000000000000C;
+}

--- a/tests/validation_tests/storage_vector.toml
+++ b/tests/validation_tests/storage_vector.toml
@@ -1,0 +1,37 @@
+[[data]]
+decision_variables = []
+predicate_to_solve = { set = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", predicate = "::Bar" }
+state_mutations = [
+  { key = [1], value = [3] },     # length
+  { key = [1, 0], value = [42] }, # v0[0]
+  { key = [1, 1], value = [43] }, # v0[1]
+  { key = [1, 2], value = [44] }, # v0[2]
+
+  { key = [2], value = [5] },     # length
+  { key = [2, 3], value = [16] }, # v1[3]
+  { key = [2, 4], value = [17] }, # v1[4]
+
+  { key = [3], value = [3] },                # length
+  { key = [3, 0], value = [1, 2, 3, 4] },    # v2[0]
+  { key = [3, 1], value = [] },              # v2[1]
+  { key = [3, 2], value = [9, 10, 11, 12] }, # v2[2]
+]
+
+[[data]]
+decision_variables = []
+predicate_to_solve = { set = "0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE", predicate = "" }
+state_mutations = [
+  { key = [1], value = [3] },     # length
+  { key = [1, 0], value = [42] }, # v0[0]
+  { key = [1, 1], value = [43] }, # v0[1]
+  { key = [1, 2], value = [44] }, # v0[2]
+
+  { key = [2], value = [5] },     # length
+  { key = [2, 3], value = [16] }, # v1[3]
+  { key = [2, 4], value = [17] }, # v1[4]
+
+  { key = [3], value = [3] },                # length
+  { key = [3, 0], value = [1, 2, 3, 4] },    # v2[0]
+  { key = [3, 1], value = [] },              # v2[1]
+  { key = [3, 2], value = [9, 10, 11, 12] }, # v2[2]
+]


### PR DESCRIPTION
Adds a storage vector type that can only be used in storage.
* New intrinsic `__vec_len` that returns the length of a vector and should only be used as a storage access, i.e., to initialize a `state` variable. I expect this intrinsic to be wrapped in a `macro` when we have a standard library.
* A storage vector stores its length in storage, at the base key.
* Keys in a storage vectors are assigned similarly to storage maps.
* Add OOB checks in the flattening phase.
* **Currently, only 1-dimensional vectors of basic types are supported.**