### PR TITLE
Add front-end support for unions and `match` expressions and declarations.

### DIFF
--- a/pintc/src/lexer.rs
+++ b/pintc/src/lexer.rs
@@ -113,6 +113,8 @@ pub enum Token {
     Else,
     #[token("cond")]
     Cond,
+    #[token("match")]
+    Match,
 
     #[token("var")]
     Var,
@@ -128,6 +130,8 @@ pub enum Token {
     Enum,
     #[token("type")]
     Type,
+    #[token("union")]
+    Union,
     #[token("constraint")]
     Constraint,
 
@@ -219,6 +223,7 @@ pub(super) static KEYWORDS: &[Token] = &[
     Token::Int,
     Token::Interface,
     Token::Macro,
+    Token::Match,
     Token::Nil,
     Token::Predicate,
     Token::Pub,
@@ -230,6 +235,7 @@ pub(super) static KEYWORDS: &[Token] = &[
     Token::String,
     Token::True,
     Token::Type,
+    Token::Union,
     Token::Use,
     Token::Var,
     Token::Where,
@@ -315,6 +321,7 @@ impl fmt::Display for Token {
             Token::If => write!(f, "if"),
             Token::Else => write!(f, "else"),
             Token::Cond => write!(f, "cond"),
+            Token::Match => write!(f, "match"),
             Token::Var => write!(f, "var"),
             Token::State => write!(f, "state"),
             Token::Const => write!(f, "const"),
@@ -322,6 +329,7 @@ impl fmt::Display for Token {
             Token::Interface => write!(f, "interface"),
             Token::Enum => write!(f, "enum"),
             Token::Type => write!(f, "type"),
+            Token::Union => write!(f, "union"),
             Token::Constraint => write!(f, "constraint"),
             Token::Pub => write!(f, "pub"),
             Token::Mut => write!(f, "mut"),

--- a/pintc/src/lexer/tests.rs
+++ b/pintc/src/lexer/tests.rs
@@ -224,6 +224,7 @@ fn variables() {
 fn r#types() {
     assert_eq!(lex_one_success("enum"), Token::Enum);
     assert_eq!(lex_one_success("type"), Token::Type);
+    assert_eq!(lex_one_success("union"), Token::Union);
 }
 
 #[test]
@@ -250,6 +251,7 @@ fn if_else_cond() {
     assert_eq!(lex_one_success("if"), Token::If);
     assert_eq!(lex_one_success("else"), Token::Else);
     assert_eq!(lex_one_success("cond"), Token::Cond);
+    assert_eq!(lex_one_success("match"), Token::Match);
 }
 
 #[test]

--- a/pintc/src/parser/context.rs
+++ b/pintc/src/parser/context.rs
@@ -185,8 +185,8 @@ impl<'a> ParserContext<'a> {
         self.contract.interfaces.push(interface);
     }
 
-    /// Given a predicate instance name as an `Predicate`, a list `els` of `Ident`s forming a path,
-    /// an predicate name as an `Predicate` and an address as an `ExprKey`, produce an
+    /// Given a predicate instance name as a `Predicate`, a list `els` of `Ident`s forming a path,
+    /// an predicate name as a `Predicate` and an address as an `ExprKey`, produce an
     /// `PredicateInstance` object and insert it into the current Pred. `l` and `r` are the code
     /// locations before and after the predicate instance declaration. `l1` and `r1` are the code
     /// locations before and after the path represented by `els`. Uses `is_abs` to decide how to

--- a/pintc/src/parser/tests.rs
+++ b/pintc/src/parser/tests.rs
@@ -1028,24 +1028,24 @@ fn storage_access() {
     check(
         &run_parser!(pint, r#"predicate test { var x = storage::foo; }"#),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`, found `storage`
-            @25..32: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`, found `storage`
+            @25..32: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`
         "#]],
     );
 
     check(
         &run_parser!(pint, r#"predicate test { var x = storage::map[4][3]; }"#),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`, found `storage`
-            @25..32: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`, found `storage`
+            @25..32: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`
         "#]],
     );
 
     check(
         &run_parser!(pint, r#"constraint storage::map[69] == 0;"#),
         expect_test::expect![[r#"
-            expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`, found `constraint`
-            @0..10: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`
+            expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`, found `constraint`
+            @0..10: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`
         "#]],
     );
 }
@@ -1096,8 +1096,8 @@ fn external_storage_access() {
     check(
         &run_parser!(pint, r#"constraint ::Foo::storage::map[69] == 0;"#),
         expect_test::expect![[r#"
-            expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`, found `constraint`
-            @0..10: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`
+            expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`, found `constraint`
+            @0..10: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`
         "#]],
     );
 }
@@ -1761,8 +1761,8 @@ fn parens_exprs() {
     check(
         &run_parser!(expr, "()"),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`, found `)`
-            @12..13: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`, found `)`
+            @12..13: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`
         "#]],
     );
 
@@ -1773,8 +1773,8 @@ fn parens_exprs() {
     check(
         &run_parser!(expr, "(foo(a, b, c))"),
         expect_test::expect![[r#"
-            expected `!=`, `%`, `&&`, `'`, `)`, `*`, `+`, `-`, `.`, `/`, `::`, `<`, `<=`, `==`, `>`, `>=`, `?`, `[`, `as`, `in`, or `||`, found `(`
-            @15..16: expected `!=`, `%`, `&&`, `'`, `)`, `*`, `+`, `-`, `.`, `/`, `::`, `<`, `<=`, `==`, `>`, `>=`, `?`, `[`, `as`, `in`, or `||`
+            expected `)`, found `,`
+            @17..18: expected `)`
         "#]],
     );
 }
@@ -1883,8 +1883,8 @@ fn ranges() {
     check(
         &run_parser!(range, "1...2"),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`, found `.`
-            @15..16: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`, found `.`
+            @15..16: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`
         "#]],
     );
 
@@ -2328,8 +2328,8 @@ fn tuple_expressions() {
     check(
         &run_parser!(
             expr,
-            r#"{0, 
-            {true, 0x0000222200002222000022220000222200002222000022220000222200002222}, 
+            r#"{0,
+            {true, 0x0000222200002222000022220000222200002222000022220000222200002222},
             0x0000111100001111000011110000111100001111000011110000111100001111}"#
         ),
         expect_test::expect!["{0, {true, 0x0000222200002222000022220000222200002222000022220000222200002222}, 0x0000111100001111000011110000111100001111000011110000111100001111}"],
@@ -2338,8 +2338,8 @@ fn tuple_expressions() {
     check(
         &run_parser!(
             expr,
-            r#"{x: 0, {y: true, 
-            0x0000222200002222000022220000222200002222000022220000222200002222}, z: 
+            r#"{x: 0, {y: true,
+            0x0000222200002222000022220000222200002222000022220000222200002222}, z:
             0x0000111100001111000011110000111100001111000011110000111100001111}"#
         ),
         expect_test::expect!["{x: 0, {y: true, 0x0000222200002222000022220000222200002222000022220000222200002222}, z: 0x0000111100001111000011110000111100001111000011110000111100001111}"],
@@ -2506,8 +2506,8 @@ fn tuple_field_accesses() {
             "var x = t.222222222222222222222.111111111111111111111111111;"
         ),
         expect_test::expect![[r#"
-            expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`, found `var`
-            @0..3: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`
+            expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`, found `var`
+            @0..3: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`
         "#]],
     );
 
@@ -2526,6 +2526,51 @@ fn tuple_field_accesses() {
             @31..33: empty tuple type found
             empty tuple expressions are not allowed
             @36..38: empty tuple expression found
+        "#]],
+    );
+}
+
+#[test]
+fn union_expression() {
+    let expr = (yp::TestDelegateParser::new(), "expr");
+
+    check(
+        &run_parser!(expr, r#"foo(x)"#),
+        expect_test::expect!["::foo(::x)"],
+    );
+
+    check(
+        &run_parser!(expr, r#"foo(1,)"#),
+        expect_test::expect![[r#"
+            expected `)`, found `,`
+            @16..17: expected `)`
+        "#]],
+    );
+
+    check(
+        &run_parser!(expr, r#"foo(1, 2,)"#),
+        expect_test::expect![[r#"
+            expected `)`, found `,`
+            @16..17: expected `)`
+        "#]],
+    );
+
+    check(
+        &run_parser!(expr, r#"foo(1, 2, { 3, x }.1, [y, __vec_len()])"#),
+        expect_test::expect![[r#"
+            expected `)`, found `,`
+            @16..17: expected `)`
+        "#]],
+    );
+
+    check(
+        &run_parser!(
+            (yp::PintParser::new(), ""),
+            r#"predicate test { var x = foo(a*3, c); }"#
+        ),
+        expect_test::expect![[r#"
+            expected `)`, found `,`
+            @32..33: expected `)`
         "#]],
     );
 }
@@ -2562,8 +2607,8 @@ fn cond_exprs() {
     check(
         &run_parser!(expr, r#"cond { a => b, }"#),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `else`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`, found `}`
-            @26..27: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `else`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `else`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`, found `}`
+            @26..27: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `else`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`
         "#]],
     );
 
@@ -2648,8 +2693,8 @@ fn in_expr() {
             r#"predicate test { var x = 5 in"#
         ),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`, found `end of file`
-            @29..29: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`, found `end of file`
+            @29..29: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`
         "#]],
     );
 }
@@ -2733,8 +2778,8 @@ fn forall_expr() {
             r#"predicate test { constraint forall i in 0..3 { constraint x; true }; }"#
         ),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`, found `constraint`
-            @47..57: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`, found `constraint`
+            @47..57: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`
         "#]],
     );
 }
@@ -2817,8 +2862,8 @@ fn exists_expr() {
             r#"predicate test { constraint exists i in 0..3 { constraint x; true }; }"#
         ),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`, found `constraint`
-            @47..57: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`, found `constraint`
+            @47..57: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, or `{`
         "#]],
     );
 }
@@ -2833,53 +2878,7 @@ fn intrinsic_call() {
     );
 
     check(
-        &run_parser!(expr, r#"foo(x)"#),
-        expect_test::expect![[r#"
-            expected `!=`, `%`, `&&`, `'`, `*`, `+`, `-`, `.`, `/`, `::`, `<`, `<=`, `==`, `>`, `>=`, `?`, `[`, `as`, `in`, or `||`, found `(`
-            @14..15: expected `!=`, `%`, `&&`, `'`, `*`, `+`, `-`, `.`, `/`, `::`, `<`, `<=`, `==`, `>`, `>=`, `?`, `[`, `as`, `in`, or `||`
-        "#]],
-    );
-
-    check(
-        &run_parser!(expr, r#"foo(1,)"#),
-        expect_test::expect![[r#"
-            expected `!=`, `%`, `&&`, `'`, `*`, `+`, `-`, `.`, `/`, `::`, `<`, `<=`, `==`, `>`, `>=`, `?`, `[`, `as`, `in`, or `||`, found `(`
-            @14..15: expected `!=`, `%`, `&&`, `'`, `*`, `+`, `-`, `.`, `/`, `::`, `<`, `<=`, `==`, `>`, `>=`, `?`, `[`, `as`, `in`, or `||`
-        "#]],
-    );
-
-    check(
-        &run_parser!(expr, r#"foo(1, 2,)"#),
-        expect_test::expect![[r#"
-            expected `!=`, `%`, `&&`, `'`, `*`, `+`, `-`, `.`, `/`, `::`, `<`, `<=`, `==`, `>`, `>=`, `?`, `[`, `as`, `in`, or `||`, found `(`
-            @14..15: expected `!=`, `%`, `&&`, `'`, `*`, `+`, `-`, `.`, `/`, `::`, `<`, `<=`, `==`, `>`, `>=`, `?`, `[`, `as`, `in`, or `||`
-        "#]],
-    );
-
-    check(
-        &run_parser!(expr, r#"foo(1, 2, { 3, x }.1, [y, __vec_len()])"#),
-        expect_test::expect![[r#"
-            expected `!=`, `%`, `&&`, `'`, `*`, `+`, `-`, `.`, `/`, `::`, `<`, `<=`, `==`, `>`, `>=`, `?`, `[`, `as`, `in`, or `||`, found `(`
-            @14..15: expected `!=`, `%`, `&&`, `'`, `*`, `+`, `-`, `.`, `/`, `::`, `<`, `<=`, `==`, `>`, `>=`, `?`, `[`, `as`, `in`, or `||`
-        "#]],
-    );
-
-    check(
-        &run_parser!(
-            (yp::PintParser::new(), ""),
-            r#"predicate test { var x = foo(a*3, c); }"#
-        ),
-        expect_test::expect![[r#"
-            expected `!=`, `%`, `&&`, `'`, `*`, `+`, `-`, `.`, `..`, `/`, `;`, `<`, `<=`, `==`, `>`, `>=`, `?`, `[`, `as`, `in`, or `||`, found `(`
-            @28..29: expected `!=`, `%`, `&&`, `'`, `*`, `+`, `-`, `.`, `..`, `/`, `;`, `<`, `<=`, `==`, `>`, `>=`, `?`, `[`, `as`, `in`, or `||`
-        "#]],
-    );
-
-    check(
-        &run_parser!(
-            (yp::TestDelegateParser::new(), "expr"),
-            "__this_address(-a, b+c)"
-        ),
+        &run_parser!(expr, "__this_address(-a, b+c)"),
         expect_test::expect!["__this_address(-::a, (::b + ::c))"],
     );
 }
@@ -3018,8 +3017,8 @@ fn big_ints() {
             "var blah = 0xfeedbadfd2adeadcafed00dbabefacefeedbadf00d2adeadcafed00dbabeface;"
         ),
         expect_test::expect![[r#"
-            expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`, found `var`
-            @0..3: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`
+            expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`, found `var`
+            @0..3: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`
         "#]],
     );
 
@@ -3412,8 +3411,8 @@ fn experimental() {
     check(
         &run_parser!(
             expr,
-            r#"{0, 
-            {1.0, 0x0000222200002222000022220000222200002222000022220000222200002222}, 
+            r#"{0,
+            {1.0, 0x0000222200002222000022220000222200002222000022220000222200002222},
             0x0000111100001111000011110000111100001111000011110000111100001111}"#
         ),
         expect_test::expect!["{0, {1e0, 0x0000222200002222000022220000222200002222000022220000222200002222}, 0x0000111100001111000011110000111100001111000011110000111100001111}"],
@@ -3422,8 +3421,8 @@ fn experimental() {
     check(
         &run_parser!(
             expr,
-            r#"{x: 0, {y: 1.0, 
-            0x0000222200002222000022220000222200002222000022220000222200002222}, z: 
+            r#"{x: 0, {y: 1.0,
+            0x0000222200002222000022220000222200002222000022220000222200002222}, z:
             0x0000111100001111000011110000111100001111000011110000111100001111}"#
         ),
         expect_test::expect!["{x: 0, {y: 1e0, 0x0000222200002222000022220000222200002222000022220000222200002222}, z: 0x0000111100001111000011110000111100001111000011110000111100001111}"],

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -1,19 +1,18 @@
 use crate::{
     error::{Error, Handler, ParseError},
     expr::*,
-    predicate::{
-        BlockStatement, Const, ConstraintDecl, ExprKey, IfDecl, PredicateInterface, InterfaceDecl,
-        InterfaceInstance, InterfaceVar, Predicate,
-        StorageVar,
-    },
     lexer,
     macros::{MacroCall, MacroDecl},
     parser::{
         ParserContext,
         UseTree::{self, Path as UseTreePath},
     },
+    predicate::{
+        BlockStatement, Const, ConstraintDecl, ExprKey, IfDecl, InterfaceDecl, InterfaceInstance,
+        InterfaceVar, MatchDecl, MatchDeclBranch, Predicate, PredicateInterface, StorageVar,
+    },
     span::Spanned,
-    types::{EnumDecl, NewTypeDecl, Path, PrimitiveKind, Type},
+    types::{EnumDecl, NewTypeDecl, Path, PrimitiveKind, Type, UnionDecl, UnionVariant},
 };
 
 grammar<'a>(
@@ -37,20 +36,22 @@ Decl: () = {
     NewTypeDecl ";",
     PredicateDecl,
     StorageDecl,
+    UnionDecl ";",
     UseStatement ";",
-};
+}
 
 // Decls allowed inside predicates.
 PredicateInnerDecl: () = {
     ConstraintDecl ";",
     IfDecl,
+    MatchDecl,
     InterfaceInstance ";",
     MacroCallDecl ";",
     PredicateInstance ";",
     StateDecl ";",
     UseStatement ";",
     VarDecl ";",
-};
+}
 
 // Decls allowed inside macro bodies, which is ALL of them except `MacroDecl`.
 DeclInnerMacroBody: () = {
@@ -58,6 +59,7 @@ DeclInnerMacroBody: () = {
     ConstraintDecl ";",
     EnumDecl ";",
     IfDecl,
+    //MatchDecl,        We can't have match decls _and_ match expressions in bodies, there's a conflict.  Needs special casing.
     Interface,
     InterfaceInstance ";",
     MacroCallDecl ";",
@@ -66,9 +68,10 @@ DeclInnerMacroBody: () = {
     PredicateInstance ";",
     StateDecl ";",
     StorageDecl,
+    UnionDecl ";",
     UseStatement ";",
     VarDecl ";",
-};
+}
 
 PredicateDecl: () = {
     PredicateOpen PredicateInnerDecl* PredicateClose,
@@ -220,7 +223,7 @@ UseStatement: () = {
     "use" <l:@L> <abs:"::"?> <ut:UseTree> <r:@R> => {
         context.parse_use_statement(handler, abs.is_some(), ut, (l, r))
     }
-};
+}
 
 UsePathIdent: Ident = {
     Ident,
@@ -233,7 +236,7 @@ UseTree: UseTree = {
     <prefix:UsePathIdent> "::" <suffix:UseTree> => UseTreePath { prefix, suffix: Box::new(suffix) },
     "{" <imports:SepList<UseTree, ",">> "}" => UseTree::Group { imports },
     <name:UsePathIdent> "as" <alias:Ident> => UseTree::Alias { name, alias },
-};
+}
 
 VarDecl: () = {
     <l:@L> <r#pub:"pub"?> "var" <name:VarName> ":" <ty:Type> <init:VarInit?> <r:@R> => {
@@ -245,16 +248,16 @@ VarDecl: () = {
     <l:@L> <r#pub:"pub"?> "var" <name:VarName> <r:@R> => {
         context.parse_var_decl(handler, r#pub.is_some(), name, None, None, (l, r));
     }
-};
+}
 
 VarName: (Ident, Option<&'a str>) = {
     <l:@L> <id:"ident"> <r:@R> => context.parse_var_name(id, (l, r)),
-};
+}
 
 VarInit: ExprKey = {
     "=" <Range>,
     "=" <Expr>,
-};
+}
 
 StateDecl: () = {
     <l:@L> "state" <name:Ident> <ty:(":" <Type>)?> "=" <init:StateInit> <r:@R> => {
@@ -267,7 +270,7 @@ StateDecl: () = {
             .insert_state(handler, mod_prefix, &name, ty, init, span)
             .map(|_| ());
     },
-};
+}
 
 ConstDecl: () = {
     <l:@L> "const" <name:Ident> <ty:(":" <Type>)?> "=" <init:Expr> <r:@R> => {
@@ -290,13 +293,13 @@ ConstDecl: () = {
             );
         }
     }
-};
+}
 
 ConstraintDecl: () = {
     <constraint: Constraint> => context.current_pred()
             .expect("adding a contraint to the predicate")
     .constraints.push(constraint),
-};
+}
 
 Constraint: ConstraintDecl = {
     <l:@L> "constraint" <expr:Expr> <r:@R> => {
@@ -305,24 +308,25 @@ Constraint: ConstraintDecl = {
             span: (context.span_from)(l, r),
         }
     }
-};
+}
 
 BlockStatement: BlockStatement = {
     <constraint: Constraint> ";" => BlockStatement::Constraint(constraint),
     <if_decl: If> => BlockStatement::If(if_decl),
+    <match_decl: Match> => BlockStatement::Match(match_decl),
 }
 
-ThenBlock: Vec<BlockStatement> = {
+BlockStmts: Vec<BlockStatement> = {
     "{" <block_statements:BlockStatement*> "}" => block_statements
-};
+}
 
-ElseBlock: Vec<BlockStatement> = {
+IfBlockElse: Vec<BlockStatement> = {
     "else" "{" <block_statements:BlockStatement*> "}" => block_statements,
     "else" <if_decl:If> => vec![BlockStatement::If(if_decl)],
-};
+}
 
 If: IfDecl = {
-    <l:@L> "if" <condition:Expr> <then_block:ThenBlock> <else_block:ElseBlock?> <r:@R> => {
+    <l:@L> "if" <condition:Expr> <then_block:BlockStmts> <else_block:IfBlockElse?> <r:@R> => {
         IfDecl {
             condition,
             then_block,
@@ -330,13 +334,53 @@ If: IfDecl = {
             span: (context.span_from)(l, r),
         }
     }
-};
+}
 
 IfDecl: () = {
-    <if_decl: If> => context.current_pred()
+    <if_decl: If> => {
+        context
+            .current_pred()
             .expect("adding an if-decl to the predicate")
-    .if_decls.push(if_decl)
-};
+            .if_decls
+            .push(if_decl)
+    }
+}
+
+MatchBlock: MatchDeclBranch = {
+    <l:@L> <name:Path> <r:@R> <binding:("(" <Ident> ")")?> "=>" <block:BlockStmts> ","? => {
+        MatchDeclBranch {
+            name,
+            name_span: (context.span_from)(l, r),
+            binding,
+            block,
+        }
+    }
+}
+
+MatchBlockElse: Vec<BlockStatement> = {
+    "else" "=>" <BlockStmts> ","?,
+}
+
+Match: MatchDecl = {
+    <l:@L> "match" <match_expr:Expr> "{" <match_branches:MatchBlock+> <else_branch:MatchBlockElse?> "}" <r:@R> => {
+        MatchDecl {
+            match_expr,
+            match_branches,
+            else_branch,
+            span: (context.span_from)(l, r),
+        }
+    }
+}
+
+MatchDecl: () = {
+    <match_decl: Match> => {
+        context
+            .current_pred()
+            .expect("adding a match-decl to the predicate")
+            .match_decls
+            .push(match_decl)
+    }
+}
 
 EnumDecl: () = {
     <l:@L> "enum" <name:Ident> "=" <variants:Sep1ListNoTrail<Ident, "|">> <r:@R> => {
@@ -357,6 +401,26 @@ NewTypeDecl: () = {
             span: (context.span_from)(l, r),
         };
         context.contract.new_types.push(new_type_decl);
+    }
+}
+
+UnionDecl: () = {
+    <l:@L> "union" <name:Ident> "=" <variants:Sep1ListNoTrail<UnionVariant, "|">> <r:@R> => {
+        let union_decl = UnionDecl {
+            name: context.add_top_level_symbol(handler, name, context.mod_prefix),
+            variants,
+            span: (context.span_from)(l, r),
+        };
+        context.contract.unions.push(union_decl);
+    }
+}
+
+UnionVariant: UnionVariant = {
+    <variant_name:Ident> <ty:("(" <Type> ")")?> => {
+        UnionVariant {
+            variant_name,
+            ty,
+        }
     }
 }
 
@@ -408,7 +472,7 @@ Type: Type = {
     <ArrayType>,
     <VectorType>,
     <TypeAtom>,
-};
+}
 
 TypeAtom: Type = {
     <l:@L> <kind:PrimitiveType> <r:@R> => {
@@ -445,7 +509,7 @@ TypeAtom: Type = {
         path,
         span: (context.span_from)(l, r),
     },
-};
+}
 
 ArrayType: Type = {
     <l:@L> <ty:TypeAtom> <ranges: ("[" <Expr> "]")+ > <r:@R> => {
@@ -460,7 +524,7 @@ ArrayType: Type = {
             span: (context.span_from)(l, r),
         })
     },
-};
+}
 
 PrimitiveType: PrimitiveKind = {
     "int_ty" => PrimitiveKind::Int,
@@ -472,11 +536,11 @@ PrimitiveType: PrimitiveKind = {
 TupleFields: Vec<(Option<Ident>, Type)> = {
     <field:TupleField> => vec![field],
     <Sep1List<TupleField, ",">>,
-};
+}
 
 TupleField: (Option<Ident>, Type) = {
     <id:(<Ident> ":")?> <ty:Type> => (id, ty),
-};
+}
 
 /////////////////////
 /// Storage Types ///
@@ -534,7 +598,7 @@ LogicalOrOp: ExprKey = {
         )
     },
     <LogicalAndOp>,
-};
+}
 
 LogicalAndOp: ExprKey = {
     <l:@L> <lhs:LogicalAndOp> "&&" <rhs:Comparison> <r:@R> => {
@@ -550,7 +614,7 @@ LogicalAndOp: ExprKey = {
         )
     },
     <Comparison>,
-};
+}
 
 Comparison: ExprKey = {
     <l:@L> <lhs:Comparison> <op:RelOpOp> <rhs:InOp> <r:@R> => {
@@ -566,7 +630,7 @@ Comparison: ExprKey = {
         )
     },
     <InOp>,
-};
+}
 
 RelOpOp: BinaryOp = {
     "==" => BinaryOp::Equal,
@@ -575,7 +639,7 @@ RelOpOp: BinaryOp = {
     "<=" => BinaryOp::LessThanOrEqual,
     ">" => BinaryOp::GreaterThan,
     ">=" => BinaryOp::GreaterThanOrEqual,
-};
+}
 
 InOp: ExprKey = {
      <l:@L> <value:InOp> "in" <collection:Additive> <r:@R> => {
@@ -601,7 +665,7 @@ InOp: ExprKey = {
         )
      },
     <Additive>,
-};
+}
 
 Additive: ExprKey = {
     <l:@L> <lhs:Additive> <op:AddOpOp> <rhs:Multiplicative> <r:@R> => {
@@ -617,12 +681,12 @@ Additive: ExprKey = {
         )
     },
     <Multiplicative>,
-};
+}
 
 AddOpOp: BinaryOp = {
     "+" => BinaryOp::Add,
     "-" => BinaryOp::Sub,
-};
+}
 
 Multiplicative: ExprKey = {
     <l:@L> <lhs:Multiplicative> <op:MultOpOp> <rhs:AsOp> <r:@R> => {
@@ -638,13 +702,13 @@ Multiplicative: ExprKey = {
         )
     },
     <AsOp>,
-};
+}
 
 MultOpOp: BinaryOp = {
     "*" => BinaryOp::Mul,
     "/" => BinaryOp::Div,
     "%" => BinaryOp::Mod,
-};
+}
 
 AsOp: ExprKey = {
      <l:@L> <value:AsOp> "as" <ty:Type> <r:@R> => {
@@ -652,14 +716,14 @@ AsOp: ExprKey = {
         context.contract.exprs.insert(
             Expr::Cast {
                 value,
-                ty: Box::new(ty),
+                ty,
                 span: span.clone(),
             },
             Type::Unknown(span),
         )
      },
     <UnaryOp>,
-};
+}
 
 UnaryOpOp: UnaryOp = {
     <l:@L> "+" <r:@R> => {
@@ -672,7 +736,7 @@ UnaryOpOp: UnaryOp = {
     },
     "-" => UnaryOp::Neg,
     "!" => UnaryOp::Not,
-};
+}
 
 UnaryOp: ExprKey = {
     <l:@L> <op:UnaryOpOp> <expr:UnaryOp> <r:@R> => {
@@ -687,7 +751,7 @@ UnaryOp: ExprKey = {
         )
     },
     <PostfixOp>,
-};
+}
 
 PostfixOp: ExprKey = {
     <l:@L> <expr:PostfixOp> "[" <index:Expr> "]" <r:@R> => {
@@ -734,7 +798,7 @@ PostfixOp: ExprKey = {
         )
     },
     <Term>,
-};
+}
 
 Term: ExprKey = {
     <e:TermInner> => {
@@ -743,8 +807,9 @@ Term: ExprKey = {
     },
     MacroCallExpr,
     CondExpr,
+    MatchExpr,
     "(" <Expr> ")",
-};
+}
 
 TermInner: Expr = {
     <l:@L> <imm:Immediate> <r:@R> => {
@@ -776,8 +841,9 @@ TermInner: Expr = {
     },
     ArrayExpr,
     TupleExpr,
+    UnionExpr,
     <l:@L> <path:Path> <r:@R> => Expr::Path(path, (context.span_from)(l, r)),
-};
+}
 
 GeneratorRange: (Ident, ExprKey) = {
     <index:Ident> "in" <range:Range> => {
@@ -826,11 +892,11 @@ GeneratorExpr: Expr = {
 
 CondBranch: (ExprKey, ExprKey) = {
     <condition:Expr> "=>" <result:Expr> "," => (condition, result)
-};
+}
 
 ElseBranch: ExprKey = {
     "else" "=>" <else_result:Expr> ","? => else_result
-};
+}
 
 CondExpr: ExprKey = {
     <l:@L> "cond" "{" <cond_branches: (<CondBranch>)*> <else_branch: ElseBranch> "}" <r:@R> => {
@@ -854,7 +920,80 @@ CondExpr: ExprKey = {
                 )
             })
     }
