### PR TITLE
publish: new versions to support changes in asm and mut keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "ena"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "essential-check"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a8b25d8811175188df03d86edc28af74b97ef2d96ac8a4a33552a9cabd65a9"
+checksum = "04306f9e80a21f4c0887ff96d91c04cbf05c93f77389be9abfbbe88a83fa7f42"
 dependencies = [
  "essential-constraint-vm",
  "essential-hash",
@@ -843,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1138,7 +1144,7 @@ checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pint-abi"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "essential-types",
  "pint-abi-gen",
@@ -1149,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "pint-abi-gen"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "essential-hash",
  "essential-types",
@@ -1179,14 +1185,14 @@ dependencies = [
 
 [[package]]
 name = "pint-abi-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "pint-abi-visit"
-version = "0.0.1"
+version = "0.2.0"
 dependencies = [
  "essential-types",
  "petgraph",
@@ -1195,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "pint-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1216,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "pint-pkg"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "essential-hash",
  "essential-types",
@@ -1247,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "pintc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -1258,7 +1264,7 @@ dependencies = [
  "essential-types",
  "expect-test",
  "fxhash",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "lalrpop",
  "lalrpop-util",
  "logos",
@@ -1286,7 +1292,7 @@ dependencies = [
  "chumsky",
  "clap",
  "expect-test",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "logos",
  "regex",
  "tempfile",
@@ -1307,12 +1313,13 @@ dependencies = [
 
 [[package]]
 name = "postcard"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+checksum = "20ee10b999a00ca189ac2cb99f5db1ca71fb7371e3d5f493b879ca95d2a67220"
 dependencies = [
  "cobs",
- "embedded-io",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
  "heapless",
  "serde",
 ]
@@ -1984,9 +1991,9 @@ checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,23 +24,23 @@ ariadne = "0.4"
 chumsky = "0.9"
 clap = { version = "4.5", features = ["derive"] }
 constraint-asm = { version = "0.3", package = "essential-constraint-asm" }
-essential-check = { version = "0.3", features = ["tracing"] }
+essential-check = { version = "0.4", features = ["tracing"] }
 essential-constraint-vm = "0.3"
 essential-state-read-vm = "0.3"
 essential-hash = "0.2"
 essential-types = "0.2"
 expect-test = "1.4"
 fxhash = "0.2"
-itertools = "0.12"
+itertools = "0.13"
 logos = "0.14"
 petgraph = "0.6"
-pint-abi = { path = "pint-abi", version = "0.1.0" }
-pint-abi-gen = { path = "pint-abi-gen", version = "0.1.0" }
-pint-abi-types = { path = "pint-abi-types", version = "0.1.0" }
-pint-abi-visit = { path = "pint-abi-visit", version = "0.0.1" }
+pint-abi = { path = "pint-abi", version = "0.2.0" }
+pint-abi-gen = { path = "pint-abi-gen", version = "0.2.0" }
+pint-abi-types = { path = "pint-abi-types", version = "0.2.0" }
+pint-abi-visit = { path = "pint-abi-visit", version = "0.2.0" }
 pint-manifest = { path = "pint-manifest", version = "0.1.0" }
-pint-pkg = { path = "pint-pkg", version = "0.1.0" }
-pintc = { path = "pintc", version = "0.1.0" }
+pint-pkg = { path = "pint-pkg", version = "0.2.0" }
+pintc = { path = "pintc", version = "0.2.0" }
 proc-macro2 = "1.0"
 quote = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/pint-abi-gen/Cargo.toml
+++ b/pint-abi-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pint-abi-gen"
-version = "0.1.0"
+version = "0.2.0"
 description = "proc-macro for generating pint ABI items"
 edition.workspace = true
 authors.workspace = true

--- a/pint-abi-types/Cargo.toml
+++ b/pint-abi-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pint-abi-types"
-version = "0.1.0"
+version = "0.2.0"
 description = "A crate containing the types used in the Pint ABI"
 edition.workspace = true
 authors.workspace = true

--- a/pint-abi-visit/Cargo.toml
+++ b/pint-abi-visit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pint-abi-visit"
-version = "0.0.1"
+version = "0.2.0"
 description = "Items to assist in traversing the Pint ABI types."
 edition.workspace = true
 authors.workspace = true

--- a/pint-abi/Cargo.toml
+++ b/pint-abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pint-abi"
-version = "0.1.0"
+version = "0.2.0"
 description = "Encoding, decoding and other helpers for working with the Pint Essential ABI."
 edition.workspace = true
 authors.workspace = true

--- a/pint-cli/Cargo.toml
+++ b/pint-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pint-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "Pint's package manager and CLI plugin host."
 edition.workspace = true
 authors.workspace = true

--- a/pint-pkg/Cargo.toml
+++ b/pint-pkg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pint-pkg"
 description = "The library implementation for Pint package management."
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/pintc/Cargo.toml
+++ b/pintc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pintc"
-version = "0.1.0"
+version = "0.2.0"
 description = "Compiler for the Pint language"
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Publish new versions of pint crates to support changes in asm so the new version of the server can be deployed.