### PR TITLE
Reduce the error output from type checking a little bit more.

### DIFF
--- a/pintc/src/error/compile_error.rs
+++ b/pintc/src/error/compile_error.rs
@@ -1272,24 +1272,28 @@ fn generate_type_error_labels(
     found_span: &Span,
     expected_span: &Option<Span>,
 ) -> Vec<ErrorLabel> {
-    let message = if found_ty == "Unknown" || found_ty == "Error" {
-        format!("{what} has unknown type")
-    } else {
-        format!("{what} has unexpected type `{found_ty}`")
+    let mut labels = Vec::default();
+    let mut expected_label_color = Color::Red;
+
+    if found_ty != "Unknown" && found_ty != "Error" {
+        labels.push(ErrorLabel {
+            message: format!("{what} has unexpected type `{found_ty}`"),
+            span: found_span.clone(),
+            color: Color::Red,
+        });
+
+        // Make this label red and the next one blue.
+        expected_label_color = Color::Blue;
     };
 
-    let mut labels = vec![ErrorLabel {
-        message,
-        span: found_span.clone(),
-        color: Color::Red,
-    }];
-
     if let Some(span) = expected_span {
-        labels.push(ErrorLabel {
-            message: format!("expecting type `{expected_ty}`"),
-            span: span.clone(),
-            color: Color::Blue,
-        });
+        if expected_ty != "Unknown" && expected_ty != "Error" {
+            labels.push(ErrorLabel {
+                message: format!("expecting type `{expected_ty}`"),
+                span: span.clone(),
+                color: expected_label_color,
+            });
+        }
     }
 
     labels

--- a/pintc/src/types.rs
+++ b/pintc/src/types.rs
@@ -84,6 +84,10 @@ impl Type {
         matches!(self, Type::Unknown(_))
     }
 
+    pub fn is_error(&self) -> bool {
+        matches!(self, Type::Error(_))
+    }
+
     pub fn is_alias(&self) -> Option<&Type> {
         if let Type::Alias { ty, .. } = self {
             Some(ty)

--- a/pintc/tests/arrays/bad_indexed_value.pnt
+++ b/pintc/tests/arrays/bad_indexed_value.pnt
@@ -15,6 +15,5 @@ predicate test {
 // no intrinsic named `__foo` is found
 // @49..56: intrinsic not found
 // constraint expression type error
-// @38..64: constraint expression has unknown type
-// @38..64: expecting type `bool`
+// @49..64: expecting type `bool`
 // >>>

--- a/pintc/tests/arrays/non_existent_array_access.pnt
+++ b/pintc/tests/arrays/non_existent_array_access.pnt
@@ -13,7 +13,4 @@ predicate test {
 // @32..33: not found in this scope
 // indexed expression invalid
 // @32..36: value must be an array or a storage map; found `Error`
-// binary operator type error
-// @40..41: operator `==` argument has unexpected type `int`
-// @32..36: expecting type `Error`
 // >>>

--- a/pintc/tests/basic_tests/bad_nil.pnt
+++ b/pintc/tests/basic_tests/bad_nil.pnt
@@ -31,5 +31,5 @@ predicate test {
 // @28..31: expecting type `int`
 // constraint expression type error
 // @109..123: constraint expression has unexpected type `nil`
-// @109..123: expecting type `bool`
+// @120..123: expecting type `bool`
 // >>>

--- a/pintc/tests/regression/github_721.pnt
+++ b/pintc/tests/regression/github_721.pnt
@@ -25,9 +25,4 @@ predicate Foo {
 // @107..111: value must be a tuple; found `{a: int, b: int}[_]`
 // attempt to access tuple field from a non-tuple value
 // @114..118: value must be a tuple; found `{a: int, b: int}[_]`
-// binary operator type error
-// @107..111: operator `+` argument has unexpected type `{a: int, b: int}[_]`
-// binary operator type error
-// @166..167: operator `==` argument has unexpected type `int`
-// @107..118: expecting type `{a: int, b: int}[_]`
 // >>>

--- a/pintc/tests/storage/invalid_next_state.pnt
+++ b/pintc/tests/storage/invalid_next_state.pnt
@@ -13,7 +13,4 @@ predicate test {
 // typecheck_failure <<<
 // `next state` access must be bound to a state variable
 // @48..49: `next state` access must be bound to a state variable
-// binary operator type error
-// @54..55: operator `==` argument has unexpected type `int`
-// @48..50: expecting type `Error`
 // >>>

--- a/pintc/tests/storage/missing_extern.pnt
+++ b/pintc/tests/storage/missing_extern.pnt
@@ -38,6 +38,4 @@ predicate Foo {
 // @365..397: cannot find interface instance `::ERC20InstanceMissing`
 // unable to determine expression type
 // @313..348: type of this expression is ambiguous
-// unable to determine expression type
-// @355..397: type of this expression is ambiguous
 // >>>

--- a/pintc/tests/types/bad_in_expr.pnt
+++ b/pintc/tests/types/bad_in_expr.pnt
@@ -43,6 +43,5 @@ predicate test {
 // value type and array element type in range differ
 // @0..123: array element type mismatch; expecting `int` type, found `::SupperGuest` type
 // constraint expression type error
-// @252..280: constraint expression has unknown type
-// @252..280: expecting type `bool`
+// @263..280: expecting type `bool`
 // >>>

--- a/pintc/tests/types/bad_tuple_name_index.pnt
+++ b/pintc/tests/types/bad_tuple_name_index.pnt
@@ -16,6 +16,4 @@ predicate test {
 // invalid tuple accessor
 // @65..68: unable to get field from tuple using `z`
 // tuple has type `{x: int, y: real}`
-// binary operator type error
-// @65..68: operator `>` argument has unexpected type `{x: int, y: real}`
 // >>>

--- a/pintc/tests/types/bad_tuple_num_index.pnt
+++ b/pintc/tests/types/bad_tuple_num_index.pnt
@@ -16,7 +16,4 @@ predicate test {
 // invalid tuple accessor
 // @61..64: unable to get field from tuple using `4`
 // tuple has type `{int, int, int}`
-// binary operator type error
-// @68..70: operator `==` argument has unexpected type `int`
-// @61..64: expecting type `{int, int, int}`
 // >>>

--- a/pintc/tests/types/constraint_non_bool_types.pnt
+++ b/pintc/tests/types/constraint_non_bool_types.pnt
@@ -26,17 +26,17 @@ predicate test {
 // typecheck_failure <<<
 // constraint expression type error
 // @74..90: constraint expression has unexpected type `int`
-// @74..90: expecting type `bool`
+// @85..90: expecting type `bool`
 // constraint expression type error
 // @96..108: constraint expression has unexpected type `b256`
-// @96..108: expecting type `bool`
+// @107..108: expecting type `bool`
 // constraint expression type error
 // @114..133: constraint expression has unexpected type `{int, int}`
-// @114..133: expecting type `bool`
+// @125..133: expecting type `bool`
 // constraint expression type error
 // @139..159: constraint expression has unexpected type `int[3]`
-// @139..159: expecting type `bool`
+// @150..159: expecting type `bool`
 // constraint expression type error
 // @165..187: constraint expression has unexpected type `::Colour`
-// @165..187: expecting type `bool`
+// @176..187: expecting type `bool`
 // >>>

--- a/pintc/tests/types/recursive_array_vars.pnt
+++ b/pintc/tests/types/recursive_array_vars.pnt
@@ -41,12 +41,9 @@ predicate test {
 // unable to determine expression type
 // @66..67: type of this expression is ambiguous
 // constraint expression type error
-// @21..38: constraint expression has unknown type
 // @21..38: expecting type `bool`
 // constraint expression type error
-// @44..56: constraint expression has unknown type
 // @44..56: expecting type `bool`
 // constraint expression type error
-// @62..84: constraint expression has unknown type
 // @62..84: expecting type `bool`
 // >>>

--- a/pintc/tests/types/recursive_scalar_vars.pnt
+++ b/pintc/tests/types/recursive_scalar_vars.pnt
@@ -41,12 +41,9 @@ predicate test {
 // unable to determine expression type
 // @63..64: type of this expression is ambiguous
 // constraint expression type error
-// @21..34: constraint expression has unknown type
 // @21..34: expecting type `bool`
 // constraint expression type error
-// @40..53: constraint expression has unknown type
 // @40..53: expecting type `bool`
 // constraint expression type error
-// @59..72: constraint expression has unknown type
 // @59..72: expecting type `bool`
 // >>>


### PR DESCRIPTION
While looking through the type checker there were a couple of things I wasn't 100% happy with.

Previously, to reduce error message noise, we would return an incorrect inferred type when an expression type was known but invalid and an error had been emitted.  This was to smooth out the flow and avoid a bunch of superfluous checks, but I don't think it's great for the type checker to be saying 'um, well, this expression is bogus but here's a type I made up, just go with it'. 🙂 

So in those cases I've replaced the pretend type with `Type::Error`.  But this re-introduces some legitimate noise, but also stops errors declaring they were expecting incorrect types.  So to avoid the noise I've added a bunch of extra checks -- especially around binary operators.  If either the LHS or RHS type is error then it will not emit more type errors.  There are also checks so that we don't ever say 'expecting Unknown' or 'expecting Error' _or_ 'found Unknown' or 'found Error'.

I also changed the span for constraint decl type errors since it was highlighting the whole decl as needing to be `bool` when really only the RHS should be.