-};
+}
+
+MatchExpr: ExprKey = {
+    <l:@L> "match" <expr:Expr> "{" <match_branches:Sep1List<MatchBranch, ",">> "}" <r:@R> => {
+        let span = (context.span_from)(l, r);
+        context.contract.exprs.insert(
+            Expr::Match {
+                match_expr: expr,
+                match_branches,
+                else_branch: None,
+                span: span.clone(),
+            },
+            Type::Unknown(span),
+        )
+    },
+
+    <l:@L> "match" <expr:Expr> "{" <match_branches:(<MatchBranch> ",")*> <else_branch:MatchElse> "}" <r:@R> => {
+        let span = (context.span_from)(l, r);
+        context.contract.exprs.insert(
+            Expr::Match {
+                match_expr: expr,
+                match_branches,
+                else_branch: Some(else_branch),
+                span: span.clone(),
+            },
+            Type::Unknown(span),
+        )
+    },
+}
+
+MatchBranch: MatchBranch = {
+    <l:@L> <name:Path> <r:@R> <binding:("(" <Ident> ")")?> "=>" <expr:Expr> => {
+        MatchBranch {
+            name,
+            name_span: (context.span_from)(l, r),
+            binding,
+            constraints: Vec::default(),
+            expr,
+        }
+    },
+
+    // The block must contain a constraint, otherwise there's an ambiguity between a single
+    // expression in block `{ expr }` or a tuple literal `{ field_expr }`.
+    <l:@L> <name:Path> <r:@R> <binding:("(" <Ident> ")")?> "=>" "{"
+        <cdecls:(<Constraint> ";")+>
+        <expr:Expr>
+    "}" => {
+        let constraints = cdecls.into_iter().map(|ConstraintDecl { expr, .. }| expr).collect();
+        MatchBranch {
+            name,
+            name_span: (context.span_from)(l, r),
+            binding,
+            constraints,
+            expr
+        }
+    }
+}
+
+MatchElse: MatchElse = {
+    "else" "=>" <else_expr:Expr> ","? => {
+        MatchElse {
+            constraints: Vec::default(),
+            expr: else_expr,
+        }
+    },
+
+    "else" "=>" "{"
+        <cdecls:(<Constraint> ";")+>
+        <expr:Expr>
+    "}" => {
+        let constraints = cdecls.into_iter().map(|ConstraintDecl { expr, .. }| expr).collect();
+        MatchElse { constraints, expr }
+    }
+}
 
 MacroCallExpr: ExprKey = {
     <l:@L> <name:MacroPath> <tag:"macro_tag"?> <args:"macro_call_args"> <r:@L> => {
@@ -890,7 +1029,7 @@ MacroCallExpr: ExprKey = {
             .insert(call_key, (call_expr_key, call_data));
         call_expr_key
     },
-};
+}
 
 IntrinsicArg: ExprKey = {
     Expr,
@@ -913,7 +1052,7 @@ IntrinsicCallExpr: Expr = {
     <l:@L> <name:IntrinsicName> "(" <args:SepList<IntrinsicArg, ",">> ")" <r:@R> => {
         context.parse_intrinsic_call(handler, name, args, (l, r))
     },
-};
+}
 
 ArrayExpr: Expr = {
     <l:@L> "[" <il:@L> <elements:SepList<Expr, ",">> <ir:@R> "]" <r:@R> => {
@@ -931,7 +1070,7 @@ ArrayExpr: Expr = {
             span: (context.span_from)(l, r),
         }
     },
-};
+}
 
 TupleExpr: Expr = {
     <l:@L> "{" <fields:TupleExprFields> "}" <r:@R> => {
@@ -948,7 +1087,7 @@ TupleExpr: Expr = {
 
         Expr::Error(span)
     },
-};
+}
 
 TupleExprFields: Vec<(Option<Ident>, ExprKey)> = {
     <id:Ident> ":" <expr:Expr> => {
@@ -962,11 +1101,22 @@ TupleExprFields: Vec<(Option<Ident>, ExprKey)> = {
         vec![(None, expr)]
     },
     <Sep1List<TupleExprField, ",">>,
-};
+}
 
 TupleExprField: (Option<Ident>, ExprKey) = {
     <id:(<Ident> ":")?> <expr:Expr> => (id, expr),
-};
+}
+
+UnionExpr: Expr = {
+    <l:@L> <path:Path> <m:@R> "(" <value:Expr> ")" <r:@R> => {
+        Expr::UnionVariant {
+            path,
+            path_span: (context.span_from)(l, m),
+            value: Some(value),
+            span: (context.span_from)(l, r),
+        }
+    }
+}
 
 Range: ExprKey = {
     <l:@L> <lb:Additive> ".." <ub:Additive> <r:@R> => {
@@ -995,10 +1145,10 @@ PathWithLast<Last>: Path = {
         let span = (context.span_from)(l, r);
         context.parse_relative_path(els, last, true, span)
     }
-};
+}
 
 Immediate: Immediate = {
-    <l:@L> <s:"int_lit"> <r:@R>=> context.parse_int_immediate(handler, s, (l, r)),
+    <l:@L> <s:"int_lit"> <r:@R> => context.parse_int_immediate(handler, s, (l, r)),
     <s:"real_lit"> => Immediate::Real(s.replace('_', "").parse().unwrap()),
     "true" => Immediate::Bool(true),
     "false" => Immediate::Bool(false),
@@ -1083,7 +1233,7 @@ StorageIndexOp: ExprKey = {
             .insert(Expr::Error(span.clone()), Type::Unknown(span))
     },
     <StorageAccess>,
-};
+}
 
 StorageAccess: ExprKey = {
     <l:@L> <mutable: "mut"?> "storage" "::" <name:Ident> <r:@R> => {
@@ -1114,7 +1264,7 @@ SepList<Ty, Sep>: Vec<Ty> = {
         }
         v
     }
-};
+}
 
 // List of one or more Ty separated by Sep, allowing a trailing Sep.  The separator is required in
 // the single element case.
