### PR TITLE
Re-enable some `<disabled>` E2E tests.

### DIFF
--- a/pintc/src/predicate.rs
+++ b/pintc/src/predicate.rs
@@ -261,6 +261,27 @@ impl Contract {
             .iter_mut()
             .for_each(|NewTypeDecl { ty, .. }| ty.replace_type_expr(old_expr, new_expr));
 
+        self.interfaces.iter_mut().for_each(
+            |Interface {
+                 storage,
+                 predicate_interfaces,
+                 ..
+             }| {
+                if let Some((storage_vars, _)) = storage {
+                    storage_vars
+                        .iter_mut()
+                        .for_each(|StorageVar { ty, .. }| ty.replace_type_expr(old_expr, new_expr))
+                }
+                predicate_interfaces
+                    .iter_mut()
+                    .for_each(|PredicateInterface { vars, .. }| {
+                        vars.iter_mut().for_each(|InterfaceVar { ty, .. }| {
+                            ty.replace_type_expr(old_expr, new_expr)
+                        });
+                    });
+            },
+        );
+
         if let Some(pred_key) = pred_key {
             self.preds
                 .get_mut(pred_key)

--- a/pintc/src/predicate/transform/lower.rs
+++ b/pintc/src/predicate/transform/lower.rs
@@ -545,6 +545,29 @@ pub(crate) fn lower_array_ranges(
         })
         .collect();
 
+    for Interface {
+        storage,
+        predicate_interfaces,
+        ..
+    } in &contract.interfaces
+    {
+        if let Some((storage_vars, _)) = storage {
+            array_range_expr_keys.extend(storage_vars.iter().filter_map(
+                |StorageVar { ty, .. }| {
+                    dbg!(ty.get_array_range_expr());
+                    ty_non_int_range_expr(contract, None, ty)
+                },
+            ));
+        }
+
+        array_range_expr_keys.extend(predicate_interfaces.iter().flat_map(
+            |PredicateInterface { vars, .. }| {
+                vars.iter()
+                    .filter_map(|InterfaceVar { ty, .. }| ty_non_int_range_expr(contract, None, ty))
+            },
+        ));
+    }
+
     for pred_key in contract.preds.keys() {
         array_range_expr_keys.extend(contract.exprs(pred_key).filter_map(|expr_key| {
             ty_non_int_range_expr(contract, Some(pred_key), expr_key.get_ty(contract))

--- a/pintc/tests/consts/simple.pnt
+++ b/pintc/tests/consts/simple.pnt
@@ -1,5 +1,3 @@
-// Non-primitive consts are temporarily disabled.  Re-enable when they're back.
-
 const a = 11;
 const b = 0x2222222222222222222222222222222222222222222222222222222222222222;
 const c: int = 33;

--- a/pintc/tests/root_types/consts.pnt
+++ b/pintc/tests/root_types/consts.pnt
@@ -1,5 +1,3 @@
-// <disabled>
-
 const five = 5;
 
 type deuce = int[10 / five];
@@ -24,7 +22,7 @@ predicate test {
 
 // flattened <<<
 // const ::two_ints: int[2] = [11, 22];
-// const ::five = 5;
+// const ::five: int = 5;
 // type ::deuce = int[2];
 //
 // predicate ::test {

--- a/pintc/tests/root_types/interfaces.pnt
+++ b/pintc/tests/root_types/interfaces.pnt
@@ -1,5 +1,3 @@
-// <disabled>
-
 type num = int;
 type ary = num[2 + 1];
 
@@ -39,10 +37,10 @@ predicate test {
 
 // flattened <<<
 // type ::num = int;
-// type ::ary = int[3];
+// type ::ary = ::num (int)[3];
 // interface ::i {
 //     storage {
-//         x: int[3];
+//         x: int[3],
 //     }
 //     predicate p {
 //         pub var x1: int[3];


### PR DESCRIPTION
I just noticed some tests had been disabled when they could've been re-enabled.  I updated the `replace_exprs()` code to include interfaces to get one of them to pass.

Closes #818.