### PR TITLE
Remove `warning` for constraints that are always positive

### DIFF
--- a/pintc/src/predicate/optimize/dead_code_elimination.rs
+++ b/pintc/src/predicate/optimize/dead_code_elimination.rs
@@ -75,10 +75,6 @@ pub(crate) fn dead_constraint_elimination(handler: &Handler, contract: &mut Cont
                             handler.emit_warn(Warning::AlwaysFalseConstraint {
                                 span: constraint.span.clone(),
                             });
-                        } else {
-                            handler.emit_warn(Warning::TrivialConstraint {
-                                span: constraint.span.clone(),
-                            });
                         }
 
                         Some(i)

--- a/pintc/src/warning.rs
+++ b/pintc/src/warning.rs
@@ -16,8 +16,6 @@ pub struct WarningLabel {
 pub enum Warning {
     #[error("unneeded else branch")]
     MatchUnneededElse { span: Span },
-    #[error("constraint is always `true`")]
-    TrivialConstraint { span: Span },
     #[error("constraint is always `false`")]
     AlwaysFalseConstraint { span: Span },
 }
@@ -28,12 +26,6 @@ impl ReportableWarning for Warning {
         match self {
             MatchUnneededElse { span } => vec![WarningLabel {
                 message: "`else` branch in match will never be evaluated".to_string(),
-                span: span.clone(),
-                color: Color::Yellow,
-            }],
-
-            TrivialConstraint { span } => vec![WarningLabel {
-                message: "this constraint always evaluates to `true`".to_string(),
                 span: span.clone(),
                 color: Color::Yellow,
             }],
@@ -50,9 +42,7 @@ impl ReportableWarning for Warning {
     fn note(&self) -> Option<String> {
         use Warning::*;
         match self {
-            MatchUnneededElse { .. } | TrivialConstraint { .. } | AlwaysFalseConstraint { .. } => {
-                None
-            }
+            MatchUnneededElse { .. } | AlwaysFalseConstraint { .. } => None,
         }
     }
 
@@ -63,9 +53,6 @@ impl ReportableWarning for Warning {
     fn help(&self) -> Option<String> {
         use Warning::*;
         match self {
-            TrivialConstraint { .. } => {
-                Some("if this is intentional, consider removing this constraint".to_string())
-            }
 
             AlwaysFalseConstraint { .. } => {
                 Some("if this is intentional, consider removing the containing predicate because its constraints can never be satisfied".to_string())
@@ -80,9 +67,7 @@ impl Spanned for Warning {
     fn span(&self) -> &Span {
         use Warning::*;
         match self {
-            MatchUnneededElse { span }
-            | TrivialConstraint { span }
-            | AlwaysFalseConstraint { span } => span,
+            MatchUnneededElse { span } | AlwaysFalseConstraint { span } => span,
         }
     }
 }

--- a/pintc/tests/experimental/dead_constraint_elimination.pnt
+++ b/pintc/tests/experimental/dead_constraint_elimination.pnt
@@ -30,7 +30,4 @@ predicate Test {
 // >>>
 
 // warnings <<<
-// constraint is always `true`
-// @45..57: this constraint always evaluates to `true`
-// if this is intentional, consider removing this constraint
 // >>>

--- a/pintc/tests/optimizations/dead_constraint_elimination.pnt
+++ b/pintc/tests/optimizations/dead_constraint_elimination.pnt
@@ -83,25 +83,4 @@ predicate Test {
 // >>>
 
 // warnings <<<
-// constraint is always `true`
-// @179..194: this constraint always evaluates to `true`
-// if this is intentional, consider removing this constraint
-// constraint is always `true`
-// @200..217: this constraint always evaluates to `true`
-// if this is intentional, consider removing this constraint
-// constraint is always `true`
-// @223..244: this constraint always evaluates to `true`
-// if this is intentional, consider removing this constraint
-// constraint is always `true`
-// @250..262: this constraint always evaluates to `true`
-// if this is intentional, consider removing this constraint
-// constraint is always `true`
-// @268..280: this constraint always evaluates to `true`
-// if this is intentional, consider removing this constraint
-// constraint is always `true`
-// @286..307: this constraint always evaluates to `true`
-// if this is intentional, consider removing this constraint
-// constraint is always `true`
-// @313..334: this constraint always evaluates to `true`
-// if this is intentional, consider removing this constraint
 // >>>


### PR DESCRIPTION
@mohammadfawaz and I chatted and determined this should not be a `warning`.

A `warning` should be given when something is inherently wrong with the code written. Not just because some code is being optimized away.