@@ -1125,7 +1275,7 @@ Sep1List<Ty, Sep>: Vec<Ty> = {
         }
         v
     }
-};
+}
 
 // List of one or more Ty separated by Sep, disallowing a trailing Sep.
 Sep1ListNoTrail<Ty, Sep>: Vec<Ty> = {
@@ -1133,7 +1283,7 @@ Sep1ListNoTrail<Ty, Sep>: Vec<Ty> = {
         v.push(e);
         v
     }
-};
+}
 
 pub(crate) TestDelegate: crate::parser::TestWrapper = {
     "test_expr" <Expr> => crate::parser::TestWrapper::Expr(<>),
@@ -1144,7 +1294,7 @@ pub(crate) TestDelegate: crate::parser::TestWrapper = {
     "test_intrinsic" <IntrinsicName> => crate::parser::TestWrapper::Ident(<>),
     "test_usetree" <UseTree> => crate::parser::TestWrapper::UseTree(<>),
     "test_state" <StateInit> => crate::parser::TestWrapper::Expr(<>),
-};
+}
 
 /////////////
 /// Lexer ///
@@ -1210,6 +1360,7 @@ extern {
         "if" => lexer::Token::If,
         "else" => lexer::Token::Else,
         "cond" => lexer::Token::Cond,
+        "match" => lexer::Token::Match,
 
         "pub" => lexer::Token::Pub,
         "mut" => lexer::Token::Mut,
@@ -1222,6 +1373,7 @@ extern {
         "interface" => lexer::Token::Interface,
         "enum" => lexer::Token::Enum,
         "type" => lexer::Token::Type,
+        "union" => lexer::Token::Union,
         "constraint" => lexer::Token::Constraint,
         "as" => lexer::Token::As,
         "predicate" => lexer::Token::Predicate,

--- a/pintc/src/predicate/analyse.rs
+++ b/pintc/src/predicate/analyse.rs
@@ -3,7 +3,7 @@ mod type_check;
 
 use super::{
     BlockStatement, Const, ConstraintDecl, Contract, Expr, ExprKey, Ident, IfDecl,
-    InterfaceInstance, Predicate, PredicateInstance, VarKey,
+    InterfaceInstance, MatchDecl, Predicate, PredicateInstance, VarKey,
 };
 use crate::{
     error::{CompileError, Error, ErrorEmitted, Handler},
@@ -12,11 +12,16 @@ use crate::{
     types::Type,
 };
 
+#[derive(Debug)]
 enum Inference {
     Ignored,
     Type(Type),
     Dependant(ExprKey),
     Dependencies(Vec<ExprKey>),
+    BoundDependencies {
+        deps: Vec<ExprKey>,
+        bound_deps: Vec<(Ident, Type, Vec<ExprKey>)>,
+    },
 }
 
 impl Contract {
@@ -186,7 +191,8 @@ impl Contract {
 
                         Inference::Ignored
                         | Inference::Dependant(_)
-                        | Inference::Dependencies(_) => {
+                        | Inference::Dependencies(_)
+                        | Inference::BoundDependencies { .. } => {
                             emit_internal("const inferred a dependant type");
                         }
                     }

--- a/pintc/src/predicate/display.rs
+++ b/pintc/src/predicate/display.rs
@@ -94,6 +94,10 @@ impl Display for Contract {
             writeln!(f, "{enum};")?;
         }
 
+        for r#union in &self.unions {
+            writeln!(f, "{};", self.with_ctrct(union))?;
+        }
+
         for new_type in &self.new_types {
             writeln!(f, "{};", self.with_ctrct(new_type))?;
         }
@@ -221,6 +225,10 @@ impl Predicate {
             if_decl.fmt_with_indent(f, contract, self, indent)?;
         }
 
+        for match_decl in &self.match_decls {
+            match_decl.fmt_with_indent(f, contract, self, indent)?;
+        }
+
         Ok(())
     }
 }
@@ -244,5 +252,17 @@ impl DisplayWithContract for ConstraintDecl {
 impl DisplayWithContract for StorageVar {
     fn fmt(&self, f: &mut Formatter, contract: &Contract) -> Result {
         write!(f, "{}: {},", self.name.name, contract.with_ctrct(&self.ty))
+    }
+}
+
+impl DisplayWithPred for IfDecl {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> Result {
+        self.fmt_with_indent(f, contract, pred, 0)
+    }
+}
+
+impl DisplayWithPred for MatchDecl {
+    fn fmt(&self, f: &mut Formatter, contract: &Contract, pred: &Predicate) -> Result {
+        self.fmt_with_indent(f, contract, pred, 0)
     }
 }

--- a/pintc/src/predicate/states.rs
+++ b/pintc/src/predicate/states.rs
@@ -86,13 +86,13 @@ impl StateKey {
         pred.states.states.get(*self).unwrap()
     }
 
-    /// Returns the type of key `self` given an `Predicate`. Panics if the type can't be
+    /// Returns the type of key `self` given a `Predicate`. Panics if the type can't be
     /// found in the `state_types` map.
     pub fn get_ty<'a>(&'a self, pred: &'a Predicate) -> &Type {
         pred.states.state_types.get(*self).unwrap()
     }
 
-    /// Set the type of key `self` in an `Predicate`. Panics if the type can't be found in
+    /// Set the type of key `self` in a `Predicate`. Panics if the type can't be found in
     /// the `state_types` map.
     pub fn set_ty<'a>(&'a self, ty: Type, pred: &'a mut Predicate) {
         pred.states.state_types.insert(*self, ty);

--- a/pintc/src/predicate/transform/unroll.rs
+++ b/pintc/src/predicate/transform/unroll.rs
@@ -9,7 +9,7 @@ use fxhash::FxHashMap;
 use itertools::Itertools;
 use std::collections::HashSet;
 
-/// Given an `Predicate`, and a generator expression containing a list of indices with
+/// Given a `Predicate`, and a generator expression containing a list of indices with
 /// their ranges `gen_ranges`, an optional list of `conditions`, and a body, return a new
 /// expression that is the conjunction or disjunction of all the possible valid generator bodies.
 ///
@@ -207,7 +207,7 @@ fn unroll_generator(
     Ok(unrolled)
 }
 
-/// Given an `Predicate`, unroll all generator expressions and replace them in the
+/// Given a `Predicate`, unroll all generator expressions and replace them in the
 /// expressions map with their unrolled version
 pub(crate) fn unroll_generators(
     handler: &Handler,

--- a/pintc/src/predicate/vars.rs
+++ b/pintc/src/predicate/vars.rs
@@ -87,13 +87,13 @@ impl VarKey {
         pred.vars.vars.get(*self).unwrap()
     }
 
-    /// Returns the type of key `self` given an `Predicate`. Panics if the type can't be
+    /// Returns the type of key `self` given a `Predicate`. Panics if the type can't be
     /// found in the `var_types` map.
     pub fn get_ty<'a>(&'a self, pred: &'a Predicate) -> &Type {
         pred.vars.var_types.get(*self).unwrap()
     }
 
-    /// Set the type of key `self` in an `Predicate`. Panics if the type can't be found in
+    /// Set the type of key `self` in a `Predicate`. Panics if the type can't be found in
     /// the `var_types` map.
     pub fn set_ty<'a>(&'a self, ty: Type, pred: &'a mut Predicate) {
         pred.vars.var_types.insert(*self, ty);

--- a/pintc/src/types.rs
+++ b/pintc/src/types.rs
@@ -39,6 +39,10 @@ pub enum Type {
         fields: Vec<(Option<Ident>, Self)>,
         span: Span,
     },
+    Union {
+        path: Path,
+        span: Span,
+    },
     Custom {
         path: Path,
         span: Span,
@@ -76,6 +80,12 @@ macro_rules! check_alias {
         $self
             .is_alias()
             .map(|ty| ty.$recurse($recurse_arg))
+            .unwrap_or_else(|| $otherwise)
+    };
+    ($self: ident, $recurse: ident, $recurse_arg0: expr, $recurse_arg1: expr, $otherwise: expr) => {
+        $self
+            .is_alias()
+            .map(|ty| ty.$recurse($recurse_arg0, $recurse_arg1))
             .unwrap_or_else(|| $otherwise)
     };
 }
@@ -172,6 +182,112 @@ impl Type {
             } else {
                 None
             }
+        })
+    }
+
+    pub fn is_union(&self, unions: &[UnionDecl]) -> bool {
+        self.get_union_name(unions).is_some()
+            || check_alias!(self, is_union, unions, matches!(self, Type::Union { .. }))
+    }
+
+    pub fn get_union_name<'a>(&self, unions: &'a [UnionDecl]) -> Option<&'a Path> {
+        check_alias!(self, get_union_name, unions, {
+            self.get_union_decl(unions).map(|ud| &ud.name.name)
+        })
+    }
+
+    fn get_union_decl<'a>(&self, unions: &'a [UnionDecl]) -> Option<&'a UnionDecl> {
+        match self {
+            Type::Custom { path, .. } | Type::Union { path, .. } => unions
+                .iter()
+                .find(|UnionDecl { name, .. }| (&name.name == path)),
+
+            _ => None,
+        }
+    }
+
+    // This is a little wacky.  It returns Err if the union or variant is unknown, and returns
+    // Ok(Some(ty)) if the union variant has a binding, else Ok(None).
+    pub fn get_union_variant_ty<'a>(
+        &self,
+        unions: &'a [UnionDecl],
+        variant_name: &Path,
+    ) -> Result<Option<&'a Type>, ()> {
+        check_alias!(self, get_union_variant_ty, unions, variant_name, {
+            self.get_union_decl(unions).ok_or(()).and_then(
+                |UnionDecl {
+                     name: union_name,
+                     variants,
+                     ..
+                 }| {
+                    // The name prefix has to match the union name first, and it has to have the
+                    // '::' separator.
+                    let ul = union_name.name.len();
+                    if variant_name.len() > ul + 2
+                        && variant_name.starts_with(&union_name.name)
+                        && &variant_name[ul..(ul + 2)] == "::"
+                    {
+                        // Then we compare each variant with the rest of the variant name.
+                        variants
+                            .iter()
+                            .find_map(
+                                |UnionVariant {
+                                     variant_name: union_variant_name,
+                                     ty,
+                                     ..
+                                 }| {
+                                    (union_variant_name.name == variant_name[(ul + 2)..])
+                                        .then_some(ty.as_ref())
+                                },
+                            )
+                            .ok_or(())
+                    } else {
+                        // Variant not found.
+                        Err(())
+                    }
+                },
+            )
+        })
+    }
+
+    pub fn get_union_variant_names(&self, unions: &[UnionDecl]) -> Vec<String> {
+        check_alias!(self, get_union_variant_names, unions, {
+            self.get_union_decl(unions)
+                .map(
+                    |UnionDecl {
+                         name: union_name,
+                         variants,
+                         ..
+                     }| {
+                        variants
+                            .iter()
+                            .map(|UnionVariant { variant_name, .. }| {
+                                union_name.name[2..].to_string() + "::" + variant_name.name.as_str()
+                            })
+                            .collect()
+                    },
+                )
+                .unwrap_or_default()
+        })
+    }
+
+    pub fn get_union_variant_types(&self, unions: &[UnionDecl]) -> Vec<Option<Type>> {
+        check_alias!(self, get_union_variant_types, unions, {
+            self.get_union_decl(unions)
+                .map(|UnionDecl { variants, .. }| {
+                    variants
+                        .iter()
+                        .map(|UnionVariant { ty, .. }| ty.clone())
+                        .collect()
+                })
+                .unwrap_or_default()
+        })
+    }
+
+    pub fn get_union_variant_count(&self, unions: &[UnionDecl]) -> Option<usize> {
+        check_alias!(self, get_union_variant_count, unions, {
+            self.get_union_decl(unions)
+                .map(|UnionDecl { variants, .. }| variants.len())
         })
     }
 
