### PR TITLE
Finalise predicate refactor.

### DIFF
--- a/pintc/src/error/compile_error.rs
+++ b/pintc/src/error/compile_error.rs
@@ -286,8 +286,8 @@ pub enum CompileError {
         decl_span: Span,
         use_span: Span,
     },
-    #[error("non-primitive const declaration")]
-    TemporaryNonPrimitiveConst { name: String, span: Span },
+    #[error("invalid range for `in` operator")]
+    InRangeInvalid { found_ty: String, span: Span },
 }
 
 // This is here purely at the suggestion of Clippy, who pointed out that these error variants are
@@ -1023,9 +1023,9 @@ impl ReportableError for CompileError {
                 },
             ],
 
-            TemporaryNonPrimitiveConst { name, span } => vec![ErrorLabel {
+            InRangeInvalid { found_ty, span } => vec![ErrorLabel {
                 message: format!(
-                    "constant declaration `{name}` must not have a non-primitive type"
+                    "`in` operator range must be either an enum or an array, found `{found_ty}`"
                 ),
                 span: span.clone(),
                 color: Color::Red,
@@ -1141,11 +1141,6 @@ impl ReportableError for CompileError {
                 "only `enum` and `type` declarations are allowed outside a predicate".to_string(),
             ),
 
-            TemporaryNonPrimitiveConst { .. } => Some(
-                "constant immediate arrays and tuples will be supported in a future update"
-                    .to_string(),
-            ),
-
             Internal { .. }
             | FileIO { .. }
             | MacroNotFound { .. }
@@ -1199,7 +1194,8 @@ impl ReportableError for CompileError {
             | IntrinsicArgMustBeStorageAccess { .. }
             | MismatchedIntrinsicArgType { .. }
             | CompareToNilError { .. }
-            | RecursiveNewType { .. } => None,
+            | RecursiveNewType { .. }
+            | InRangeInvalid { .. } => None,
         }
     }
 
@@ -1362,7 +1358,7 @@ impl Spanned for CompileError {
             | IntrinsicArgMustBeStorageAccess { span, .. }
             | CompareToNilError { span, .. }
             | RecursiveNewType { use_span: span, .. }
-            | TemporaryNonPrimitiveConst { span, .. } => span,
+            | InRangeInvalid { span, .. } => span,
 
             SelectBranchesTypeMismatch { large_err }
             | OperatorTypeError { large_err, .. }

--- a/pintc/src/expr/evaluate.rs
+++ b/pintc/src/expr/evaluate.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use fxhash::FxHashMap;
 
+#[derive(Default)]
 pub(crate) struct Evaluator {
     enum_values: FxHashMap<Path, Imm>,
     scope_values: FxHashMap<Path, Imm>,

--- a/pintc/src/parser.rs
+++ b/pintc/src/parser.rs
@@ -214,7 +214,7 @@ impl<'a> ProjectParser<'a> {
         for (current_pred, call_expr_key, body_expr_key, span) in call_replacements {
             if let Some(body_expr_key) = body_expr_key {
                 self.contract
-                    .replace_exprs(current_pred, call_expr_key, body_expr_key);
+                    .replace_exprs(Some(current_pred), call_expr_key, body_expr_key);
             } else {
                 // Keep track of the removed macro for type-checking, in case the predicate
                 // erroneously expected the macro call to be an expression (and not just

--- a/pintc/src/predicate/analyse/type_check.rs
+++ b/pintc/src/predicate/analyse/type_check.rs
@@ -1786,9 +1786,9 @@ impl Contract {
                     }
                 } else {
                     Err(Error::Compile {
-                        error: CompileError::Internal {
-                            msg: "range ty is not numeric or array?",
-                            span: span.clone(),
+                        error: CompileError::InRangeInvalid {
+                            found_ty: self.with_ctrct(collection_ty).to_string(),
+                            span: self.expr_key_to_span(collection_key),
                         },
                     })
                 }

--- a/pintc/src/predicate/exprs.rs
+++ b/pintc/src/predicate/exprs.rs
@@ -175,6 +175,41 @@ impl<'a> ExprsIter<'a> {
             visited: HashSet::default(),
         }
     }
+
+    pub(super) fn new_by_expr_set(
+        contract: &'a Contract,
+        pred_key: Option<PredKey>,
+        with_consts: bool,
+        with_array_ranges: bool,
+    ) -> ExprsIter<'a> {
+        let mut queue = Vec::default();
+
+        // Add the predicate root set.
+        if let Some(pred_key) = pred_key {
+            queue.extend(contract.root_set(pred_key));
+        }
+
+        // Add the consts.
+        if with_consts {
+            queue.extend(
+                contract
+                    .consts
+                    .iter()
+                    .map(|(_, super::Const { expr, .. })| expr),
+            );
+        }
+
+        // Add the array range expressions from storage, interfaces and new-types.
+        if with_array_ranges {
+            queue.extend(contract.root_exprs());
+        }
+
+        ExprsIter {
+            contract,
+            queue,
+            visited: HashSet::default(),
+        }
+    }
 }
 
 impl<'a> Iterator for ExprsIter<'a> {

--- a/pintc/src/predicate/transform/lower.rs
+++ b/pintc/src/predicate/transform/lower.rs
@@ -2,7 +2,8 @@ use crate::{
     error::{CompileError, Error, ErrorEmitted, Handler},
     expr::{evaluate::Evaluator, BinaryOp, Expr, Ident, Immediate, TupleAccess, UnaryOp},
     predicate::{
-        BlockStatement, Const, ConstraintDecl, Contract, ExprKey, IfDecl, PredKey, StorageVar, Var,
+        BlockStatement, Const, ConstraintDecl, Contract, ExprKey, ExprsIter, IfDecl, PredKey,
+        StorageVar, Var,
     },
     span::{empty_span, Spanned},
     types::{EnumDecl, NewTypeDecl, PrimitiveKind, Type},
@@ -105,7 +106,7 @@ pub(crate) fn lower_enums(handler: &Handler, contract: &mut Contract) -> Result<
                 },
                 int_ty.clone(),
             );
-            contract.replace_exprs(pred_key, old_expr_key, new_expr_key);
+            contract.replace_exprs(Some(pred_key), old_expr_key, new_expr_key);
         }
 
         // Replace any var or state enum type with int.  Also add constraints to disallow vars or state
@@ -269,7 +270,7 @@ pub(crate) fn lower_casts(handler: &Handler, contract: &mut Contract) -> Result<
         }
 
         for (old_expr_key, new_expr_key) in replacements {
-            contract.replace_exprs(pred_key, old_expr_key, new_expr_key);
+            contract.replace_exprs(Some(pred_key), old_expr_key, new_expr_key);
         }
     }
 
@@ -340,6 +341,97 @@ pub(crate) fn lower_aliases(contract: &mut Contract) {
     }
 }
 
+pub(crate) fn lower_array_ranges(
+    handler: &Handler,
+    contract: &mut Contract,
+) -> Result<(), ErrorEmitted> {
+    // The type checker will have confirmed that every array range expression has an integer (or
+    // enum) _type_. Find every single array range expression which isn't already an int primitive.
+    // (One day we'll have `var` ranges, but we'll ignore them.)
+
+    // Check if an expr key is to an immediate.
+    let is_not_immediate = |contract: &Contract, expr_key: ExprKey| {
+        !matches!(expr_key.get(contract), Expr::Immediate { .. })
+    };
+
+    // Get an array range expression from a type iff it's not already an immediate.
+    let ty_non_int_range_expr = |contract: &Contract, pred_key: Option<PredKey>, ty: &Type| {
+        ty.get_array_range_expr().and_then(|range_expr_key| {
+            is_not_immediate(contract, range_expr_key).then_some((pred_key, range_expr_key))
+        })
+    };
+
+    // Get all the non-immediate array range exprs from the contract root exprs.
+    let mut array_range_expr_keys: Vec<(Option<PredKey>, ExprKey)> = contract
+        .root_exprs()
+        .filter_map(|range_expr_key| {
+            is_not_immediate(contract, range_expr_key).then_some((None, range_expr_key))
+        })
+        .collect();
+
+    for pred_key in contract.preds.keys() {
+        array_range_expr_keys.extend(contract.exprs(pred_key).filter_map(|expr_key| {
+            ty_non_int_range_expr(contract, Some(pred_key), expr_key.get_ty(contract))
+        }));
+
+        let pred = &contract.preds[pred_key];
+
+        array_range_expr_keys.extend(pred.vars.vars().filter_map(|(var_key, _var)| {
+            ty_non_int_range_expr(contract, Some(pred_key), var_key.get_ty(pred))
+        }));
+
+        array_range_expr_keys.extend(pred.states.states().filter_map(|(state_key, _state)| {
+            ty_non_int_range_expr(contract, Some(pred_key), state_key.get_ty(pred))
+        }));
+    }
+
+    // Now evaluate them all.  This pass should be after const decls have been resolved/replaced
+    // and enums have been lowered, so the evaluator should be fairly simple.
+    // TODO: It seems lower_enums() isn't lowering within array ranges, so we need to included them
+    // here.
+    let evaluator = Evaluator::new(&contract.enums);
+    let mut eval_memos: FxHashMap<ExprKey, ExprKey> = FxHashMap::default();
+
+    let int_ty = Type::Primitive {
+        kind: PrimitiveKind::Int,
+        span: empty_span(),
+    };
+
+    for (pred_key, old_range_expr_key) in array_range_expr_keys {
+        let new_range_expr_key = match eval_memos.get(&old_range_expr_key) {
+            Some(key) => *key,
+            None => {
+                // The type checker should already ensure that our immediate value returned is an int.
+                let value = evaluator.evaluate_key(&old_range_expr_key, handler, contract)?;
+                if !matches!(value, Immediate::Int(_)) {
+                    return Err(handler.emit_err(Error::Compile {
+                        error: CompileError::Internal {
+                            msg: "array range expression evaluates to non int immediate",
+                            span: contract.expr_key_to_span(old_range_expr_key),
+                        },
+                    }));
+                }
+
+                // Create a new Primitive expr for the new range.
+                let new_expr_key = contract.exprs.insert(
+                    Expr::Immediate {
+                        value,
+                        span: contract.expr_key_to_span(old_range_expr_key),
+                    },
+                    int_ty.clone(),
+                );
+
+                eval_memos.insert(old_range_expr_key, new_expr_key);
+                new_expr_key
+            }
+        };
+
+        contract.replace_exprs(pred_key, old_range_expr_key, new_range_expr_key);
+    }
+
+    Ok(())
+}
+
 pub(crate) fn lower_imm_accesses(
     handler: &Handler,
     contract: &mut Contract,
@@ -347,8 +439,7 @@ pub(crate) fn lower_imm_accesses(
     let pred_keys = contract.preds.keys().collect::<Vec<_>>();
 
     let mut replace_direct_accesses = |pred_key: PredKey| {
-        let candidates = contract
-            .exprs(pred_key)
+        let candidates = ExprsIter::new_by_expr_set(contract, Some(pred_key), false, true)
             .filter_map(|expr_key| match expr_key.get(contract) {
                 Expr::Index { expr, index, .. } => expr.try_get(contract).and_then(|array_expr| {
                     let is_array_expr = matches!(array_expr, Expr::Array { .. });
@@ -530,7 +621,7 @@ pub(crate) fn lower_imm_accesses(
         // Iterate for each replacement without borrowing.
         while let Some((old_expr_key, new_expr_key)) = replacements.pop() {
             // Replace the old with the new throughout the Pred.
-            contract.replace_exprs(pred_key, old_expr_key, new_expr_key);
+            contract.replace_exprs(Some(pred_key), old_expr_key, new_expr_key);
             contract.exprs.remove(old_expr_key);
 
             // But _also_ replace the old within `replacements` in case any of our new keys is now
@@ -684,7 +775,7 @@ pub(crate) fn lower_ins(handler: &Handler, contract: &mut Contract) -> Result<()
                 bool_ty.clone(),
             );
 
-            contract.replace_exprs(pred_key, in_expr_key, and_key);
+            contract.replace_exprs(Some(pred_key), in_expr_key, and_key);
         }
 
         let int_ty = Type::Primitive {
@@ -741,7 +832,7 @@ pub(crate) fn lower_ins(handler: &Handler, contract: &mut Contract) -> Result<()
                 })
                 .expect("can't have empty array expressions");
 
-            contract.replace_exprs(pred_key, in_expr_key, or_key);
+            contract.replace_exprs(Some(pred_key), in_expr_key, or_key);
         }
     }
 
@@ -845,7 +936,7 @@ pub(crate) fn lower_compares_to_nil(contract: &mut Contract) {
                 _ => unreachable!("both operands cannot be non-nil simultaneously at this stage"),
             };
 
-            contract.replace_exprs(pred_key, *old_bin_op, new_bin_op);
+            contract.replace_exprs(Some(pred_key), *old_bin_op, new_bin_op);
         }
     }
 }
@@ -1003,9 +1094,9 @@ pub(super) fn replace_const_refs(contract: &mut Contract) {
         .collect::<Vec<_>>();
 
     for pred_key in contract.preds.keys().collect::<Vec<_>>() {
-        // Find all the paths which refer to a const and link them.
-        let const_refs = contract
-            .exprs(pred_key)
+        // Find all the paths which refer to a const and link them.  Iterate over all predicate
+        // exprs and array range expressions.
+        let const_refs = ExprsIter::new_by_expr_set(contract, Some(pred_key), false, true)
             .filter_map(|path_expr_key| {
                 if let Expr::Path(path, _span) = path_expr_key.get(contract) {
                     consts.iter().find_map(|(const_path, const_expr_key)| {
@@ -1019,7 +1110,7 @@ pub(super) fn replace_const_refs(contract: &mut Contract) {
 
         // Replace all paths to consts with the consts themselves.
         for (old_expr_key, new_expr_key) in const_refs {
-            contract.replace_exprs(pred_key, old_expr_key, new_expr_key);
+            contract.replace_exprs(Some(pred_key), old_expr_key, new_expr_key);
         }
     }
 }
@@ -1057,7 +1148,7 @@ pub(super) fn coalesce_prime_ops(contract: &mut Contract) {
             old_key: ExprKey,
             new_key: ExprKey,
         ) {
-            contract.replace_exprs(pred_key, old_key, new_key);
+            contract.replace_exprs(Some(pred_key), old_key, new_key);
 
             for (ref mut op_key, ref mut arg_key) in work_list {
                 if *op_key == old_key {

--- a/pintc/src/predicate/transform/lower.rs
+++ b/pintc/src/predicate/transform/lower.rs
@@ -1018,10 +1018,9 @@ pub(super) fn replace_const_refs(contract: &mut Contract) {
             .collect::<Vec<_>>();
 
         // Replace all paths to consts with the consts themselves.
-        contract.replace_exprs_by_map(
-            pred_key,
-            &FxHashMap::from_iter(const_refs.into_iter().map(|refs| (refs.0, refs.1))),
-        );
+        for (old_expr_key, new_expr_key) in const_refs {
+            contract.replace_exprs(pred_key, old_expr_key, new_expr_key);
+        }
     }
 }
 

--- a/pintc/src/predicate/transform/unroll.rs
+++ b/pintc/src/predicate/transform/unroll.rs
@@ -243,7 +243,7 @@ pub(crate) fn unroll_generators(
             // On success, update the key of the generator to map to the new unrolled expression.
             let generator = old_generator_key.get(contract).clone();
             if let Ok(unrolled_generator_key) = unroll_generator(handler, contract, generator) {
-                contract.replace_exprs(pred_key, old_generator_key, unrolled_generator_key);
+                contract.replace_exprs(Some(pred_key), old_generator_key, unrolled_generator_key);
             }
         }
 

--- a/pintc/src/types.rs
+++ b/pintc/src/types.rs
@@ -209,6 +209,7 @@ impl Type {
         range_expr: &Expr,
         contract: &Contract,
     ) -> Result<i64, ErrorEmitted> {
+        // TODO: REMOVE THIS.  WE'RE LOWERING IN A PASS.
         if let Expr::Path(path, _) = range_expr {
             // It's hopefully an enum for the range expression.
             if let Some(size) = contract.enums.iter().find_map(|enum_decl| {
@@ -322,17 +323,14 @@ impl Type {
             Self::Array {
                 ty, range, size, ..
             } => Ok(ty.size(handler, contract)?
-                * size.unwrap_or(
-                    Self::get_array_size_from_range_expr(
-                        handler,
-                        range
-                            .as_ref()
-                            .and_then(|e| e.try_get(contract))
-                            .expect("expr key guaranteed to exist"),
-                        contract,
-                    )
-                    .unwrap(),
-                ) as usize),
+                * size.unwrap_or(Self::get_array_size_from_range_expr(
+                    handler,
+                    range
+                        .as_ref()
+                        .and_then(|e| e.try_get(contract))
+                        .expect("expr key guaranteed to exist"),
+                    contract,
+                )?) as usize),
 
             // The point here is that a `Map` takes up a storage slot, even though it doesn't
             // actually store anything in it. The `Map` type is not really allowed anywhere else,
@@ -341,6 +339,7 @@ impl Type {
 
             // `Vector` also takes up a single storage slot that stores the length of the vector
             Self::Vector { .. } => Ok(1),
+
             _ => unimplemented!("Size of type is not yet specified"),
         }
     }

--- a/pintc/src/types.rs
+++ b/pintc/src/types.rs
@@ -558,6 +558,38 @@ impl Type {
             }
         }
     }
+
+    pub fn replace_type_expr(&mut self, old_expr: ExprKey, new_expr: ExprKey) {
+        match self {
+            Type::Array { ty, range, .. } => {
+                // Arrays are the only type which have an expr key.
+                if let Some(range) = range {
+                    if *range == old_expr {
+                        *range = new_expr;
+                    }
+                }
+
+                ty.replace_type_expr(old_expr, new_expr);
+            }
+
+            Type::Tuple { fields, .. } => {
+                fields
+                    .iter_mut()
+                    .for_each(|(_, field_ty)| field_ty.replace_type_expr(old_expr, new_expr));
+            }
+
+            Type::Alias { ty, .. } => ty.replace_type_expr(old_expr, new_expr),
+
+            Type::Map { ty_from, ty_to, .. } => {
+                ty_from.replace_type_expr(old_expr, new_expr);
+                ty_to.replace_type_expr(old_expr, new_expr);
+            }
+
+            Type::Vector { ty, .. } => ty.replace_type_expr(old_expr, new_expr),
+
+            Type::Error(_) | Type::Unknown(_) | Type::Primitive { .. } | Type::Custom { .. } => {}
+        }
+    }
 }
 
 impl Spanned for Type {

--- a/pintc/tests/consts/dependent.pnt
+++ b/pintc/tests/consts/dependent.pnt
@@ -1,12 +1,10 @@
-// Non-primitive consts are temporarily disabled.  Re-enable when they're back.
-
 const a = b * 2;
 const b = c + d;
 const c = 11;
 const d = c + c;
 
-//const e = { c, 22 };
-//const f = [a, b, c];
+const e = { c, 22 };
+const f = [a, b, c];
 
 predicate test {
     var x: int;
@@ -14,7 +12,9 @@ predicate test {
 }
 
 // parsed <<<
+// const ::f = [::a, ::b, ::c];
 // const ::b = (::c + ::d);
+// const ::e = {::c, 22};
 // const ::d = (::c + ::c);
 // const ::a = (::b * 2);
 // const ::c = 11;
@@ -26,7 +26,9 @@ predicate test {
 // >>>
 
 // flattened <<<
+// const ::f: int[_] = [66, 33, 11];
 // const ::b: int = 33;
+// const ::e: {int, int} = {11, 22};
 // const ::d: int = 22;
 // const ::a: int = 66;
 // const ::c: int = 11;

--- a/pintc/tests/consts/index_out_of_bounds.pnt
+++ b/pintc/tests/consts/index_out_of_bounds.pnt
@@ -12,13 +12,9 @@ predicate test {
 // }
 // >>>
 
-// typecheck_failure <<<
-// non-primitive const declaration
-// @18..30: constant declaration `::a` must not have a non-primitive type
-// constant immediate arrays and tuples will be supported in a future update
-// >>>
-
 // flattening_failure <<<
 // attempt to access array with out of bounds index
-// @46..47: array index is out of bounds
+// @67..68: array index is out of bounds
+// attempt to access array with out of bounds index
+// @67..68: array index is out of bounds
 // >>>

--- a/pintc/tests/consts/simple.pnt
+++ b/pintc/tests/consts/simple.pnt
@@ -5,10 +5,10 @@ const b = 0x2222222222222222222222222222222222222222222222222222222222222222;
 const c: int = 33;
 const d: b256 = 0x4444444444444444444444444444444444444444444444444444444444444444;
 const e = 0x5555555555555555555555555555555555555555555555555555555555555555 == 0x5555555555555555555555555555555555555555555555555555555555555555;
-//const f = {66, 77};
-//const g = [88, 99];
-//const h: { int, bool } = { 1010, false };
-//const i: bool[3] = [false, true, true];
+const f = {66, 77};
+const g = [88, 99];
+const h: { int, bool } = { 1010, false };
+const i: bool[3] = [false, true, true];
 
 enum JacketColour = Cream | Bone | White | OffWhite | Ivory | Beige;
 const j = JacketColour::Beige; // Yes.
@@ -21,52 +21,72 @@ predicate test {
     var r: b256;
     constraint r != b && r != d;
 
-    //var s = f.1;
-    //var t = g[1];
+    var s = f.1;
+    var t = g[1];
 
-    //var u: bool;
-    //constraint u == h.1 && u != i[2];
+    var u: bool;
+    constraint u == h.1 && u != i[2];
 
     var v: JacketColour;
     constraint v != j && v != k;
 }
 
 // parsed <<<
-// const ::j = ::JacketColour::Beige;
+// const ::i: bool[3] = [false, true, true];
 // const ::b = 0x2222222222222222222222222222222222222222222222222222222222222222;
+// const ::h: {int, bool} = {1010, false};
 // const ::e = (0x5555555555555555555555555555555555555555555555555555555555555555 == 0x5555555555555555555555555555555555555555555555555555555555555555);
 // const ::k: ::JacketColour = ::JacketColour::Bone;
 // const ::d: b256 = 0x4444444444444444444444444444444444444444444444444444444444444444;
 // const ::a = 11;
+// const ::g = [88, 99];
+// const ::j = ::JacketColour::Beige;
+// const ::f = {66, 77};
 // const ::c: int = 33;
 // enum ::JacketColour = Cream | Bone | White | OffWhite | Ivory | Beige;
 //
 // predicate ::test {
 //     var ::q: int;
 //     var ::r: b256;
+//     var ::s;
+//     var ::t;
+//     var ::u: bool;
 //     var ::v: ::JacketColour;
 //     constraint ((::q > ::a) && (::q < ::c));
 //     constraint ((::r != ::b) && (::r != ::d));
+//     constraint (::s == ::f.1);
+//     constraint (::t == ::g[1]);
+//     constraint ((::u == ::h.1) && (::u != ::i[2]));
 //     constraint ((::v != ::j) && (::v != ::k));
 // }
 // >>>
 
 // flattened <<<
-// const ::j: ::JacketColour = 5;
+// const ::i: bool[3] = [false, true, true];
 // const ::b: b256 = 0x2222222222222222222222222222222222222222222222222222222222222222;
+// const ::h: {int, bool} = {1010, false};
 // const ::e: bool = true;
 // const ::k: ::JacketColour = 1;
 // const ::d: b256 = 0x4444444444444444444444444444444444444444444444444444444444444444;
 // const ::a: int = 11;
+// const ::g: int[_] = [88, 99];
+// const ::j: ::JacketColour = 5;
+// const ::f: {int, int} = {66, 77};
 // const ::c: int = 33;
 // enum ::JacketColour = Cream | Bone | White | OffWhite | Ivory | Beige;
 //
 // predicate ::test {
 //     var ::q: int;
 //     var ::r: b256;
+//     var ::s: int;
+//     var ::t: int;
+//     var ::u: bool;
 //     var ::v: int;
 //     constraint ((::q > 11) && (::q < 33));
 //     constraint ((::r != 0x2222222222222222222222222222222222222222222222222222222222222222) && (::r != 0x4444444444444444444444444444444444444444444444444444444444444444));
+//     constraint (::s == 77);
+//     constraint (::t == 99);
+//     constraint ((::u == false) && (::u != true));
 //     constraint ((::v != 5) && (::v != 1));
 //     constraint (::v >= 0);
 //     constraint (::v <= 5);

--- a/pintc/tests/evaluator/index_error_0.pnt
+++ b/pintc/tests/evaluator/index_error_0.pnt
@@ -13,13 +13,9 @@ predicate test {
 // }
 // >>>
 
-// typecheck_failure <<<
-// non-primitive const declaration
-// @10..22: constant declaration `::b` must not have a non-primitive type
-// constant immediate arrays and tuples will be supported in a future update
-// >>>
-
 // flattening_failure <<<
 // attempt to access array with out of bounds index
-// @34..35: array index is out of bounds
+// @56..57: array index is out of bounds
+// attempt to access array with out of bounds index
+// @56..57: array index is out of bounds
 // >>>

--- a/pintc/tests/evaluator/index_error_1.pnt
+++ b/pintc/tests/evaluator/index_error_1.pnt
@@ -15,15 +15,13 @@ predicate test {
 // }
 // >>>
 
-// typecheck_failure <<<
-// non-primitive const declaration
-// @10..22: constant declaration `::b` must not have a non-primitive type
-// constant immediate arrays and tuples will be supported in a future update
-// >>>
-
 // flattening_failure <<<
 // cannot find value `::a` in this scope
-// @50..51: not found in this scope
+// @76..77: not found in this scope
+// attempt to use a non-constant value as an array index
+// @76..77: this must be a constant
+// cannot find value `::a` in this scope
+// @76..77: not found in this scope
 // attempt to use a non-constant value as an array length
-// @50..51: this must be a constant
+// @76..77: this must be a constant
 // >>>

--- a/pintc/tests/evaluator/simple.pnt
+++ b/pintc/tests/evaluator/simple.pnt
@@ -45,13 +45,13 @@ predicate test {
 // enum ::Egg = Ovum | Oeuf | Uovo | HuaManu;
 //
 // predicate ::test {
-//     var ::a: int[[1, 2, 3][1]];
-//     var ::b0: int[{1, 2, 3}.1];
-//     var ::b1: int[{x: 1, y: 2, z: 3}.y];
-//     var ::c: int[(false ? 1 : 2)];
-//     var ::f: int[true as int];
-//     var ::h: int[::Egg::Uovo as int];
-//     var ::i: int[3 as int];
+//     var ::a: int[2];
+//     var ::b0: int[2];
+//     var ::b1: int[2];
+//     var ::c: int[2];
+//     var ::f: int[1];
+//     var ::h: int[2];
+//     var ::i: int[3];
 //     constraint (((true && (0 == 0)) && (1 == 1)) && (2 == 2));
 //     constraint true;
 // }

--- a/pintc/tests/root_types/arrays.pnt
+++ b/pintc/tests/root_types/arrays.pnt
@@ -5,19 +5,13 @@ type myTuple = { x: int };
 type myTupleArray = { x: int[5] };
 type myNestedArrayTuple = { y: { z: int[{4, 1}.0] } };
 
-predicate Foo {}
+predicate Foo {
+    var a: myArrayTuple;
+    constraint a[2] == 11;
 
-// flattened <<<
-// type ::myArray = int[2];
-// type ::myMultiDimArray = int[2][2];
-// type ::myArrayTuple = int[{3, 1}.0];
-// type ::myTuple = {x: int};
-// type ::myTupleArray = {x: int[5]};
-// type ::myNestedArrayTuple = {y: {z: int[{4, 1}.0]}};
-//
-// predicate ::Foo {
-// }
-// >>>
+    var b: myNestedArrayTuple;
+    constraint b.y.z[2] == 22;
+}
 
 // parsed <<<
 // type ::myArray = int[2];
@@ -28,5 +22,25 @@ predicate Foo {}
 // type ::myNestedArrayTuple = {y: {z: int[{4, 1}.0]}};
 //
 // predicate ::Foo {
+//     var ::a: ::myArrayTuple;
+//     var ::b: ::myNestedArrayTuple;
+//     constraint (::a[2] == 11);
+//     constraint (::b.y.z[2] == 22);
+// }
+// >>>
+
+// flattened <<<
+// type ::myArray = int[2];
+// type ::myMultiDimArray = int[2][2];
+// type ::myArrayTuple = int[3];
+// type ::myTuple = {x: int};
+// type ::myTupleArray = {x: int[5]};
+// type ::myNestedArrayTuple = {y: {z: int[4]}};
+//
+// predicate ::Foo {
+//     var ::a: int[3];
+//     var ::b: {y: {z: int[4]}};
+//     constraint (::a[2] == 11);
+//     constraint (::b.y.z[2] == 22);
 // }
 // >>>

--- a/pintc/tests/root_types/consts.pnt
+++ b/pintc/tests/root_types/consts.pnt
@@ -1,0 +1,34 @@
+// <disabled>
+
+const five = 5;
+
+type deuce = int[10 / five];
+
+const two_ints: deuce = [11, 22];
+
+predicate test {
+    var a: int;
+    constraint a == two_ints[1];
+}
+
+// parsed <<<
+// const ::two_ints: ::deuce = [11, 22];
+// const ::five = 5;
+// type ::deuce = int[(10 / ::five)];
+//
+// predicate ::test {
+//     var ::a: int;
+//     constraint (::a == ::two_ints[1]);
+// }
+// >>>
+
+// flattened <<<
+// const ::two_ints: int[2] = [11, 22];
+// const ::five = 5;
+// type ::deuce = int[2];
+//
+// predicate ::test {
+//     var ::a: int;
+//     constraint (::a == 22);
+// }
+// >>>

--- a/pintc/tests/root_types/custom.pnt
+++ b/pintc/tests/root_types/custom.pnt
@@ -1,20 +1,26 @@
 type myAlias = int;
 type myCustom = myAlias;
 
-predicate Foo {}
-
-// flattened <<<
-// type ::myAlias = int;
-// type ::myCustom = ::myAlias (int);
-//
-// predicate ::Foo {
-// }
-// >>>
+predicate Foo {
+    var a: myCustom = 11;
+}
 
 // parsed <<<
 // type ::myAlias = int;
 // type ::myCustom = ::myAlias;
 //
 // predicate ::Foo {
+//     var ::a: ::myCustom;
+//     constraint (::a == 11);
+// }
+// >>>
+
+// flattened <<<
+// type ::myAlias = int;
+// type ::myCustom = ::myAlias (int);
+//
+// predicate ::Foo {
+//     var ::a: int;
+//     constraint (::a == 11);
 // }
 // >>>

--- a/pintc/tests/root_types/exprs.pnt
+++ b/pintc/tests/root_types/exprs.pnt
@@ -5,9 +5,26 @@ type myNestedBinaryOp = int[1 + 2];
 type myNestedSelect = int[ 1 > 0 ? 5 : 6 ];
 type myNestedTuple = int[{2, 1}.0];
 type myNestedArray = int[[2, 1][1]];
-type complexType = { myNestedCast, myNestedSelect }[(2 in {1, 2, 3}) as int];
+type complexType = { myNestedCast, myNestedSelect }[(2 in [1, 2, 3]) as int];
 
-predicate Foo {}
+predicate Foo {
+    var a: myNestedCast;
+    constraint a[2] == 11;
+
+    var b: myNestedUnaryOp;
+    var c: myNestedBinaryOp;
+
+    var d: myNestedSelect;
+    constraint d[3] == 22;
+
+    var e: myNestedTuple;
+    constraint e[0] != e[1];
+
+    var f: myNestedArray;
+
+    var g: complexType;
+    constraint g[0].1[3] != f[0];
+}
 
 // parsed <<<
 // type ::myAliasForCast = int;
@@ -17,22 +34,44 @@ predicate Foo {}
 // type ::myNestedSelect = int[((1 > 0) ? 5 : 6)];
 // type ::myNestedTuple = int[{2, 1}.0];
 // type ::myNestedArray = int[[2, 1][1]];
-// type ::complexType = {::myNestedCast, ::myNestedSelect}[2 in {1, 2, 3} as int];
+// type ::complexType = {::myNestedCast, ::myNestedSelect}[2 in [1, 2, 3] as int];
 //
 // predicate ::Foo {
+//     var ::a: ::myNestedCast;
+//     var ::b: ::myNestedUnaryOp;
+//     var ::c: ::myNestedBinaryOp;
+//     var ::d: ::myNestedSelect;
+//     var ::e: ::myNestedTuple;
+//     var ::f: ::myNestedArray;
+//     var ::g: ::complexType;
+//     constraint (::a[2] == 11);
+//     constraint (::d[3] == 22);
+//     constraint (::e[0] != ::e[1]);
+//     constraint (::g[0].1[3] != ::f[0]);
 // }
 // >>>
 
 // flattened <<<
 // type ::myAliasForCast = int;
-// type ::myNestedCast = int[4 as int];
-// type ::myNestedUnaryOp = int[--3];
-// type ::myNestedBinaryOp = int[(1 + 2)];
-// type ::myNestedSelect = int[((1 > 0) ? 5 : 6)];
-// type ::myNestedTuple = int[{2, 1}.0];
-// type ::myNestedArray = int[[2, 1][1]];
-// type ::complexType = {::myNestedCast (int[4 as int]), ::myNestedSelect (int[((1 > 0) ? 5 : 6)])}[2 in {1, 2, 3} as int];
+// type ::myNestedCast = int[4];
+// type ::myNestedUnaryOp = int[3];
+// type ::myNestedBinaryOp = int[3];
+// type ::myNestedSelect = int[5];
+// type ::myNestedTuple = int[2];
+// type ::myNestedArray = int[1];
+// type ::complexType = {::myNestedCast (int[4]), ::myNestedSelect (int[5])}[1];
 //
 // predicate ::Foo {
+//     var ::a: int[4];
+//     var ::b: int[3];
+//     var ::c: int[3];
+//     var ::d: int[5];
+//     var ::e: int[2];
+//     var ::f: int[1];
+//     var ::g: {int[4], int[5]}[1];
+//     constraint (::a[2] == 11);
+//     constraint (::d[3] == 22);
+//     constraint (::e[0] != ::e[1]);
+//     constraint (::g[0].1[3] != ::f[0]);
 // }
 // >>>

--- a/pintc/tests/root_types/exprs.pnt
+++ b/pintc/tests/root_types/exprs.pnt
@@ -1,11 +1,13 @@
+const two: int = 2;
+
 type myAliasForCast = int;
 type myNestedCast = int[4 as myAliasForCast];
 type myNestedUnaryOp = int[--3];
-type myNestedBinaryOp = int[1 + 2];
+type myNestedBinaryOp = int[1 + two];
 type myNestedSelect = int[ 1 > 0 ? 5 : 6 ];
-type myNestedTuple = int[{2, 1}.0];
+type myNestedTuple = int[{two, 1}.0];
 type myNestedArray = int[[2, 1][1]];
-type complexType = { myNestedCast, myNestedSelect }[(2 in [1, 2, 3]) as int];
+type complexType = { myNestedCast, myNestedSelect }[(2 in [1, two, 3]) as int];
 
 predicate Foo {
     var a: myNestedCast;
@@ -27,14 +29,15 @@ predicate Foo {
 }
 
 // parsed <<<
+// const ::two: int = 2;
 // type ::myAliasForCast = int;
 // type ::myNestedCast = int[4 as ::myAliasForCast];
 // type ::myNestedUnaryOp = int[--3];
-// type ::myNestedBinaryOp = int[(1 + 2)];
+// type ::myNestedBinaryOp = int[(1 + ::two)];
 // type ::myNestedSelect = int[((1 > 0) ? 5 : 6)];
-// type ::myNestedTuple = int[{2, 1}.0];
+// type ::myNestedTuple = int[{::two, 1}.0];
 // type ::myNestedArray = int[[2, 1][1]];
-// type ::complexType = {::myNestedCast, ::myNestedSelect}[2 in [1, 2, 3] as int];
+// type ::complexType = {::myNestedCast, ::myNestedSelect}[2 in [1, ::two, 3] as int];
 //
 // predicate ::Foo {
 //     var ::a: ::myNestedCast;
@@ -52,6 +55,7 @@ predicate Foo {
 // >>>
 
 // flattened <<<
+// const ::two: int = 2;
 // type ::myAliasForCast = int;
 // type ::myNestedCast = int[4];
 // type ::myNestedUnaryOp = int[3];

--- a/pintc/tests/root_types/interfaces.pnt
+++ b/pintc/tests/root_types/interfaces.pnt
@@ -1,0 +1,56 @@
+// <disabled>
+
+type num = int;
+type ary = num[2 + 1];
+
+interface i {
+    storage {
+        x: ary,
+    }
+
+    predicate p {
+        pub var x1: ary;
+    }
+}
+
+predicate test {
+    var addr1: b256;
+
+    interface inst = i(addr1);
+}
+
+// parsed <<<
+// type ::num = int;
+// type ::ary = ::num[(2 + 1)];
+// interface ::i {
+//     storage {
+//         x: ::ary,
+//     }
+//     predicate p {
+//         pub var x1: ::ary;
+//     }
+// }
+//
+// predicate ::test {
+//     interface ::inst = ::i(::addr1)
+//     var ::addr1: b256;
+// }
+// >>>
+
+// flattened <<<
+// type ::num = int;
+// type ::ary = int[3];
+// interface ::i {
+//     storage {
+//         x: int[3];
+//     }
+//     predicate p {
+//         pub var x1: int[3];
+//     }
+// }
+//
+// predicate ::test {
+//     interface ::inst = ::i(::addr1)
+//     var ::addr1: b256;
+// }
+// >>>

--- a/pintc/tests/root_types/storage.pnt
+++ b/pintc/tests/root_types/storage.pnt
@@ -1,0 +1,38 @@
+const two = 2;
+
+type ary = int[1 + [2, two, 2, 2][two]];
+
+storage {
+    x: ary,
+}
+
+predicate test {
+    state y = storage::x[1];
+    constraint y' == 11;
+}
+
+// parsed <<<
+// const ::two = 2;
+// type ::ary = int[(1 + [2, ::two, 2, 2][::two])];
+// storage {
+//     x: ::ary,
+// }
+//
+// predicate ::test {
+//     state ::y = storage::x[1];
+//     constraint (::y' == 11);
+// }
+// >>>
+
+// flattened <<<
+// const ::two: int = 2;
+// type ::ary = int[3];
+// storage {
+//     x: int[3],
+// }
+//
+// predicate ::test {
+//     state ::y: int = storage::x[1];
+//     constraint (::y' == 11);
+// }
+// >>>


### PR DESCRIPTION
This PR is ticking off the final tasks in #774... to a degree.

Arrays in `const`s is back, which was one of the driving factors behind the whole thing.

This PR also adds a `lower_array_ranges()` pass which on paper sounds like a nice thing to have (all the array types in the flattened contract have base integer immediates for ranges, rather than arbitrary expressions).  But it was a huge pain and possibly is not worth it.

Until now, at asm-gen, have just evaluated those ranges, at the very last moment as they're required and it's OK.  So flattening them with a transform isn't necessary.  Maybe.  But as I was fleshing out the `e2e::root_types` tests I came across many, many panics and failures.  These have been fixed in this PR, mostly.  There are still two tests in there which fail, and are currently `<disabled>` but fixing them is a fair bit more work and I'm completely sick of looking at this right now.

They're pretty edge-casey and debatable as to whether they're even worthwhile.  (Do we need to allow type aliases in `Interface` decls?)  So we can come back to them later, IMO.

Closes #774.