### PR TITLE
Assign `intrinsic` types even if malformed

### DIFF
--- a/pintc/src/predicate/analyse/intrinsics.rs
+++ b/pintc/src/predicate/analyse/intrinsics.rs
@@ -31,9 +31,9 @@ impl Contract {
                 // Access ops
                 "__mut_keys_len" => infer_intrinsic_mut_keys_len(args, span),
                 "__mut_keys_contains" => infer_intrinsic_mut_keys_contains(self, name, args, span),
-                "__this_address" => infer_intrinsic_this_address(args, span),
-                "__this_set_address" => infer_intrinsic_this_set_address(args, span),
-                "__this_pathway" => infer_intrinsic_this_pathway(args, span),
+                "__this_address" => infer_intrinsic_this_address(handler, args, span),
+                "__this_set_address" => infer_intrinsic_this_set_address(handler, args, span),
+                "__this_pathway" => infer_intrinsic_this_pathway(handler, args, span),
 
                 // Crypto ops
                 "__sha256" => infer_intrinsic_sha256(handler, args, span),
@@ -171,10 +171,14 @@ fn infer_intrinsic_mut_keys_contains(
 //
 // Description: Get the content hash of the contract that this predicate belongs to.
 //
-fn infer_intrinsic_this_set_address(args: &[ExprKey], span: &Span) -> Result<Inference, Error> {
+fn infer_intrinsic_this_set_address(
+    handler: &Handler,
+    args: &[ExprKey],
+    span: &Span,
+) -> Result<Inference, Error> {
     // This intrinsic expects no arguments
     if !args.is_empty() {
-        return Err(Error::Compile {
+        handler.emit_err(Error::Compile {
             error: CompileError::UnexpectedIntrinsicArgCount {
                 expected: 0,
                 found: args.len(),
@@ -199,10 +203,14 @@ fn infer_intrinsic_this_set_address(args: &[ExprKey], span: &Span) -> Result<Inf
 //
 // Description: Get the content hash of this predicate.
 //
-fn infer_intrinsic_this_address(args: &[ExprKey], span: &Span) -> Result<Inference, Error> {
+fn infer_intrinsic_this_address(
+    handler: &Handler,
+    args: &[ExprKey],
+    span: &Span,
+) -> Result<Inference, Error> {
     // This intrinsic expects no arguments
     if !args.is_empty() {
-        return Err(Error::Compile {
+        handler.emit_err(Error::Compile {
             error: CompileError::UnexpectedIntrinsicArgCount {
                 expected: 0,
                 found: args.len(),
@@ -228,10 +236,14 @@ fn infer_intrinsic_this_address(args: &[ExprKey], span: &Span) -> Result<Inferen
 // Description: This operation returns the index of the solution data currently being used to check
 // this predicate.
 //
-fn infer_intrinsic_this_pathway(args: &[ExprKey], span: &Span) -> Result<Inference, Error> {
+fn infer_intrinsic_this_pathway(
+    handler: &Handler,
+    args: &[ExprKey],
+    span: &Span,
+) -> Result<Inference, Error> {
     // This intrinsic expects no arguments
     if !args.is_empty() {
-        return Err(Error::Compile {
+        handler.emit_err(Error::Compile {
             error: CompileError::UnexpectedIntrinsicArgCount {
                 expected: 0,
                 found: args.len(),

--- a/pintc/src/predicate/analyse/intrinsics.rs
+++ b/pintc/src/predicate/analyse/intrinsics.rs
@@ -36,7 +36,7 @@ impl Contract {
                 "__this_pathway" => infer_intrinsic_this_pathway(args, span),
 
                 // Crypto ops
-                "__sha256" => infer_intrinsic_sha256(args, span),
+                "__sha256" => infer_intrinsic_sha256(handler, args, span),
                 "__verify_ed25519" => {
                     infer_intrinsic_verify_ed25519(self, handler, name, args, span)
                 }
@@ -257,10 +257,14 @@ fn infer_intrinsic_this_pathway(args: &[ExprKey], span: &Span) -> Result<Inferen
 //
 // Description: Produce a SHA 256 hash from the specified data.
 //
-fn infer_intrinsic_sha256(args: &[ExprKey], span: &Span) -> Result<Inference, Error> {
+fn infer_intrinsic_sha256(
+    handler: &Handler,
+    args: &[ExprKey],
+    span: &Span,
+) -> Result<Inference, Error> {
     // This intrinsic expects exactly 1 argument
     if args.len() != 1 {
-        return Err(Error::Compile {
+        handler.emit_err(Error::Compile {
             error: CompileError::UnexpectedIntrinsicArgCount {
                 expected: 1,
                 found: args.len(),

--- a/pintc/src/predicate/analyse/intrinsics.rs
+++ b/pintc/src/predicate/analyse/intrinsics.rs
@@ -481,25 +481,22 @@ fn infer_intrinsic_state_len(
     }
 
     // First argument must be a path to a state variable
-    match args[0].try_get(contract) {
+    match args.first().and_then(|expr_key| expr_key.try_get(contract)) {
         Some(Expr::Path(name, _))
             if pred
                 .map(|pred| pred.states().any(|(_, state)| state.name == *name))
-                .unwrap_or(false) =>
-        {
-            Ok(())
-        }
+                .unwrap_or(false) => {}
         Some(Expr::UnaryOp {
             op: UnaryOp::NextState,
             ..
-        }) => Ok(()),
+        }) => {}
+        None => {}
         _ => {
             handler.emit_err(Error::Compile {
                 error: CompileError::IntrinsicArgMustBeStateVar { span: span.clone() },
             });
-            Ok(())
         }
-    }?;
+    };
 
     // This intrinsic returns a `int`
     Ok(Inference::Type(Type::Primitive {

--- a/pintc/tests/intrinsics/bad_state_len_arg.pnt
+++ b/pintc/tests/intrinsics/bad_state_len_arg.pnt
@@ -19,10 +19,4 @@ predicate test {
 // @45..59: intrinsic argument must be a state variable
 // intrinsic argument must be a state variable
 // @73..87: intrinsic argument must be a state variable
-// constraint expression type error
-// @37..59: constraint expression has unknown type
-// @37..59: expecting type `bool`
-// constraint expression type error
-// @65..87: constraint expression has unknown type
-// @65..87: expecting type `bool`
 // >>>

--- a/pintc/tests/intrinsics/incorrect_args.pnt
+++ b/pintc/tests/intrinsics/incorrect_args.pnt
@@ -217,10 +217,4 @@ predicate test {
 // constraint expression type error
 // @1218..1312: constraint expression has unknown type
 // @1218..1312: expecting type `bool`
-// constraint expression type error
-// @1346..1385: constraint expression has unknown type
-// @1346..1385: expecting type `bool`
-// constraint expression type error
-// @1391..1426: constraint expression has unknown type
-// @1391..1426: expecting type `bool`
 // >>>

--- a/pintc/tests/intrinsics/incorrect_args.pnt
+++ b/pintc/tests/intrinsics/incorrect_args.pnt
@@ -133,25 +133,4 @@ predicate test {
 // @1368..1385: unexpected number of arguments here
 // this intrinsic takes 1 argument but 0 arguments were supplied
 // @1413..1426: unexpected number of arguments here
-// variable initialization type error
-// @313..335: variable initializer has unknown type
-// @306..310: expecting type `bool`
-// variable initialization type error
-// @373..394: variable initializer has unknown type
-// @366..370: expecting type `bool`
-// variable initialization type error
-// @432..465: variable initializer has unknown type
-// @425..429: expecting type `bool`
-// constraint expression type error
-// @237..274: constraint expression has unknown type
-// @237..274: expecting type `bool`
-// constraint expression type error
-// @281..335: constraint expression has unknown type
-// @281..335: expecting type `bool`
-// constraint expression type error
-// @341..394: constraint expression has unknown type
-// @341..394: expecting type `bool`
-// constraint expression type error
-// @400..465: constraint expression has unknown type
-// @400..465: expecting type `bool`
 // >>>

--- a/pintc/tests/intrinsics/incorrect_args.pnt
+++ b/pintc/tests/intrinsics/incorrect_args.pnt
@@ -154,13 +154,4 @@ predicate test {
 // constraint expression type error
 // @400..465: constraint expression has unknown type
 // @400..465: expecting type `bool`
-// constraint expression type error
-// @472..509: constraint expression has unknown type
-// @472..509: expecting type `bool`
-// constraint expression type error
-// @516..561: constraint expression has unknown type
-// @516..561: expecting type `bool`
-// constraint expression type error
-// @568..605: constraint expression has unknown type
-// @568..605: expecting type `bool`
 // >>>

--- a/pintc/tests/intrinsics/incorrect_args.pnt
+++ b/pintc/tests/intrinsics/incorrect_args.pnt
@@ -163,10 +163,4 @@ predicate test {
 // constraint expression type error
 // @568..605: constraint expression has unknown type
 // @568..605: expecting type `bool`
-// constraint expression type error
-// @612..637: constraint expression has unknown type
-// @612..637: expecting type `bool`
-// constraint expression type error
-// @643..672: constraint expression has unknown type
-// @643..672: expecting type `bool`
 // >>>

--- a/pintc/tests/intrinsics/incorrect_args.pnt
+++ b/pintc/tests/intrinsics/incorrect_args.pnt
@@ -142,18 +142,6 @@ predicate test {
 // variable initialization type error
 // @432..465: variable initializer has unknown type
 // @425..429: expecting type `bool`
-// variable initialization type error
-// @708..749: variable initializer has unknown type
-// @701..705: expecting type `bool`
-// variable initialization type error
-// @784..818: variable initializer has unknown type
-// @777..781: expecting type `bool`
-// variable initialization type error
-// @853..871: variable initializer has unknown type
-// @846..850: expecting type `bool`
-// variable initialization type error
-// @906..955: variable initializer has unknown type
-// @899..903: expecting type `bool`
 // constraint expression type error
 // @237..274: constraint expression has unknown type
 // @237..274: expecting type `bool`
@@ -181,16 +169,4 @@ predicate test {
 // constraint expression type error
 // @643..672: constraint expression has unknown type
 // @643..672: expecting type `bool`
-// constraint expression type error
-// @679..749: constraint expression has unknown type
-// @679..749: expecting type `bool`
-// constraint expression type error
-// @755..818: constraint expression has unknown type
-// @755..818: expecting type `bool`
-// constraint expression type error
-// @824..871: constraint expression has unknown type
-// @824..871: expecting type `bool`
-// constraint expression type error
-// @877..955: constraint expression has unknown type
-// @877..955: expecting type `bool`
 // >>>

--- a/pintc/tests/intrinsics/incorrect_args.pnt
+++ b/pintc/tests/intrinsics/incorrect_args.pnt
@@ -154,18 +154,6 @@ predicate test {
 // variable initialization type error
 // @906..955: variable initializer has unknown type
 // @899..903: expecting type `bool`
-// variable initialization type error
-// @1003..1048: variable initializer has unknown type
-// @987..1000: expecting type `{b256, int}`
-// variable initialization type error
-// @1095..1139: variable initializer has unknown type
-// @1079..1092: expecting type `{b256, int}`
-// variable initialization type error
-// @1186..1212: variable initializer has unknown type
-// @1170..1183: expecting type `{b256, int}`
-// variable initialization type error
-// @1259..1312: variable initializer has unknown type
-// @1243..1256: expecting type `{b256, int}`
 // constraint expression type error
 // @237..274: constraint expression has unknown type
 // @237..274: expecting type `bool`
@@ -205,16 +193,4 @@ predicate test {
 // constraint expression type error
 // @877..955: constraint expression has unknown type
 // @877..955: expecting type `bool`
-// constraint expression type error
-// @962..1048: constraint expression has unknown type
-// @962..1048: expecting type `bool`
-// constraint expression type error
-// @1054..1139: constraint expression has unknown type
-// @1054..1139: expecting type `bool`
-// constraint expression type error
-// @1145..1212: constraint expression has unknown type
-// @1145..1212: expecting type `bool`
-// constraint expression type error
-// @1218..1312: constraint expression has unknown type
-// @1218..1312: expecting type `bool`
 // >>>


### PR DESCRIPTION
Just the start to #812. This PR significantly cuts down on chained errors due to errors inferring `intrinsics`.

Before, if we saw a proper `intrinsic` name (ex. __sha256 with the wrong # of arguments) we would `handler.emit_err()` and bail on inferring the type. This caused extra errors down the line because further `type_checking` operated on a `Type::Error | Type::Unknown` instead of `Type::Int` or whatever the type of the malformed `intrinsic call` was.

By assigning the proper `type` to the `intrinsic call` the rest of the `type_checking` goes smoothly and prevents a lot of future errors that are not helpful.

My thought, after having discussed with @mohammadfawaz, is that we shouldn't bail early near as often as we currently do when inferring a type. Typically we know what the type _should be_. If we assign that type, emit the error, and move on then we would prevent a lot of errors from cropping up in the subsequent `type_check` stages. This also helps the user know the root cause of the issue instead of sifting through 4+ errors to figure out which one is the actionable one.