@@ -357,6 +473,10 @@ impl Type {
                 // aliases have been lowered by now
                 false
             }
+            Type::Union { .. } => {
+                // Also disallow unions for now.
+                false
+            }
             _ => true,
         }
     }
@@ -389,6 +509,27 @@ impl Type {
                     contract,
                 )?) as usize),
 
+            Self::Union { path, .. } => {
+                let Some(UnionDecl { variants, .. }) = contract
+                    .unions
+                    .iter()
+                    .find(|union_decl| &union_decl.name.name == path)
+                else {
+                    unreachable!("unknown path in union type")
+                };
+
+                let mut max_variant_size = 0;
+                for variant in variants {
+                    if let Some(ty) = &variant.ty {
+                        max_variant_size =
+                            std::cmp::max(max_variant_size, ty.size(handler, contract)?);
+                    }
+                }
+
+                // Add 1 for the tag.
+                Ok(max_variant_size + 1)
+            }
+
             // The point here is that a `Map` takes up a storage slot, even though it doesn't
             // actually store anything in it. The `Map` type is not really allowed anywhere else,
             // so we can't have a decision variable of type `Map` for example.
@@ -410,7 +551,7 @@ impl Type {
             | Self::Custom { span, .. }
             | Self::Alias { span, .. } => Err(handler.emit_err(Error::Compile {
                 error: CompileError::Internal {
-                    msg: "unexpected type",
+                    msg: "unexpected type when getting size",
                     span: span.clone(),
                 },
             })),
@@ -468,9 +609,10 @@ impl Type {
             | Self::Unknown(span)
             | Self::Any(span)
             | Self::Custom { span, .. }
+            | Self::Union { span, .. }
             | Self::Alias { span, .. } => Err(handler.emit_err(Error::Compile {
                 error: CompileError::Internal {
-                    msg: "unexpected type",
+                    msg: "unexpected type when calculating storage slots",
                     span: span.clone(),
                 },
             })),
@@ -540,6 +682,8 @@ impl Type {
                     span: span.clone(),
                 },
             })),
