### PR TITLE
Disallow `==` or `!=` comparisons for union variant.

### DIFF
--- a/pintc/src/error/compile_error.rs
+++ b/pintc/src/error/compile_error.rs
@@ -222,6 +222,13 @@ pub enum CompileError {
         arity: &'static str,
         large_err: Box<LargeTypeError>,
     },
+    #[error("operator invalid type error")]
+    OperatorInvalidType {
+        op: &'static str,
+        ty_kind: &'static str,
+        bad_ty: String,
+        span: Span,
+    },
     #[error("{init_kind} initialization type error")]
     InitTypeError {
         init_kind: &'static str,
@@ -981,6 +988,17 @@ impl ReportableError for CompileError {
                 }
             },
 
+            OperatorInvalidType {
+                op,
+                ty_kind,
+                bad_ty,
+                span,
+            } => vec![ErrorLabel {
+                message: format!("invalid {ty_kind} type `{bad_ty}` for operator `{op}`"),
+                span: span.clone(),
+                color: Color::Red,
+            }],
+
             BadCastTo { ty, span } => vec![ErrorLabel {
                 message: format!("illegal cast to a `{ty}`"),
                 span: span.clone(),
@@ -1363,6 +1381,7 @@ impl ReportableError for CompileError {
             | SelectBranchesTypeMismatch { .. }
             | ConstraintExpressionTypeError { .. }
             | OperatorTypeError { .. }
+            | OperatorInvalidType { .. }
             | InitTypeError { .. }
             | StateVarInitTypeError { .. }
             | IndexExprNonIndexable { .. }
@@ -1614,7 +1633,8 @@ impl Spanned for CompileError {
             | UnknownUnionVariant { span, .. }
             | SuperfluousUnionExprValue { span, .. }
             | MissingUnionExprValue { span, .. }
-            | UnionVariantTypeMismatch { span, .. } => span,
+            | UnionVariantTypeMismatch { span, .. }
+            | OperatorInvalidType { span, .. } => span,
 
             DependencyCycle { spans } => &spans[0],
 

--- a/pintc/tests/basic_tests/bad_nil.pnt
+++ b/pintc/tests/basic_tests/bad_nil.pnt
@@ -22,10 +22,10 @@ predicate test {
 // binary operator type error
 // @25..26: unexpected argument for operator `==`
 // only state variables and next state expressions can be compared to `nil`
-// binary operator type error
-// @60..63: operator `+` argument has unexpected type `nil`
-// binary operator type error
-// @100..103: operator `<` argument has unexpected type `nil`
+// operator invalid type error
+// @56..63: invalid non-numeric type `nil` for operator `+`
+// operator invalid type error
+// @96..103: invalid non-numeric type `nil` for operator `<`
 // variable initialization type error
 // @34..37: variable initializer has unexpected type `nil`
 // @28..31: expecting type `int`

--- a/pintc/tests/basic_tests/if_statement_body_type_error.pnt
+++ b/pintc/tests/basic_tests/if_statement_body_type_error.pnt
@@ -67,8 +67,8 @@ predicate test {
 // binary operator type error
 // @185..186: operator `&&` argument has unexpected type `int`
 // @174..186: expecting type `bool`
-// binary operator type error
-// @271..275: operator `+` argument has unexpected type `bool`
-// binary operator type error
-// @533..544: operator `+` argument has unexpected type `{int, bool}`
+// operator invalid type error
+// @267..275: invalid non-numeric type `bool` for operator `+`
+// operator invalid type error
+// @528..544: invalid non-numeric type `{int, bool}` for operator `+`
 // >>>

--- a/pintc/tests/interfaces/bad_address.pnt
+++ b/pintc/tests/interfaces/bad_address.pnt
@@ -45,16 +45,16 @@ predicate Simple {
 // >>>
 
 // typecheck_failure <<<
-// binary operator type error
-// @202..206: operator `+` argument has unexpected type `bool`
+// operator invalid type error
+// @198..206: invalid non-numeric type `bool` for operator `+`
 // address expression type error
 // @198..206: address expression has unexpected type `int`
 // @198..206: expecting type `b256`
 // address expression type error
 // @242..248: address expression has unexpected type `{int, int}`
 // @242..248: expecting type `b256`
-// binary operator type error
-// @359..363: operator `+` argument has unexpected type `bool`
+// operator invalid type error
+// @355..363: invalid non-numeric type `bool` for operator `+`
 // address expression type error
 // @355..363: address expression has unexpected type `int`
 // @355..363: expecting type `b256`

--- a/pintc/tests/types/binary_ops.pnt
+++ b/pintc/tests/types/binary_ops.pnt
@@ -24,7 +24,7 @@ predicate test {
 
 // parsed <<<
 // enum ::T = FortyTwo | FleventyFive;
-// 
+//
 // predicate ::test {
 //     var ::a;
 //     var ::b;
@@ -54,28 +54,28 @@ predicate test {
 // >>>
 
 // typecheck_failure <<<
-// binary operator type error
-// @69..74: operator `+` argument has unexpected type `bool`
-// binary operator type error
-// @93..97: operator `-` argument has unexpected type `bool`
-// binary operator type error
-// @111..116: operator `*` argument has unexpected type `int[2]`
-// binary operator type error
-// @135..201: operator `/` argument has unexpected type `b256`
-// binary operator type error
-// @226..237: operator `%` argument has unexpected type `::T`
+// operator invalid type error
+// @64..74: invalid non-numeric type `bool` for operator `+`
+// operator invalid type error
+// @88..97: invalid non-numeric type `bool` for operator `-`
+// operator invalid type error
+// @111..121: invalid non-numeric type `int[2]` for operator `*`
+// operator invalid type error
+// @135..206: invalid non-numeric type `b256` for operator `/`
+// operator invalid type error
+// @221..237: invalid non-numeric type `::T` for operator `%`
 // binary operator type error
 // @322..337: operator `==` argument has unexpected type `::T`
 // @316..318: expecting type `int`
 // binary operator type error
 // @357..361: operator `!=` argument has unexpected type `bool`
 // @351..353: expecting type `int`
-// binary operator type error
-// @376..380: operator `>` argument has unexpected type `bool`
-// binary operator type error
-// @407..473: operator `<` argument has unexpected type `b256`
-// binary operator type error
-// @493..501: operator `<=` argument has unexpected type `int[2]`
+// operator invalid type error
+// @376..388: invalid non-numeric type `bool` for operator `>`
+// operator invalid type error
+// @402..473: invalid non-numeric type `b256` for operator `<`
+// operator invalid type error
+// @487..501: invalid non-numeric type `int[2]` for operator `<=`
 // binary operator type error
 // @524..526: operator `&&` argument has unexpected type `int`
 // @516..526: expecting type `bool`

--- a/pintc/tests/unions/bad_conditional.pnt
+++ b/pintc/tests/unions/bad_conditional.pnt
@@ -1,0 +1,29 @@
+union pet = cats(int) | dogs(int) | emu;
+
+predicate test {
+    var a: pet;
+
+    constraint pet::cats(11) == a;
+    constraint a > pet::cats(11);
+    constraint pet::dogs(22) <= pet::emu;
+}
+
+// parsed <<<
+// union ::pet = cats(int) | dogs(int) | emu;
+//
+// predicate ::test {
+//     var ::a: ::pet;
+//     constraint (::pet::cats(11) == ::a);
+//     constraint (::a > ::pet::cats(11));
+//     constraint (::pet::dogs(22) <= ::pet::emu);
+// }
+// >>>
+
+// typecheck_failure <<<
+// operator invalid type error
+// @91..109: invalid union type `::pet` for operator `==`
+// operator invalid type error
+// @126..143: invalid non-numeric type `::pet` for operator `>`
+// operator invalid type error
+// @160..185: invalid non-numeric type `::pet` for operator `<=`
+// >>>

--- a/pintc/tests/unions/no_value_union.pnt
+++ b/pintc/tests/unions/no_value_union.pnt
@@ -1,7 +1,7 @@
 union either = left | right;
 
 predicate test {
-    var x: either = either::right;
+    var x: either; // DISABLED until we 'fix' initialisers. = either::right;
     constraint match x {
         either::left => true,
         either::right => false,
@@ -9,7 +9,7 @@ predicate test {
 }
 
 predicate decl_test {
-    var x: either = either::right;
+    var x: either; // DISABLED until we 'fix' initialisers. = either::right;
     match x {
         either::left => {
             constraint true;
@@ -25,13 +25,11 @@ predicate decl_test {
 //
 // predicate ::test {
 //     var ::x: ::either;
-//     constraint (::x == ::either::right);
 //     constraint match ::x { ::either::left => true, ::either::right => false };
 // }
 //
 // predicate ::decl_test {
 //     var ::x: ::either;
-//     constraint (::x == ::either::right);
 //     match ::x {
 //         ::either::left => {
 //             constraint true
@@ -48,14 +46,12 @@ predicate decl_test {
 //
 // predicate ::test {
 //     var ::x: ::either;
-//     constraint (::x == ::either::right);
 //     constraint ((UnTag(::x) == 0) ? true : false);
 //     constraint __eq_set(__mut_keys(), {0});
 // }
 //
 // predicate ::decl_test {
 //     var ::x: ::either;
-//     constraint (::x == ::either::right);
 //     constraint (!(UnTag(::x) == 0) || true);
 //     constraint ((UnTag(::x) == 0) || (!(UnTag(::x) == 1) || false));
 //     constraint __eq_set(__mut_keys(), {0});

--- a/pintc/tests/unions/simple.pnt
+++ b/pintc/tests/unions/simple.pnt
@@ -49,19 +49,17 @@ predicate test {
     }
 
     // Constraining an address to either zero or something.
-    var no_base_addr: maydr = maybe_addr::no_addr;
-    var a_base_addr: maydr = maybe_addr::addr(0x1111111111111111111111111111111111111111111111111111111111111111);
+    //
+    // DISABLED until we 'fix' initialisers.  These initialisers would generate constraints like
+    // `no_bad_addr == maybe_addr::no_bad_addr` but `==` is illegal for unions.
+    //
+    //var no_base_addr: maydr = maybe_addr::no_addr;
+    //var a_base_addr: maydr = maybe_addr::addr(0x1111111111111111111111111111111111111111111111111111111111111111);
 
-    var actual_addr = match no_base_addr {
-        maybe_addr::no_addr => 0x0000000000000000000000000000000000000000000000000000000000000000,
-        maybe_addr::addr(a) => a,
-    };
-
-    // Direct comparisons.
-    constraint no_base_addr != a_base_addr;
-    constraint no_base_addr == maybe_addr::no_addr;
-    constraint thing::b(77) == thing::b(77);
-    constraint thing::b(88) != thing::b(99);
+    //var actual_addr = match no_base_addr {
+    //    maybe_addr::no_addr => 0x0000000000000000000000000000000000000000000000000000000000000000,
+    //    maybe_addr::addr(a) => a,
+    //};
 }
 
 // parsed <<<
@@ -73,19 +71,9 @@ predicate test {
 // predicate ::test {
 //     var ::x: ::thing;
 //     var ::d: int;
-//     var ::no_base_addr: ::maydr;
-//     var ::a_base_addr: ::maydr;
-//     var ::actual_addr;
 //     constraint match ::x { ::thing::a(b) => ::b, ::thing::b(n) => (::n > 0), ::thing::c(t) => ((::t.0 + ::t.1) == 11) };
 //     constraint (match ::x { ::thing::b(b) => ::b, else => 22 } > 0);
 //     constraint match ::x { ::thing::a(b) => ::b, ::thing::b(n) => constraint (::n > 0); ((::n * 2) < 10), ::thing::c(t) => constraint (::t.0 == 33); constraint (::t.1 != 44); true };
-//     constraint (::no_base_addr == ::maybe_addr::no_addr);
-//     constraint (::a_base_addr == ::maybe_addr::addr(0x1111111111111111111111111111111111111111111111111111111111111111));
-//     constraint (::actual_addr == match ::no_base_addr { ::maybe_addr::no_addr => 0x0000000000000000000000000000000000000000000000000000000000000000, ::maybe_addr::addr(a) => ::a });
-//     constraint (::no_base_addr != ::a_base_addr);
-//     constraint (::no_base_addr == ::maybe_addr::no_addr);
-//     constraint (::thing::b(77) == ::thing::b(77));
-//     constraint (::thing::b(88) != ::thing::b(99));
 //     match ::x {
 //         ::thing::a(b) => {
 //         }
@@ -109,19 +97,9 @@ predicate test {
 // predicate ::test {
 //     var ::x: ::thing;
 //     var ::d: int;
-//     var ::no_base_addr: ::maybe_addr;
-//     var ::a_base_addr: ::maybe_addr;
-//     var ::actual_addr: b256;
 //     constraint ((UnTag(::x) == 0) ? UnVal(::x, bool) : ((UnTag(::x) == 1) ? (UnVal(::x, int) > 0) : ((UnVal(::x, {int, int}).0 + UnVal(::x, {int, int}).1) == 11)));
 //     constraint (((UnTag(::x) == 1) ? UnVal(::x, int) : 22) > 0);
 //     constraint ((UnTag(::x) == 0) ? UnVal(::x, bool) : ((UnTag(::x) == 1) ? ((UnVal(::x, int) * 2) < 10) : true));
-//     constraint (::no_base_addr == ::maybe_addr::no_addr);
-//     constraint (::a_base_addr == ::maybe_addr::addr(0x1111111111111111111111111111111111111111111111111111111111111111));
-//     constraint (::actual_addr == ((UnTag(::no_base_addr) == 0) ? 0x0000000000000000000000000000000000000000000000000000000000000000 : UnVal(::no_base_addr, b256)));
-//     constraint (::no_base_addr != ::a_base_addr);
-//     constraint (::no_base_addr == ::maybe_addr::no_addr);
-//     constraint (::thing::b(77) == ::thing::b(77));
-//     constraint (::thing::b(88) != ::thing::b(99));
 //     constraint ((UnTag(::x) == 0) || (!(UnTag(::x) == 2) || ((UnVal(::x, {int, int}).0 * UnVal(::x, {int, int}).1) == 66)));
 //     constraint ((UnTag(::x) == 0) || (!(UnTag(::x) == 2) || (::d == (UnVal(::x, {int, int}).0 - UnVal(::x, {int, int}).1))));
 //     constraint ((UnTag(::x) == 0) || ((UnTag(::x) == 2) || (::d == 55)));


### PR DESCRIPTION
Initially I thought implementing `==` for union variants would be pretty straightforward.  They just need to be converted into tag and value compares.

E.g., `shape::triangles(3) == shape::square` would become
```
tag(shape::triangles(3)) == tag(shape::square) && value(shape::triangles(3)) == value(shape::square)
```

But `value(union_variant)` requires the type of the value be known at compile time, and obviously for it to be correct.  Comparing two values with different types, or especially with different sizes, is not really possible at the assembly level.

By comparing the tags first we can at least know that the two values are the same type and same size.  And with shortcutting `&&` we can avoid the impossible comparisons -- they will be skipped unless the tags already match.

But then what are we comparing at runtime if the tags _do_ match?  It depends entirely on what the tag actually is.  It might be an unbound variant like `option::none` where comparing the tags is enough.  Or it might be one of many bound values, all of which may be different sizes.  So the value comparison would need to get the size of the type at runtime based on the tag... which could be in a table somewhere?  Or more likely be encoded in a switch statement..?  All just to do a `==` comparison?

So I've decided for now that comparing variants is not feasible.

BUT!  This is very unfortunate for `var` initialisation.  As I've outlined in #892 when we initialise a `var` we actually emit a constraint to ensure that the var `==` the RHS initialiser.  This is now impossible for unions so we can't have initialised `var` union.

## Edit...

Well, not an edit, but I was just thinking about this after I'd written all the above.  How are unions handled in other languages/runtimes?

Hrmm, actually, you just reserve the biggest variant size in memory and just populate the bits you need, zero out the rest and compare that.  So I guess instead of a table or switch statement to get variant sizes, you just use the biggest size and partially fill it.

This would require a new `Expr` and some fancy ASM gen.  Right now when compiling a variant it's pretty straight forward: compile the tag then compile the value.  They both go onto the stack, exactly like a tagged struct would.  Instead we'd need to reserve space on the stack of the maximum size and compile into that... or more practially fill the empty zeroed space up and compile the value after it.  Then we have to be sure to clean up the whole thing, which for `EqRange` is fine if the range is the maximum size.

OK, perhaps this is the way to go eventually.  But not today.