### PR TITLE
Further adventures in enum lowering.

### DIFF
--- a/pintc/src/asm_gen/asm_builder.rs
+++ b/pintc/src/asm_gen/asm_builder.rs
@@ -253,7 +253,7 @@ impl AsmBuilder<'_> {
     ) -> Result<Location, ErrorEmitted> {
         fn compile_immediate(asm: &mut Asm, imm: &Immediate) {
             match imm {
-                Immediate::Int(val) => asm.push(Stack::Push(*val).into()),
+                Immediate::Int(val) | Immediate::Enum(val, _) => asm.push(Stack::Push(*val).into()),
                 Immediate::Bool(val) => asm.push(Stack::Push(*val as i64).into()),
                 Immediate::B256(val) => {
                     asm.push(Stack::Push(val[0] as i64).into());

--- a/pintc/src/expr.rs
+++ b/pintc/src/expr.rs
@@ -155,6 +155,7 @@ pub enum Immediate {
     Nil,
     Real(f64),
     Int(i64),
+    Enum(i64, Path),
     Bool(bool),
     String(String),
     B256([u64; 4]),
@@ -192,6 +193,11 @@ impl Immediate {
                 span,
             },
 
+            Immediate::Enum(_, path) => Type::Custom {
+                path: path.to_string(),
+                span,
+            },
+
             _ => Type::Primitive {
                 kind: match self {
                     Immediate::Nil => PrimitiveKind::Nil,
@@ -201,7 +207,10 @@ impl Immediate {
                     Immediate::String(_) => PrimitiveKind::String,
                     Immediate::B256(_) => PrimitiveKind::B256,
 
-                    Immediate::Error | Immediate::Array { .. } | Immediate::Tuple(_) => {
+                    Immediate::Error
+                    | Immediate::Array { .. }
+                    | Immediate::Tuple(_)
+                    | Immediate::Enum(..) => {
                         unreachable!()
                     }
                 },

--- a/pintc/src/expr/display.rs
+++ b/pintc/src/expr/display.rs
@@ -235,6 +235,7 @@ impl DisplayWithContract for super::Immediate {
             super::Immediate::Nil => write!(f, "nil"),
             super::Immediate::Real(n) => write!(f, "{n:e}"),
             super::Immediate::Int(n) => write!(f, "{n}"),
+            super::Immediate::Enum(n, _) => write!(f, "{n}"),
             super::Immediate::Bool(b) => write!(f, "{b}"),
             super::Immediate::String(s) => write!(f, "{s:?}"),
             super::Immediate::B256(val) => {

--- a/pintc/src/expr/evaluate.rs
+++ b/pintc/src/expr/evaluate.rs
@@ -52,7 +52,7 @@ impl Evaluator {
                 variants.iter().enumerate().map(|(idx, variant)| {
                     (
                         enum_name.name.clone() + "::" + &variant.name,
-                        Imm::Int(idx as i64),
+                        Imm::Enum(idx as i64, enum_name.name.clone()),
                     )
                 })
             },
@@ -235,7 +235,7 @@ impl Evaluator {
                 if let Imm::Array(elements) = ary {
                     // And the index is an int...
                     let idx = self.evaluate_key(index, handler, contract)?;
-                    if let Imm::Int(n) = idx {
+                    if let Imm::Int(n) | Imm::Enum(n, _) = idx {
                         // And it's not out of bounds...
                         elements.get(n as usize).cloned().ok_or_else(|| {
                             handler.emit_err(Error::Compile {
@@ -350,7 +350,7 @@ impl Evaluator {
                         }
                     }
 
-                    Imm::Int(i) => {
+                    Imm::Int(i) | Imm::Enum(i, _) => {
                         if ty.is_int() {
                             Ok(imm)
                         } else if ty.is_real() {

--- a/pintc/src/predicate/analyse/array_check.rs
+++ b/pintc/src/predicate/analyse/array_check.rs
@@ -80,7 +80,7 @@ impl Contract {
                 // Get the size of the accessed array.
                 if let Ok(array_size) = get_array_size_from_type(self, handler, &array_ty) {
                     // Check for OOB.
-                    if let Immediate::Int(imm_val) = index_value {
+                    if let Immediate::Int(imm_val) | Immediate::Enum(imm_val, _) = index_value {
                         if imm_val < 0 || imm_val >= array_size {
                             handler.emit_err(Error::Compile {
                                 error: CompileError::ArrayIndexOutOfBounds { span: index_span },

--- a/pintc/tests/consts/simple.pnt
+++ b/pintc/tests/consts/simple.pnt
@@ -66,11 +66,11 @@ predicate test {
 // const ::b: b256 = 0x2222222222222222222222222222222222222222222222222222222222222222;
 // const ::h: {int, bool} = {1010, false};
 // const ::e: bool = true;
-// const ::k: ::JacketColour = 1;
+// const ::k: int = 1;
 // const ::d: b256 = 0x4444444444444444444444444444444444444444444444444444444444444444;
 // const ::a: int = 11;
 // const ::g: int[_] = [88, 99];
-// const ::j: ::JacketColour = 5;
+// const ::j: int = 5;
 // const ::f: {int, int} = {66, 77};
 // const ::c: int = 33;
 // enum ::JacketColour = Cream | Bone | White | OffWhite | Ivory | Beige;

--- a/pintc/tests/types/const_tuples_with_enums.pnt
+++ b/pintc/tests/types/const_tuples_with_enums.pnt
@@ -1,0 +1,23 @@
+enum x = a | b;
+
+const y: { x, x } = { x::a, x::b };
+
+predicate test {
+}
+
+// parsed <<<
+// const ::y: {::x, ::x} = {::x::a, ::x::b};
+// enum ::x = a | b;
+//
+// predicate ::test {
+// }
+// >>>
+
+// flattened <<<
+// const ::y: {int, int} = {0, 1};
+// enum ::x = a | b;
+//
+// predicate ::test {
+//     constraint __eq_set(__mut_keys(), {0});
+// }
+// >>>

--- a/pintc/tests/types/nested_enums.pnt
+++ b/pintc/tests/types/nested_enums.pnt
@@ -8,6 +8,16 @@ type Father = {
     pet: Animal,
 };
 
+union Parent = Mum | Dad(Father);
+
+const papa: Father = { child: { age: 33, pet: Animal::Cat }, pet: Animal::Dog };
+
+interface InTheFace {
+    predicate Who {
+        pub var left: Father;
+    }
+}
+
 predicate Foo {
     var bob = {
         child: {
@@ -19,32 +29,64 @@ predicate Foo {
 
     var friends_pets: Animal[3] = [Animal::Dog, Animal::Cat, Animal::Cat];
 
+    var barb: Parent;
+    match barb {
+        Parent::Mum => {}
+        Parent::Dad(d) => {
+            constraint d.pet == Animal::Cat;
+        }
+    }
+
     constraint bob.pet != Animal::Dog;
 }
 
 // parsed <<<
+// const ::papa: ::Father = {child: {age: 33, pet: ::Animal::Cat}, pet: ::Animal::Dog};
 // enum ::Animal = Cat | Dog;
+// union ::Parent = Mum | Dad(::Father);
 // type ::Father = {child: {age: int, pet: ::Animal}, pet: ::Animal};
+// interface ::InTheFace {
+//     predicate Who {
+//         pub var left: ::Father;
+//     }
+// }
 //
 // predicate ::Foo {
 //     var ::bob;
 //     var ::friends_pets: ::Animal[3];
+//     var ::barb: ::Parent;
 //     constraint (::bob == {child: {age: 23, pet: ::Animal::Dog}, pet: ::Animal::Cat});
 //     constraint (::friends_pets == [::Animal::Dog, ::Animal::Cat, ::Animal::Cat]);
 //     constraint (::bob.pet != ::Animal::Dog);
+//     match ::barb {
+//         ::Parent::Mum => {
+//         }
+//         ::Parent::Dad(d) => {
+//             constraint (::d.pet == ::Animal::Cat)
+//         }
+//     }
 // }
 // >>>
 
 // flattened <<<
+// const ::papa: {child: {age: int, pet: int}, pet: int} = {child: {age: 33, pet: 0}, pet: 1};
 // enum ::Animal = Cat | Dog;
+// union ::Parent = Mum | Dad({child: {age: int, pet: ::Animal}, pet: ::Animal});
 // type ::Father = {child: {age: int, pet: ::Animal}, pet: ::Animal};
+// interface ::InTheFace {
+//     predicate Who {
+//         pub var left: {child: {age: int, pet: int}, pet: int};
+//     }
+// }
 //
 // predicate ::Foo {
 //     var ::bob: {child: {age: int, pet: int}, pet: int};
 //     var ::friends_pets: int[3];
+//     var ::barb: ::Parent;
 //     constraint (::bob == {child: {age: 23, pet: 1}, pet: 0});
 //     constraint (::friends_pets == [1, 0, 0]);
 //     constraint (::bob.pet != 1);
+//     constraint ((UnTag(::barb) == 0) || (!(UnTag(::barb) == 1) || (UnVal(::barb, {child: {age: int, pet: int}, pet: int}).pet == 0)));
 //     constraint __eq_set(__mut_keys(), {0});
 // }
 // >>>

--- a/pintc/tests/types/new_type.pnt
+++ b/pintc/tests/types/new_type.pnt
@@ -68,7 +68,7 @@ predicate test {
 //         pub var x: ::A;
 //     }
 // }
-// 
+//
 // predicate ::test {
 //     var ::t: ::A;
 //     pub var ::pt: ::A;
@@ -115,10 +115,10 @@ predicate test {
 //         c: int,
 //     }
 //     predicate Foo {
-//         pub var x: ::TheLetterA;
+//         pub var x: int;
 //     }
 // }
-// 
+//
 // predicate ::test {
 //     var ::t: int;
 //     pub var ::pt: int;

--- a/pintc/tests/unions/simple.pnt
+++ b/pintc/tests/unions/simple.pnt
@@ -109,8 +109,8 @@ predicate test {
 // predicate ::test {
 //     var ::x: ::thing;
 //     var ::d: int;
-//     var ::no_base_addr: int;
-//     var ::a_base_addr: int;
+//     var ::no_base_addr: ::maybe_addr;
+//     var ::a_base_addr: ::maybe_addr;
 //     var ::actual_addr: b256;
 //     constraint ((UnTag(::x) == 0) ? UnVal(::x, bool) : ((UnTag(::x) == 1) ? (UnVal(::x, int) > 0) : ((UnVal(::x, {int, int}).0 + UnVal(::x, {int, int}).1) == 11)));
 //     constraint (((UnTag(::x) == 1) ? UnVal(::x, int) : 22) > 0);


### PR DESCRIPTION
#873 was a bit aggressive and converted some union types into integers erroneously.

- move the nested enum code from `types.rs` into `lower.rs` since that's the only place it'll get called.
- make the nested checking more `Type::Custom` aware -- they're not necessarily enums.
- add a couple more instances to tests; `const`s and `interface`s.

This change adds to the argument for #874 to be addressed.