+
+            Type::Union { .. } => todo!("put Union into Type::primitive_elements() for storage??"),
         }
     }
 
@@ -677,17 +821,21 @@ impl Type {
                 lhs_ty.eq(new_types, rhs_ty)
             }
 
+            (Self::Union { path: lhs_path, .. }, Self::Union { path: rhs_path, .. }) => {
+                lhs_path == rhs_path
+            }
+
             (lhs_ty, rhs_ty) => {
-                // Custom types are tricky as they may be either aliases or enums.  Or, at this
-                // stage, we might just have two different types.
+                // Custom types are tricky as they may be either aliases, enums or unions.  Or, at
+                // this stage, we might just have two different types.
                 let mut lhs_alias_ty = None;
-                let mut lhs_enum_path = None;
+                let mut lhs_custom_path = None;
 
                 if let Self::Custom { path: lhs_path, .. } = lhs_ty {
                     lhs_alias_ty = new_types.iter().find_map(|NewTypeDecl { name, ty, .. }| {
                         (lhs_path == &name.name).then_some(ty)
                     });
-                    lhs_enum_path = Some(lhs_path);
+                    lhs_custom_path = Some(lhs_path);
                 }
 
                 if let Some(lhs_alias_ty) = lhs_alias_ty {
@@ -696,13 +844,13 @@ impl Type {
                 }
 
                 let mut rhs_alias_ty = None;
-                let mut rhs_enum_path = None;
+                let mut rhs_custom_path = None;
 
                 if let Self::Custom { path: rhs_path, .. } = rhs_ty {
                     rhs_alias_ty = new_types.iter().find_map(|NewTypeDecl { name, ty, .. }| {
                         (rhs_path == &name.name).then_some(ty)
                     });
-                    rhs_enum_path = Some(rhs_path);
+                    rhs_custom_path = Some(rhs_path);
                 }
 
                 if let Some(rhs_alias_ty) = rhs_alias_ty {
@@ -710,12 +858,32 @@ impl Type {
                     return rhs_alias_ty.eq(new_types, lhs_ty);
                 }
 
-                if let (Some(lhs_enum_path), Some(rhs_enum_path)) = (lhs_enum_path, rhs_enum_path) {
-                    // Neither are aliases but both are custom types; assume they're both enums.
-                    lhs_enum_path == rhs_enum_path
-                } else {
+                match (lhs_custom_path, rhs_custom_path) {
+                    (Some(lhs_custom_path), Some(rhs_custom_path)) => {
+                        // Neither are aliases but both are custom types; assume they're both enums.
+                        lhs_custom_path == rhs_custom_path
+                    }
+
+                    (Some(lhs_custom_path), None) => {
+                        if let Type::Union { path, .. } = rhs_ty {
+                            // The LHS is a Custom and the RHS is a Union.  Same path?
+                            lhs_custom_path == path
+                        } else {
+                            false
+                        }
+                    }
+
+                    (None, Some(rhs_custom_path)) => {
+                        if let Type::Union { path, .. } = lhs_ty {
+                            // The LHS is a Union and the RHS is a Custom.  Same path?
+                            rhs_custom_path == path
+                        } else {
+                            false
+                        }
+                    }
+
                     // OK, they must just be different types.
-                    false
+                    _ => false,
                 }
             }
         }
@@ -753,7 +921,8 @@ impl Type {
             | Type::Unknown(_)
             | Type::Any(_)
             | Type::Primitive { .. }
-            | Type::Custom { .. } => {}
+            | Type::Custom { .. }
+            | Type::Union { .. } => {}
         }
     }
 }
