### PR TITLE
Lift the union tag comparisons up into transforms rather than in ASM gen.

### DIFF
--- a/pintc/src/expr.rs
+++ b/pintc/src/expr.rs
@@ -109,9 +109,8 @@ pub enum Expr {
         body: ExprKey,
         span: Span,
     },
-    UnionTagIs {
+    UnionTag {
         union_expr: ExprKey,
-        tag: Path,
         span: Span,
     },
     UnionValue {
@@ -291,7 +290,7 @@ impl Spanned for Expr {
             | Expr::In { span, .. }
             | Expr::Generator { span, .. }
             | Expr::Range { span, .. }
-            | Expr::UnionTagIs { span, .. }
+            | Expr::UnionTag { span, .. }
             | Expr::UnionValue { span, .. } => span,
         }
     }
@@ -388,7 +387,7 @@ impl Expr {
                 replace(body);
             }
 
-            Expr::UnionTagIs { union_expr, .. } | Expr::UnionValue { union_expr, .. } => {
+            Expr::UnionTag { union_expr, .. } | Expr::UnionValue { union_expr, .. } => {
                 replace(union_expr)
             }
 

--- a/pintc/src/expr/display.rs
+++ b/pintc/src/expr/display.rs
@@ -208,10 +208,8 @@ impl DisplayWithContract for &super::Expr {
                 write!(f, " {{ {} }}", contract.with_ctrct(body))
             }
 
-            expr::Expr::UnionTagIs {
-                union_expr, tag, ..
-            } => {
-                write!(f, "UnTag({}) == {tag}", contract.with_ctrct(union_expr))
+            expr::Expr::UnionTag { union_expr, .. } => {
+                write!(f, "UnTag({})", contract.with_ctrct(union_expr))
             }
 
             expr::Expr::UnionValue {

--- a/pintc/src/expr/evaluate.rs
+++ b/pintc/src/expr/evaluate.rs
@@ -391,7 +391,7 @@ impl Evaluator {
             | Expr::Match { .. }
             | Expr::UnionVariant { .. }
             // These union exprs can unpack if their expression is a UnionVariant literal.
-            | Expr::UnionTagIs { .. } | Expr::UnionValue { .. } => {
+            | Expr::UnionTag { .. } | Expr::UnionValue { .. } => {
                 Err(handler.emit_err(Error::Compile {
                     error: CompileError::Internal {
                         msg: "unexpected expression during compile-time evaluation",
@@ -630,18 +630,10 @@ impl ExprKey {
                 }
             }
 
-            Expr::UnionTagIs {
-                union_expr,
-                tag,
-                span,
-            } => {
+            Expr::UnionTag { union_expr, span } => {
                 let union_expr = union_expr.plug_in(contract, values_map);
 
-                Expr::UnionTagIs {
-                    union_expr,
-                    tag,
-                    span,
-                }
+                Expr::UnionTag { union_expr, span }
             }
             Expr::UnionValue {
                 union_expr,

--- a/pintc/src/predicate.rs
+++ b/pintc/src/predicate.rs
@@ -202,7 +202,7 @@ impl Contract {
                 self.visitor_from_key(kind, *body, f);
             }
 
-            Expr::UnionTagIs { union_expr, .. } | Expr::UnionValue { union_expr, .. } => {
+            Expr::UnionTag { union_expr, .. } | Expr::UnionValue { union_expr, .. } => {
                 self.visitor_from_key(kind, *union_expr, f)
             }
         }

--- a/pintc/src/predicate/analyse/type_check.rs
+++ b/pintc/src/predicate/analyse/type_check.rs
@@ -1328,7 +1328,7 @@ impl Contract {
                 span,
             } => Ok(self.infer_generator_expr(handler, kind, gen_ranges, conditions, *body, span)),
 
-            Expr::UnionTagIs { .. } | Expr::UnionValue { .. } => {
+            Expr::UnionTag { .. } | Expr::UnionValue { .. } => {
                 Err(handler.emit_err(Error::Compile {
                     error: CompileError::Internal {
                         msg: "union utility expressions should not exist during type checking",

--- a/pintc/src/predicate/exprs.rs
+++ b/pintc/src/predicate/exprs.rs
@@ -218,7 +218,7 @@ impl ExprKey {
                     || body.can_panic(contract, pred)
             }
 
-            Expr::UnionTagIs { union_expr, .. } | Expr::UnionValue { union_expr, .. } => {
+            Expr::UnionTag { union_expr, .. } | Expr::UnionValue { union_expr, .. } => {
                 union_expr.can_panic(contract, pred)
             }
         })
@@ -433,7 +433,7 @@ impl<'a> Iterator for ExprsIter<'a> {
                 queue_if_new!(self, body);
             }
 
-            Expr::UnionTagIs { union_expr, .. } | Expr::UnionValue { union_expr, .. } => {
+            Expr::UnionTag { union_expr, .. } | Expr::UnionValue { union_expr, .. } => {
                 queue_if_new!(self, union_expr)
             }
 

--- a/pintc/src/predicate/transform/lower.rs
+++ b/pintc/src/predicate/transform/lower.rs
@@ -1274,7 +1274,7 @@ pub(super) fn coalesce_prime_ops(contract: &mut Contract) {
                 | Expr::In { .. }
                 | Expr::Range { .. }
                 | Expr::Generator { .. }
-                | Expr::UnionTagIs { .. }
+                | Expr::UnionTag { .. }
                 | Expr::UnionValue { .. } => Coalescence::None,
             };
 
@@ -1460,15 +1460,10 @@ fn convert_match_to_if_decl(
                         }
                     })
                     .and_then(|full_binding| {
-                        // The condition expression is a 'union_tag_is' expression.
-                        let cond_expr = contract.exprs.insert(
-                            Expr::UnionTagIs {
-                                union_expr: match_expr,
-                                tag: name,
-                                span: empty_span(),
-                            },
-                            bool_ty.clone(),
-                        );
+                        // The condition expression is a 'union_tag == ...' expression.
+                        let cond_expr = build_compare_tag_expr(
+                            handler, contract, match_expr, &name, &name_span,
+                        )?;
 
                         block
                             .into_iter()
@@ -1723,6 +1718,7 @@ fn convert_match_expr(
     struct BranchInfo {
         union_expr: ExprKey,
         name: Path,
+        name_span: Span,
         binding: Option<(Ident, Type)>,
         constraints: Vec<ExprKey>,
         expr: ExprKey,
@@ -1771,6 +1767,7 @@ fn convert_match_expr(
             if_then_branches.push_back(BranchInfo {
                 union_expr: *match_expr,
                 name: name.clone(),
+                name_span: name_span.clone(),
                 binding: full_binding,
                 constraints: constraints.clone(),
                 expr: *expr,
@@ -1802,22 +1799,22 @@ fn convert_match_expr(
     });
 
     fn build_if_decl_and_select(
+        handler: &Handler,
         contract: &mut Contract,
         pred_key: PredKey,
         mut then_branch: BranchInfo,
         mut rest_branches: VecDeque<BranchInfo>,
         else_branch: Option<(Vec<BlockStatement>, ExprKey)>,
         span: &Span,
-    ) -> (IfDecl, ExprKey) {
+    ) -> Result<(IfDecl, ExprKey), ErrorEmitted> {
         // The condition expression is used by both the `if` and `select`.
-        let condition = contract.exprs.insert(
-            Expr::UnionTagIs {
-                union_expr: then_branch.union_expr,
-                tag: then_branch.name,
-                span: empty_span(),
-            },
-            types::r#bool(),
-        );
+        let condition = build_compare_tag_expr(
+            handler,
+            contract,
+            then_branch.union_expr,
+            &then_branch.name,
+            &then_branch.name_span,
+        )?;
 
         if let Some((binding, bound_ty)) = then_branch.binding {
             for constraint_expr in &mut then_branch.constraints {
@@ -1866,13 +1863,14 @@ fn convert_match_expr(
         let (else_block, select_expr) = if let Some(next_then_branch) = rest_branches.pop_front() {
             // There are branches; recurse.
             let (else_if_decl, else_expr) = build_if_decl_and_select(
+                handler,
                 contract,
                 pred_key,
                 next_then_branch,
                 rest_branches,
                 else_branch,
                 span,
-            );
+            )?;
 
             let else_block = Some(vec![BlockStatement::If(else_if_decl)]);
 
@@ -1922,18 +1920,19 @@ fn convert_match_expr(
             span: span.clone(),
         };
 
-        (if_decl, select_expr)
+        Ok((if_decl, select_expr))
     }
 
     let (if_decl, select_expr_key) = if let Some(then_branch) = if_then_branches.pop_front() {
         build_if_decl_and_select(
+            handler,
             contract,
             pred_key,
             then_branch,
             if_then_branches,
             else_block,
             &if_decl_span.unwrap(),
-        )
+        )?
     } else {
         // There are no match branches.  Just make an `if false {} else <else_block>` and use the
         // else expression as the 'select'.
@@ -1970,6 +1969,52 @@ fn convert_match_expr(
     contract.replace_exprs(Some(pred_key), match_expr_key, select_expr_key);
 
     Ok(())
+}
+
+fn build_compare_tag_expr(
+    handler: &Handler,
+    contract: &mut Contract,
+    union_expr: ExprKey,
+    tag: &Path,
+    span: &Span,
+) -> Result<ExprKey, ErrorEmitted> {
+    let tag_num = union_expr
+        .get_ty(contract)
+        .get_union_variant_as_num(&contract.unions, tag)
+        .ok_or_else(|| {
+            handler.emit_err(Error::Compile {
+                error: CompileError::Internal {
+                    msg: "Union tag not found in union decl",
+                    span: contract.expr_key_to_span(union_expr),
+                },
+            })
+        })?;
+
+    let get_tag_expr = contract.exprs.insert(
+        Expr::UnionTag {
+            union_expr,
+            span: span.clone(),
+        },
+        types::r#int(),
+    );
+
+    let tag_num_expr = contract.exprs.insert(
+        Expr::Immediate {
+            value: Immediate::Int(tag_num as i64),
+            span: span.clone(),
+        },
+        types::r#int(),
+    );
+
+    Ok(contract.exprs.insert(
+        Expr::BinaryOp {
+            op: BinaryOp::Equal,
+            lhs: get_tag_expr,
+            rhs: tag_num_expr,
+            span: span.clone(),
+        },
+        types::r#bool(),
+    ))
 }
 
 pub(super) fn lower_union_variant_paths(contract: &mut Contract) {

--- a/pintc/src/predicate/transform/validate.rs
+++ b/pintc/src/predicate/transform/validate.rs
@@ -201,7 +201,7 @@ fn check_expr(
         | Expr::TupleFieldAccess { .. }
         | Expr::Index { .. }
         | Expr::ExternalStorageAccess { .. }
-        | Expr::UnionTagIs { .. }
+        | Expr::UnionTag { .. }
         | Expr::UnionValue { .. } => Ok(()),
     }
 }

--- a/pintc/src/types.rs
+++ b/pintc/src/types.rs
@@ -349,6 +349,13 @@ impl Type {
         })
     }
 
+    pub fn get_union_variant_as_num(&self, unions: &[UnionDecl], tag: &Path) -> Option<usize> {
+        self.get_union_variant_names(unions)
+            .into_iter()
+            .enumerate()
+            .find_map(|(idx, variant_name)| (variant_name == tag[2..]).then_some(idx))
+    }
+
     pub fn is_tuple(&self) -> bool {
         check_alias!(self, is_tuple, matches!(self, Type::Tuple { .. }))
     }

--- a/pintc/tests/unions/match_bindings_are_n.pnt
+++ b/pintc/tests/unions/match_bindings_are_n.pnt
@@ -55,15 +55,15 @@ predicate decl_test {
 //
 // predicate ::test {
 //     var ::n: ::number;
-//     constraint (0 <= (UnTag(::n) == ::number::one ? (UnVal(::n, bool) ? 11 : 22) : (UnTag(::n) == ::number::two ? (UnVal(::n, int) * UnVal(::n, int)) : UnVal(::n, int[3])[0])));
+//     constraint (0 <= ((UnTag(::n) == 0) ? (UnVal(::n, bool) ? 11 : 22) : ((UnTag(::n) == 1) ? (UnVal(::n, int) * UnVal(::n, int)) : UnVal(::n, int[3])[0])));
 //     constraint __eq_set(__mut_keys(), {0});
 // }
 //
 // predicate ::decl_test {
 //     var ::n: ::number;
-//     constraint (!UnTag(::n) == ::number::one || (0 <= (UnVal(::n, bool) ? 11 : 22)));
-//     constraint (UnTag(::n) == ::number::one || (!UnTag(::n) == ::number::two || (0 <= (UnVal(::n, int) * UnVal(::n, int)))));
-//     constraint (UnTag(::n) == ::number::one || (UnTag(::n) == ::number::two || (!UnTag(::n) == ::number::three || (0 <= UnVal(::n, int[3])[0]))));
+//     constraint (!(UnTag(::n) == 0) || (0 <= (UnVal(::n, bool) ? 11 : 22)));
+//     constraint ((UnTag(::n) == 0) || (!(UnTag(::n) == 1) || (0 <= (UnVal(::n, int) * UnVal(::n, int)))));
+//     constraint ((UnTag(::n) == 0) || ((UnTag(::n) == 1) || (!(UnTag(::n) == 2) || (0 <= UnVal(::n, int[3])[0]))));
 //     constraint __eq_set(__mut_keys(), {0});
 // }
 // >>>

--- a/pintc/tests/unions/match_decls.pnt
+++ b/pintc/tests/unions/match_decls.pnt
@@ -72,11 +72,11 @@ predicate test {
 // predicate ::test {
 //     var ::x: ::group;
 //     var ::y: ::group;
-//     constraint (UnTag(::x) == ::group::empty || (!UnTag(::x) == ::group::one || (!(UnVal(::x, int) > 11) || (UnVal(::x, int) < 22))));
-//     constraint (UnTag(::x) == ::group::empty || (!UnTag(::x) == ::group::one || ((UnVal(::x, int) > 11) || (UnVal(::x, int) > 0))));
-//     constraint (UnTag(::x) == ::group::empty || (UnTag(::x) == ::group::one || (!UnTag(::x) == ::group::couple || (UnVal(::x, {int, int}).0 > 0))));
-//     constraint (UnTag(::x) == ::group::empty || (UnTag(::x) == ::group::one || (!UnTag(::x) == ::group::couple || (!(UnVal(::x, {int, int}).1 > 33) || (!UnTag(::y) == ::group::one || (!(UnVal(::y, int) > 44) || (::c.1 < 111)))))));
-//     constraint (UnTag(::x) == ::group::empty || (UnTag(::x) == ::group::one || (!UnTag(::x) == ::group::couple || (!(UnVal(::x, {int, int}).1 > 33) || (!UnTag(::y) == ::group::one || ((UnVal(::y, int) > 44) || (::c.1 < 222)))))));
+//     constraint ((UnTag(::x) == 0) || (!(UnTag(::x) == 1) || (!(UnVal(::x, int) > 11) || (UnVal(::x, int) < 22))));
+//     constraint ((UnTag(::x) == 0) || (!(UnTag(::x) == 1) || ((UnVal(::x, int) > 11) || (UnVal(::x, int) > 0))));
+//     constraint ((UnTag(::x) == 0) || ((UnTag(::x) == 1) || (!(UnTag(::x) == 2) || (UnVal(::x, {int, int}).0 > 0))));
+//     constraint ((UnTag(::x) == 0) || ((UnTag(::x) == 1) || (!(UnTag(::x) == 2) || (!(UnVal(::x, {int, int}).1 > 33) || (!(UnTag(::y) == 1) || (!(UnVal(::y, int) > 44) || (::c.1 < 111)))))));
+//     constraint ((UnTag(::x) == 0) || ((UnTag(::x) == 1) || (!(UnTag(::x) == 2) || (!(UnVal(::x, {int, int}).1 > 33) || (!(UnTag(::y) == 1) || ((UnVal(::y, int) > 44) || (::c.1 < 222)))))));
 //     constraint __eq_set(__mut_keys(), {0});
 // }
 // >>>

--- a/pintc/tests/unions/no_value_union.pnt
+++ b/pintc/tests/unions/no_value_union.pnt
@@ -49,15 +49,15 @@ predicate decl_test {
 // predicate ::test {
 //     var ::x: ::either;
 //     constraint (::x == ::either::right);
-//     constraint (UnTag(::x) == ::either::left ? true : false);
+//     constraint ((UnTag(::x) == 0) ? true : false);
 //     constraint __eq_set(__mut_keys(), {0});
 // }
 //
 // predicate ::decl_test {
 //     var ::x: ::either;
 //     constraint (::x == ::either::right);
-//     constraint (!UnTag(::x) == ::either::left || true);
-//     constraint (UnTag(::x) == ::either::left || (!UnTag(::x) == ::either::right || false));
+//     constraint (!(UnTag(::x) == 0) || true);
+//     constraint ((UnTag(::x) == 0) || (!(UnTag(::x) == 1) || false));
 //     constraint __eq_set(__mut_keys(), {0});
 // }
 // >>>

--- a/pintc/tests/unions/simple.pnt
+++ b/pintc/tests/unions/simple.pnt
@@ -112,22 +112,22 @@ predicate test {
 //     var ::no_base_addr: int;
 //     var ::a_base_addr: int;
 //     var ::actual_addr: b256;
-//     constraint (UnTag(::x) == ::thing::a ? UnVal(::x, bool) : (UnTag(::x) == ::thing::b ? (UnVal(::x, int) > 0) : ((UnVal(::x, {int, int}).0 + UnVal(::x, {int, int}).1) == 11)));
-//     constraint ((UnTag(::x) == ::thing::b ? UnVal(::x, int) : 22) > 0);
-//     constraint (UnTag(::x) == ::thing::a ? UnVal(::x, bool) : (UnTag(::x) == ::thing::b ? ((UnVal(::x, int) * 2) < 10) : true));
+//     constraint ((UnTag(::x) == 0) ? UnVal(::x, bool) : ((UnTag(::x) == 1) ? (UnVal(::x, int) > 0) : ((UnVal(::x, {int, int}).0 + UnVal(::x, {int, int}).1) == 11)));
+//     constraint (((UnTag(::x) == 1) ? UnVal(::x, int) : 22) > 0);
+//     constraint ((UnTag(::x) == 0) ? UnVal(::x, bool) : ((UnTag(::x) == 1) ? ((UnVal(::x, int) * 2) < 10) : true));
 //     constraint (::no_base_addr == ::maybe_addr::no_addr);
 //     constraint (::a_base_addr == ::maybe_addr::addr(0x1111111111111111111111111111111111111111111111111111111111111111));
-//     constraint (::actual_addr == (UnTag(::no_base_addr) == ::maybe_addr::no_addr ? 0x0000000000000000000000000000000000000000000000000000000000000000 : UnVal(::no_base_addr, b256)));
+//     constraint (::actual_addr == ((UnTag(::no_base_addr) == 0) ? 0x0000000000000000000000000000000000000000000000000000000000000000 : UnVal(::no_base_addr, b256)));
 //     constraint (::no_base_addr != ::a_base_addr);
 //     constraint (::no_base_addr == ::maybe_addr::no_addr);
 //     constraint (::thing::b(77) == ::thing::b(77));
 //     constraint (::thing::b(88) != ::thing::b(99));
-//     constraint (UnTag(::x) == ::thing::a || (!UnTag(::x) == ::thing::c || ((UnVal(::x, {int, int}).0 * UnVal(::x, {int, int}).1) == 66)));
-//     constraint (UnTag(::x) == ::thing::a || (!UnTag(::x) == ::thing::c || (::d == (UnVal(::x, {int, int}).0 - UnVal(::x, {int, int}).1))));
-//     constraint (UnTag(::x) == ::thing::a || (UnTag(::x) == ::thing::c || (::d == 55)));
-//     constraint (UnTag(::x) == ::thing::a || (!UnTag(::x) == ::thing::b || (UnVal(::x, int) > 0)));
-//     constraint (UnTag(::x) == ::thing::a || (UnTag(::x) == ::thing::b || (!UnTag(::x) == ::thing::c || (UnVal(::x, {int, int}).0 == 33))));
-//     constraint (UnTag(::x) == ::thing::a || (UnTag(::x) == ::thing::b || (!UnTag(::x) == ::thing::c || (UnVal(::x, {int, int}).1 != 44))));
+//     constraint ((UnTag(::x) == 0) || (!(UnTag(::x) == 2) || ((UnVal(::x, {int, int}).0 * UnVal(::x, {int, int}).1) == 66)));
+//     constraint ((UnTag(::x) == 0) || (!(UnTag(::x) == 2) || (::d == (UnVal(::x, {int, int}).0 - UnVal(::x, {int, int}).1))));
+//     constraint ((UnTag(::x) == 0) || ((UnTag(::x) == 2) || (::d == 55)));
+//     constraint ((UnTag(::x) == 0) || (!(UnTag(::x) == 1) || (UnVal(::x, int) > 0)));
+//     constraint ((UnTag(::x) == 0) || ((UnTag(::x) == 1) || (!(UnTag(::x) == 2) || (UnVal(::x, {int, int}).0 == 33))));
+//     constraint ((UnTag(::x) == 0) || ((UnTag(::x) == 1) || (!(UnTag(::x) == 2) || (UnVal(::x, {int, int}).1 != 44))));
 //     constraint __eq_set(__mut_keys(), {0});
 // }
 // >>>


### PR DESCRIPTION
This is to better support direct union immediates equivalence comparisons.

Part of working towards #879.