### PR TITLE
Ensure during macro expansion that spans don't 'span out' of the macro to the call site.

### DIFF
--- a/pintc/tests/macros/bad_splicing.pnt
+++ b/pintc/tests/macros/bad_splicing.pnt
@@ -20,6 +20,6 @@ predicate test {
 // spliced variable `::b` must be an array
 // @157..158: unable to splice non-array variable `::b`
 // expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`, found `b`
-// @157..158: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`
+// @25..27: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`
 // @151..163: when making macro call to '::@add'
 // >>>

--- a/pintc/tests/macros/splicing_expression_size.pnt
+++ b/pintc/tests/macros/splicing_expression_size.pnt
@@ -17,6 +17,6 @@ predicate test {
 // @137..140: unable to determine spliced array size for `::ary` while parsing
 // macro array splicing is currently limited to immediate integer sizes or enums
 // expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`, found `ary`
-// @137..140: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`
+// @69..71: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`
 // @131..141: when making macro call to '::@sum'
 // >>>

--- a/pintc/tests/regression/github_721.pnt
+++ b/pintc/tests/regression/github_721.pnt
@@ -1,0 +1,29 @@
+const FOO = [{ a: 1, b: 2}];
+
+macro @foo($i, &rest) {
+    @foo($i.a + $i.b; &rest)
+}
+
+macro @foo($i) {
+    $i.a + $i.b
+}
+
+predicate Foo {
+    constraint @foo(FOO) == 3;
+}
+
+// parsed <<<
+// const ::FOO = [{a: 1, b: 2}];
+//
+// predicate ::Foo {
+//     constraint ((::FOO.a + ::FOO.b) == 3);
+// }
+// >>>
+
+// typecheck_failure <<<
+// attempt to access tuple field from a non-tuple value
+// @107..111: value must be a tuple; found `{a: int, b: int}[_]`
+// constraint expression type error
+// @142..167: constraint expression has unknown type
+// @142..167: expecting type `bool`
+// >>>


### PR DESCRIPTION
Closes #721.