@@ -768,6 +937,7 @@ impl Spanned for Type {
             | Primitive { span, .. }
             | Array { span, .. }
             | Tuple { span, .. }
+            | Union { span, .. }
             | Custom { span, .. }
             | Alias { span, .. }
             | Map { span, .. }
@@ -797,6 +967,25 @@ pub struct NewTypeDecl {
 }
 
 impl Spanned for NewTypeDecl {
+    fn span(&self) -> &Span {
+        &self.span
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct UnionDecl {
+    pub(super) name: Ident,
+    pub(super) variants: Vec<UnionVariant>,
+    pub(super) span: Span,
+}
+
+#[derive(Clone, Debug)]
+pub struct UnionVariant {
+    pub(super) variant_name: Ident,
+    pub(super) ty: Option<Type>,
+}
+
+impl Spanned for UnionDecl {
     fn span(&self) -> &Span {
         &self.span
     }

--- a/pintc/tests/consts/bad_pos.pnt
+++ b/pintc/tests/consts/bad_pos.pnt
@@ -9,6 +9,6 @@ predicate A {
 }
 
 // parse_failure <<<
-// expected `::`, `an identifier`, `constraint`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `use`, `var`, or `}`, found `const`
-// @53..58: expected `::`, `an identifier`, `constraint`, `if`, `interface`, `macro_name`, `predicate`, `pub`, `state`, `use`, `var`, or `}`
+// expected `::`, `an identifier`, `constraint`, `if`, `interface`, `macro_name`, `match`, `predicate`, `pub`, `state`, `use`, `var`, or `}`, found `const`
+// @53..58: expected `::`, `an identifier`, `constraint`, `if`, `interface`, `macro_name`, `match`, `predicate`, `pub`, `state`, `use`, `var`, or `}`
 // >>>

--- a/pintc/tests/contracts/bad_stateful.pnt
+++ b/pintc/tests/contracts/bad_stateful.pnt
@@ -20,6 +20,6 @@ predicate Baz {}
 // first `var`.
 //
 // parse_failure <<<
-// expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`, found `var`
-// @22..25: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, or `use`
+// expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`, found `var`
+// @22..25: expected `::`, `an identifier`, `const`, `enum`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`
 // >>>

--- a/pintc/tests/macros/bad_splicing.pnt
+++ b/pintc/tests/macros/bad_splicing.pnt
@@ -19,7 +19,7 @@ predicate test {
 // a macro named `::@add` found with a different signature
 // spliced variable `::b` must be an array
 // @157..158: unable to splice non-array variable `::b`
-// expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`, found `b`
-// @25..27: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`
+// expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `match`, `predicate`, `pub`, `state`, `storage`, `type`, `union`, `use`, `var`, `{`, or `}`, found `b`
+// @25..27: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `match`, `predicate`, `pub`, `state`, `storage`, `type`, `union`, `use`, `var`, `{`, or `}`
 // @151..163: when making macro call to '::@add'
 // >>>

--- a/pintc/tests/macros/splicing_expression_size.pnt
+++ b/pintc/tests/macros/splicing_expression_size.pnt
@@ -16,7 +16,7 @@ predicate test {
 // unable to determine spliced array size
 // @137..140: unable to determine spliced array size for `::ary` while parsing
 // macro array splicing is currently limited to immediate integer sizes or enums
-// expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`, found `ary`
-// @69..71: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `predicate`, `pub`, `state`, `storage`, `type`, `use`, `var`, `{`, or `}`
+// expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `match`, `predicate`, `pub`, `state`, `storage`, `type`, `union`, `use`, `var`, `{`, or `}`, found `ary`
+// @69..71: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `enum`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `macro_name`, `match`, `predicate`, `pub`, `state`, `storage`, `type`, `union`, `use`, `var`, `{`, or `}`
 // @131..141: when making macro call to '::@sum'
 // >>>

--- a/pintc/tests/test.pnt
+++ b/pintc/tests/test.pnt
@@ -1,4 +1,3 @@
-const t = __address_of("::Foo");
-
-predicate Foo {
+predicate test {
+    constraint 0 < true ? 11 : 22;
 }

--- a/pintc/tests/unions/bad_match_name.pnt
+++ b/pintc/tests/unions/bad_match_name.pnt
@@ -1,0 +1,60 @@
+union number = one(bool) | two(int);
+
+predicate test {
+    var n: number;
+    constraint match n {
+        number::one(b) => b ? 11 : 22,
+        number::two(i) => i * i,
+        number::three(a) => a[0],
+    };
+}
+
+predicate decl_test {
+    var n: number;
+    match n {
+        number::one(b) => {
+            constraint b ? 11 : 22;
+        }
+        number::two(i) => {
+            constraint i * i;
+        }
+        number::three(a) => {
+            constraint a[0];
+        }
+    }
+}
+
+// parsed <<<
+// union ::number = one(bool) | two(int);
+//
+// predicate ::test {
+//     var ::n: ::number;
+//     constraint match ::n { ::number::one(b) => (::b ? 11 : 22), ::number::two(i) => (::i * ::i), ::number::three(a) => ::a[0] };
+// }
+//
+// predicate ::decl_test {
+//     var ::n: ::number;
+//     match ::n {
+//         ::number::one(b) => {
+//             constraint (::b ? 11 : 22)
+//         }
+//         ::number::two(i) => {
+//             constraint (::i * ::i)
+//         }
+//         ::number::three(a) => {
+//             constraint ::a[0]
+//         }
+//     }
+// }
+// >>>
+
+// typecheck_failure <<<
+// unknown union variant name
+// @179..192: invalid variant name `::number::three` for union `::number`
+// valid variant names are `number::one` and `number::two`
+// unknown union variant name
+// @420..433: invalid variant name `::number::three` for union `::number`
+// valid variant names are `number::one` and `number::two`
+// constraint expression type error
+// @89..210: expecting type `bool`
+// >>>

--- a/pintc/tests/unions/bad_match_value.pnt
+++ b/pintc/tests/unions/bad_match_value.pnt
@@ -1,0 +1,62 @@
+union number = zero | one(int) | more(bool);
+
+predicate test {
+    var n: number;
+    constraint match n {
+        number::zero(x) => x == 0,
+        number::one => true,
+        else => false,
+    };
+}
+
+predicate decl_test {
+    var n: number;
+    match n {
+        number::zero(x) => {
+            constraint x == 0;
+        }
+        number::one => {
+            constraint true;
+        }
+        else => {
+            constraint false;
+        }
+    }
+}
+
+// parsed <<<
+// union ::number = zero | one(int) | more(bool);
+//
+// predicate ::test {
+//     var ::n: ::number;
+//     constraint match ::n { ::number::zero(x) => (::x == 0), ::number::one => true, else => false };
+// }
+//
+// predicate ::decl_test {
+//     var ::n: ::number;
+//     match ::n {
+//         ::number::zero(x) => {
+//             constraint (::x == 0)
+//         }
+//         ::number::one => {
+//             constraint true
+//         }
+//         else => {
+//             constraint false
+//         }
+//     }
+// }
+// >>>
+
+// typecheck_failure <<<
+// union variant does not have a value
+// @115..127: union variant `::number::zero` should not bind a value
+// missing union variant value
+// @150..161: union variant `::number::one` requires a value of type `int`
+// union variant does not have a value
+// @267..279: union variant `::number::zero` should not bind a value
+// missing union variant value
+// @337..348: union variant `::number::one` requires a value of type `int`
+// constraint expression type error
+// @97..199: expecting type `bool`
+// >>>

--- a/pintc/tests/unions/match_bindings_are_n.pnt
+++ b/pintc/tests/unions/match_bindings_are_n.pnt
@@ -1,0 +1,69 @@
+union number = one(bool) | two(int) | three(int[3]);
+
+// Everything is called `n` deliberately and are bound individually.
+
+predicate test {
+    var n: number;
+    constraint 0 <= match n {
+        number::one(n) => n ? 11 : 22,
+        number::two(n) => n * n,
+        number::three(n) => n[0],
+    };
+}
+
+predicate decl_test {
+    var n: number;
+    match n {
+        number::one(n) => {
+            constraint 0 <= (n ? 11 : 22);
+        }
+        number::two(n) => {
+            constraint 0 <= n * n;
+        }
+        number::three(n) => {
+            constraint 0 <= n[0];
+        }
+    }
+}
+
+// parsed <<<
+// union ::number = one(bool) | two(int) | three(int[3]);
+//
+// predicate ::test {
+//     var ::n: ::number;
+//     constraint (0 <= match ::n { ::number::one(n) => (::n ? 11 : 22), ::number::two(n) => (::n * ::n), ::number::three(n) => ::n[0] });
+// }
+//
+// predicate ::decl_test {
+//     var ::n: ::number;
+//     match ::n {
+//         ::number::one(n) => {
+//             constraint (0 <= (::n ? 11 : 22))
+//         }
+//         ::number::two(n) => {
+//             constraint (0 <= (::n * ::n))
+//         }
+//         ::number::three(n) => {
+//             constraint (0 <= ::n[0])
+//         }
+//     }
+// }
+// >>>
+
+// flattened <<<
+// union ::number = one(bool) | two(int) | three(int[3]);
+//
+// predicate ::test {
+//     var ::n: ::number;
+//     constraint (0 <= (UnTag(::n) == ::number::one ? (UnVal(::n, bool) ? 11 : 22) : (UnTag(::n) == ::number::two ? (UnVal(::n, int) * UnVal(::n, int)) : UnVal(::n, int[3])[0])));
+//     constraint __eq_set(__mut_keys(), {0});
+// }
+//
+// predicate ::decl_test {
+//     var ::n: ::number;
+//     constraint (!UnTag(::n) == ::number::one || (0 <= (UnVal(::n, bool) ? 11 : 22)));
+//     constraint (UnTag(::n) == ::number::one || (!UnTag(::n) == ::number::two || (0 <= (UnVal(::n, int) * UnVal(::n, int)))));
+//     constraint (UnTag(::n) == ::number::one || (UnTag(::n) == ::number::two || (!UnTag(::n) == ::number::three || (0 <= UnVal(::n, int[3])[0]))));
+//     constraint __eq_set(__mut_keys(), {0});
+// }
+// >>>

--- a/pintc/tests/unions/match_decls.pnt
+++ b/pintc/tests/unions/match_decls.pnt
@@ -1,0 +1,82 @@
+union group = empty | one(int) | couple({int, int});
+
+predicate test {
+    var x: group;
+    var y: group;
+    match x {
+        group::empty => {}
+        group::one(n) => {
+            if n > 11 {
+                constraint n < 22;
+            } else {
+                constraint n > 0;
+            }
+        },                                      // lonely comma
+        group::couple(c) => {
+            constraint c.0 > 0;
+            if c.1 > 33 {
+                match y {
+                    group::one(n) => {
+                        if n > 44 {
+                            constraint c.1 < 111;
+                        } else {
+                            constraint c.1 < 222;
+                        }
+                    }
+                    else => {}
+                }
+            }
+        }
+    }
+}
+
+// parsed <<<
+// union ::group = empty | one(int) | couple({int, int});
+//
+// predicate ::test {
+//     var ::x: ::group;
+//     var ::y: ::group;
+//     match ::x {
+//         ::group::empty => {
+//         }
+//         ::group::one(n) => {
+//             if (::n > 11) {
+//                 constraint (::n < 22)
+//             } else {
+//                 constraint (::n > 0)
+//             }
+//         }
+//         ::group::couple(c) => {
+//             constraint (::c.0 > 0)
+//             if (::c.1 > 33) {
+//                 match ::y {
+//                     ::group::one(n) => {
+//                         if (::n > 44) {
+//                             constraint (::c.1 < 111)
+//                         } else {
+//                             constraint (::c.1 < 222)
+//                         }
+//                     }
+//                     else => {
+//                     }
+//                 }
+//             }
+//         }
+//     }
+// }
+// >>>
+
+// flattened <<<
+// union ::group = empty | one(int) | couple({int, int});
+//
+// predicate ::test {
+//     var ::x: ::group;
+//     var ::y: ::group;
+//     constraint (UnTag(::x) == ::group::empty || (!UnTag(::x) == ::group::one || (!(UnVal(::x, int) > 11) || (UnVal(::x, int) < 22))));
+//     constraint (UnTag(::x) == ::group::empty || (!UnTag(::x) == ::group::one || ((UnVal(::x, int) > 11) || (UnVal(::x, int) > 0))));
+//     constraint (UnTag(::x) == ::group::empty || (UnTag(::x) == ::group::one || (!UnTag(::x) == ::group::couple || (UnVal(::x, {int, int}).0 > 0))));
+//     constraint (UnTag(::x) == ::group::empty || (UnTag(::x) == ::group::one || (!UnTag(::x) == ::group::couple || (!(UnVal(::x, {int, int}).1 > 33) || (!UnTag(::y) == ::group::one || (!(UnVal(::y, int) > 44) || (::c.1 < 111)))))));
+//     constraint (UnTag(::x) == ::group::empty || (UnTag(::x) == ::group::one || (!UnTag(::x) == ::group::couple || (!(UnVal(::x, {int, int}).1 > 33) || (!UnTag(::y) == ::group::one || ((UnVal(::y, int) > 44) || (::c.1 < 222)))))));
+//     constraint __eq_set(__mut_keys(), {0});
+// }
+// >>>

--- a/pintc/tests/unions/match_else_extra.pnt
+++ b/pintc/tests/unions/match_else_extra.pnt
@@ -1,0 +1,58 @@
+union value = nul | scalar(int);
+
+predicate test {
+    var x: value;
+
+    constraint match x {
+        value::nul => false,
+        value::scalar(n) => n > 0,
+        else => true,
+    };
+}
+
+predicate decl_test {
+    var x: value;
+
+    match x {
+        value::nul => {
+            constraint false;
+        }
+        value::scalar(n) => {
+            constraint n > 0;
+        }
+        else => {
+            constraint true;
+        }
+    }
+}
+
+// parsed <<<
+// union ::value = nul | scalar(int);
+//
+// predicate ::test {
+//     var ::x: ::value;
+//     constraint match ::x { ::value::nul => false, ::value::scalar(n) => (::n > 0), else => true };
+// }
+//
+// predicate ::decl_test {
+//     var ::x: ::value;
+//     match ::x {
+//         ::value::nul => {
+//             constraint false
+//         }
+//         ::value::scalar(n) => {
+//             constraint (::n > 0)
+//         }
+//         else => {
+//             constraint true
+//         }
+//     }
+// }
+// >>>
+
+// typecheck_failure <<<
+// unneeded else branch
+// @85..186: `else` branch in match will never be evaluated
+// unneeded else branch
+// @236..442: `else` branch in match will never be evaluated
+// >>>

--- a/pintc/tests/unions/match_else_reused.pnt
+++ b/pintc/tests/unions/match_else_reused.pnt
@@ -1,0 +1,60 @@
+union value = nul | scalar(int);
+
+predicate test {
+    var x: value;
+
+    constraint match x {
+        value::nul => false,
+        value::scalar(n) => n > 0,
+        value::nul => true,
+    };
+}
+
+predicate decl_test {
+    var x: value;
+
+    match x {
+        value::nul => {
+            constraint false;
+        }
+        value::scalar(n) => {
+            constraint n > 0;
+        }
+        value::nul => {
+            constraint true;
+        }
+    }
+}
+
+// parsed <<<
+// union ::value = nul | scalar(int);
+//
+// predicate ::test {
+//     var ::x: ::value;
+//     constraint match ::x { ::value::nul => false, ::value::scalar(n) => (::n > 0), ::value::nul => true };
+// }
+//
+// predicate ::decl_test {
+//     var ::x: ::value;
+//     match ::x {
+//         ::value::nul => {
+//             constraint false
+//         }
+//         ::value::scalar(n) => {
+//             constraint (::n > 0)
+//         }
+//         ::value::nul => {
+//             constraint true
+//         }
+//     }
+// }
+// >>>
+
+// typecheck_failure <<<
+// re-used match variant
+// @167..177: match variant `::value::nul` has previously been bound
+// re-used match variant
+// @394..404: match variant `::value::nul` has previously been bound
+// constraint expression type error
+// @85..192: expecting type `bool`
+// >>>

--- a/pintc/tests/unions/match_non_union.pnt
+++ b/pintc/tests/unions/match_non_union.pnt
@@ -1,0 +1,58 @@
+enum Enum = Zero | One | Two;
+
+predicate test {
+    var e: Enum;
+
+    constraint 0 == match e {
+        Enum::Zero => 0,
+        Enum::One => 1,
+        Enum::Two => 2,
+    };
+}
+
+predicate decl_test {
+    var e: Enum;
+
+    match e {
+        Enum::Zero => {
+            constraint 0 == 0;
+        }
+        Enum::One => {
+            constraint 0 == 1;
+        }
+        Enum::Two => {
+            constraint 0 == 2;
+        }
+    }
+}
+
+// parsed <<<
+// enum ::Enum = Zero | One | Two;
+//
+// predicate ::test {
+//     var ::e: ::Enum;
+//     constraint (0 == match ::e { ::Enum::Zero => 0, ::Enum::One => 1, ::Enum::Two => 2 });
+// }
+//
+// predicate ::decl_test {
+//     var ::e: ::Enum;
+//     match ::e {
+//         ::Enum::Zero => {
+//             constraint (0 == 0)
+//         }
+//         ::Enum::One => {
+//             constraint (0 == 1)
+//         }
+//         ::Enum::Two => {
+//             constraint (0 == 2)
+//         }
+//     }
+// }
+// >>>
+
+// typecheck_failure <<<
+// match expression not a union
+// @92..93: matched expression must be a union, found `::Enum`
+// match expression not a union
+// @229..230: matched expression must be a union, found `::Enum`
+// >>>

--- a/pintc/tests/unions/match_too_few.pnt
+++ b/pintc/tests/unions/match_too_few.pnt
@@ -1,0 +1,48 @@
+union count = nul | one | many(int);
+
+predicate test {
+    var x: count;
+
+    constraint match x {
+        count::one => true,
+    };
+}
+
+predicate decl_test {
+    var x: count;
+
+    match x {
+        count::one => {
+            constraint true;
+        }
+    }
+}
+
+// parsed <<<
+// union ::count = nul | one | many(int);
+//
+// predicate ::test {
+//     var ::x: ::count;
+//     constraint match ::x { ::count::one => true };
+// }
+//
+// predicate ::decl_test {
+//     var ::x: ::count;
+//     match ::x {
+//         ::count::one => {
+//             constraint true
+//         }
+//     }
+// }
+// >>>
+
+// typecheck_failure <<<
+// not all match variants are covered
+// @89..132: not all variants for union `::count` are covered by match
+// branches and/or bindings are required for variants `count::nul` and `count::many`
+// not all match variants are covered
+// @182..260: not all variants for union `::count` are covered by match
+// branches and/or bindings are required for variants `count::nul` and `count::many`
+// constraint expression type error
+// @89..132: expecting type `bool`
+// >>>

--- a/pintc/tests/unions/name_clash.pnt
+++ b/pintc/tests/unions/name_clash.pnt
@@ -1,0 +1,12 @@
+enum choice = is_an | illusion;
+
+union choice = one(int) | the_other(int);
+
+predicate test {}
+
+// parse_failure <<<
+// symbol `choice` has already been declared
+// @5..11: previous declaration of the symbol `choice` here
+// @39..45: `choice` redeclared here
+// `choice` must be declared or imported only once in this scope
+// >>>

--- a/pintc/tests/unions/no_value_union.pnt
+++ b/pintc/tests/unions/no_value_union.pnt
@@ -1,0 +1,63 @@
+union either = left | right;
+
+predicate test {
+    var x: either = either::right;
+    constraint match x {
+        either::left => true,
+        either::right => false,
+    };
+}
+
+predicate decl_test {
+    var x: either = either::right;
+    match x {
+        either::left => {
+            constraint true;
+        }
+        either::right => {
+            constraint false;
+        }
+    }
+}
+
+// parsed <<<
+// union ::either = left | right;
+//
+// predicate ::test {
+//     var ::x: ::either;
+//     constraint (::x == ::either::right);
+//     constraint match ::x { ::either::left => true, ::either::right => false };
+// }
+//
+// predicate ::decl_test {
+//     var ::x: ::either;
+//     constraint (::x == ::either::right);
+//     match ::x {
+//         ::either::left => {
+//             constraint true
+//         }
+//         ::either::right => {
+//             constraint false
+//         }
+//     }
+// }
+// >>>
+
+// flattened <<<
+// union ::either = left | right;
+//
+// predicate ::test {
+//     var ::x: ::either;
+//     constraint (::x == ::either::right);
+//     constraint (UnTag(::x) == ::either::left ? true : false);
+//     constraint __eq_set(__mut_keys(), {0});
+// }
+//
+// predicate ::decl_test {
+//     var ::x: ::either;
+//     constraint (::x == ::either::right);
+//     constraint (!UnTag(::x) == ::either::left || true);
+//     constraint (UnTag(::x) == ::either::left || (!UnTag(::x) == ::either::right || false));
+//     constraint __eq_set(__mut_keys(), {0});
+// }
+// >>>

--- a/pintc/tests/unions/simple.pnt
+++ b/pintc/tests/unions/simple.pnt
@@ -1,0 +1,133 @@
+type number = int;
+
+union thing = a(bool) | b(number) | c({int, number});
+union maybe_addr = no_addr | addr(b256);
+
+type maydr = maybe_addr;
+
+predicate test {
+    var x: thing;
+
+    // Boolean match expression.
+    constraint match x {
+        thing::a(b) => b,
+        thing::b(n) => n > 0,
+        thing::c(t) => t.0 + t.1 == 11
+    };
+
+    // Integer match expression in a constraint with `else`.
+    constraint match x {
+        thing::b(b) => b,
+        else => 22,
+    } > 0;
+
+    // Boolean match expression with blocks & constraints.
+    constraint match x {
+        thing::a(b) => b,
+        thing::b(n) => {
+            constraint n > 0;
+            n * 2 < 10
+        },
+        thing::c(t) => {
+            constraint t.0 == 33;
+            constraint t.1 != 44;
+            true
+        }
+    };
+
+    // Non-expression match.  Also refers to other var `d`.
+    var d: int;
+    match x {
+        thing::a(b) => {},
+        thing::c(t) => {
+            constraint t.0 * t.1 == 66;
+            constraint d == t.0 - t.1;
+        }
+        else => {
+            constraint d == 55;
+        }
+    }
+
+    // Constraining an address to either zero or something.
+    var no_base_addr: maydr = maybe_addr::no_addr;
+    var a_base_addr: maydr = maybe_addr::addr(0x1111111111111111111111111111111111111111111111111111111111111111);
+
+    var actual_addr = match no_base_addr {
+        maybe_addr::no_addr => 0x0000000000000000000000000000000000000000000000000000000000000000,
+        maybe_addr::addr(a) => a,
+    };
+
+    // Direct comparisons.
+    constraint no_base_addr != a_base_addr;
+    constraint no_base_addr == maybe_addr::no_addr;
+    constraint thing::b(77) == thing::b(77);
+    constraint thing::b(88) != thing::b(99);
+}
+
+// parsed <<<
+// union ::thing = a(bool) | b(::number) | c({int, ::number});
+// union ::maybe_addr = no_addr | addr(b256);
+// type ::number = int;
+// type ::maydr = ::maybe_addr;
+//
+// predicate ::test {
+//     var ::x: ::thing;
+//     var ::d: int;
+//     var ::no_base_addr: ::maydr;
+//     var ::a_base_addr: ::maydr;
+//     var ::actual_addr;
+//     constraint match ::x { ::thing::a(b) => ::b, ::thing::b(n) => (::n > 0), ::thing::c(t) => ((::t.0 + ::t.1) == 11) };
+//     constraint (match ::x { ::thing::b(b) => ::b, else => 22 } > 0);
+//     constraint match ::x { ::thing::a(b) => ::b, ::thing::b(n) => constraint (::n > 0); ((::n * 2) < 10), ::thing::c(t) => constraint (::t.0 == 33); constraint (::t.1 != 44); true };
+//     constraint (::no_base_addr == ::maybe_addr::no_addr);
+//     constraint (::a_base_addr == ::maybe_addr::addr(0x1111111111111111111111111111111111111111111111111111111111111111));
+//     constraint (::actual_addr == match ::no_base_addr { ::maybe_addr::no_addr => 0x0000000000000000000000000000000000000000000000000000000000000000, ::maybe_addr::addr(a) => ::a });
+//     constraint (::no_base_addr != ::a_base_addr);
+//     constraint (::no_base_addr == ::maybe_addr::no_addr);
+//     constraint (::thing::b(77) == ::thing::b(77));
+//     constraint (::thing::b(88) != ::thing::b(99));
+//     match ::x {
+//         ::thing::a(b) => {
+//         }
+//         ::thing::c(t) => {
+//             constraint ((::t.0 * ::t.1) == 66)
+//             constraint (::d == (::t.0 - ::t.1))
+//         }
+//         else => {
+//             constraint (::d == 55)
+//         }
+//     }
+// }
+// >>>
+
+// flattened <<<
+// union ::thing = a(bool) | b(int) | c({int, int});
+// union ::maybe_addr = no_addr | addr(b256);
+// type ::number = int;
+// type ::maydr = ::maybe_addr;
+//
+// predicate ::test {
+//     var ::x: ::thing;
+//     var ::d: int;
+//     var ::no_base_addr: ::maybe_addr;
+//     var ::a_base_addr: ::maybe_addr;
+//     var ::actual_addr: b256;
+//     constraint (UnTag(::x) == ::thing::a ? UnVal(::x, bool) : (UnTag(::x) == ::thing::b ? (UnVal(::x, int) > 0) : ((UnVal(::x, {int, int}).0 + UnVal(::x, {int, int}).1) == 11)));
+//     constraint ((UnTag(::x) == ::thing::b ? UnVal(::x, int) : 22) > 0);
+//     constraint (UnTag(::x) == ::thing::a ? UnVal(::x, bool) : (UnTag(::x) == ::thing::b ? ((UnVal(::x, int) * 2) < 10) : true));
+//     constraint (::no_base_addr == ::maybe_addr::no_addr);
+//     constraint (::a_base_addr == ::maybe_addr::addr(0x1111111111111111111111111111111111111111111111111111111111111111));
+//     constraint (::actual_addr == (UnTag(::no_base_addr) == ::maybe_addr::no_addr ? 0x0000000000000000000000000000000000000000000000000000000000000000 : UnVal(::no_base_addr, b256)));
+//     constraint (::no_base_addr != ::a_base_addr);
+//     constraint (::no_base_addr == ::maybe_addr::no_addr);
+//     constraint (::thing::b(77) == ::thing::b(77));
+//     constraint (::thing::b(88) != ::thing::b(99));
+//     constraint (UnTag(::x) == ::thing::a || (!UnTag(::x) == ::thing::c || ((UnVal(::x, {int, int}).0 * UnVal(::x, {int, int}).1) == 66)));
+//     constraint (UnTag(::x) == ::thing::a || (!UnTag(::x) == ::thing::c || (::d == (UnVal(::x, {int, int}).0 - UnVal(::x, {int, int}).1))));
+//     constraint (UnTag(::x) == ::thing::a || (UnTag(::x) == ::thing::c || (::d == 55)));
+//     constraint (UnTag(::x) == ::thing::a || (!UnTag(::x) == ::thing::b || (UnVal(::x, int) > 0)));
+//     constraint (UnTag(::x) == ::thing::a || (UnTag(::x) == ::thing::b || (!UnTag(::x) == ::thing::c || (UnVal(::x, {int, int}).0 == 33))));
+//     constraint (UnTag(::x) == ::thing::a || (UnTag(::x) == ::thing::b || (!UnTag(::x) == ::thing::c || (UnVal(::x, {int, int}).1 != 44))));
+//     constraint __eq_set(__mut_keys(), {0});
+// }
+// >>>

--- a/pintc/tests/unions/unknown_union.pnt
+++ b/pintc/tests/unions/unknown_union.pnt
@@ -1,0 +1,51 @@
+union known = good | better(int);
+
+predicate test {
+    // Unknown union decl.
+    var a = unknown::variant(11);
+
+    // Known union, unknown variant.
+    var b = known::unknown(22);
+
+    // Variant does not have a value.
+    var c = known::good(33);
+
+    // Variant needs a value.
+    var d = known::better;
+
+    // Variant value type mismatch.
+    var e = known::better(true);
+}
+
+// parsed <<<
+// union ::known = good | better(int);
+//
+// predicate ::test {
+//     var ::a;
+//     var ::b;
+//     var ::c;
+//     var ::d;
+//     var ::e;
+//     constraint (::a == ::unknown::variant(11));
+//     constraint (::b == ::known::unknown(22));
+//     constraint (::c == ::known::good(33));
+//     constraint (::d == ::known::better);
+//     constraint (::e == ::known::better(true));
+// }
+// >>>
+
+// typecheck_failure <<<
+// unknown union
+// @91..107: union declaration for `::unknown::variant` not found
+// unknown union variant
+// @163..177: union variant `::known::unknown` not found
+// valid variant names are `good` and `better`
+// union variant does not have a value
+// @234..249: union variant `::known::good` should not bind a value
+// missing union variant value
+// @294..307: union variant `better` requires a value of type `int`
+// cannot find value `::known::better` in this scope
+// @294..307: not found in this scope
+// union variant type mismatch
+// @372..376: expecting type `int`, found `bool`
+// >>>

--- a/pintc/tests/unions/variant_hint.pnt
+++ b/pintc/tests/unions/variant_hint.pnt
@@ -1,0 +1,59 @@
+union blah = blergh(int) | ungh(bool);
+
+predicate test {
+    var mood: blah;
+    constraint match mood {
+        blergh(n) => true,
+        ungh(b) => false,
+    };
+}
+
+predicate decl_test {
+    var mood: blah;
+    match mood {
+        blergh(n) => {
+            constraint true;
+        }
+        ungh(b) => {
+            constraint false;
+        }
+    }
+}
+
+// parsed <<<
+// union ::blah = blergh(int) | ungh(bool);
+//
+// predicate ::test {
+//     var ::mood: ::blah;
+//     constraint match ::mood { ::blergh(n) => true, ::ungh(b) => false };
+// }
+//
+// predicate ::decl_test {
+//     var ::mood: ::blah;
+//     match ::mood {
+//         ::blergh(n) => {
+//             constraint true
+//         }
+//         ::ungh(b) => {
+//             constraint false
+//         }
+//     }
+// }
+// >>>
+//
+// typecheck_failure <<<
+// unknown union variant name
+// @113..119: invalid variant name `::blergh` for union `::blah`
+// valid variant names are `blah::blergh` and `blah::ungh`
+// unknown union variant name
+// @140..144: invalid variant name `::ungh` for union `::blah`
+// valid variant names are `blah::blergh` and `blah::ungh`
+// unknown union variant name
+// @235..241: invalid variant name `::blergh` for union `::blah`
+// valid variant names are `blah::blergh` and `blah::ungh`
+// unknown union variant name
+// @297..301: invalid variant name `::ungh` for union `::blah`
+// valid variant names are `blah::blergh` and `blah::ungh`
+// constraint expression type error
+// @92..163: expecting type `bool`
+// >>>


### PR DESCRIPTION
This PR has most of the changes needed for `union`s and `match`.

- It covers the front- and middle- ends; parser, type-checker and lowering.
- It has _some_ ASM gen support, currently untested.
- It has all the E2E testing to cover all possible errors and general use.

It does not have ABI generation nor validation testing.  There are no documentation changes yet either.

I have been working on this for several weeks and have made pretty much all of the design and implementation decisions unilaterally, and so many of these choices need to be reviewed, particularly before we document it.

To get an example of how `union`s and both `match` expressions and `match` declarations work presently you can take a look at the E2E tests, especially `unions/simple.pnt`.

https://github.com/essential-contributions/pint/blob/948b540067db248f0296942a658815e1c577b36e/pintc/tests/unions/simple.pnt

I think perhaps if it's OK we could merge this PR and add issues for all the remaining work.  Contracts which use `union`s won't compile (due to missing ABI) but since we're still pre-release I'd like to get it in since it'd getting too big and merge conflicts are an issue.

The main reason I didn't implement ABI output was I made an attempt and frankly got quite lost.  I'll need some help to understand what is required there.

There are still a couple of design issues to work out too.  Especially around storage -- do we allow `union`s in storage at all?  Also, do we allow match bindings to shadow each other?  Perhaps, since they're local in scope.