### PR TITLE
Improve ASM gen for unions.

### DIFF
--- a/pintc/src/asm_gen/asm_builder.rs
+++ b/pintc/src/asm_gen/asm_builder.rs
@@ -996,7 +996,8 @@ impl AsmBuilder<'_> {
         // the front.
         match self.compile_expr_pointer(handler, asm, union_expr_key, contract, pred)? {
             Location::DecisionVar => {
-                asm.push(Access::DecisionVar.into());
+                asm.push(Stack::Push(1).into()); // len
+                asm.push(Access::DecisionVarRange.into());
             }
 
             // Are these supported?

--- a/pintc/src/asm_gen/asm_builder.rs
+++ b/pintc/src/asm_gen/asm_builder.rs
@@ -959,8 +959,8 @@ impl AsmBuilder<'_> {
         pred: &Predicate,
     ) -> Result<Location, ErrorEmitted> {
         // Find the tag string in the union decl and convert to an index.
-        let tag_num = union_expr_key
-            .get_ty(contract)
+        let union_ty = union_expr_key.get_ty(contract);
+        let tag_num = union_ty
             .get_union_variant_names(&contract.unions)
             .into_iter()
             .enumerate()
@@ -974,10 +974,22 @@ impl AsmBuilder<'_> {
                 })
             })?;
 
+        // Track the actual value size in words.
+        let mut actual_value_size = 0;
+
         // Push the tag and then compile the value if necessary.
         asm.push(Stack::Push(tag_num as i64).into());
         if let Some(value_key) = value {
             self.compile_expr(handler, asm, value_key, contract, pred)?;
+            actual_value_size = value_key.get_ty(contract).size(handler, contract)?;
+        }
+
+        // Get the total union (max) size MINUS one since .size() includes the tag word.
+        let union_value_size = union_ty.size(handler, contract)? - 1;
+        while union_value_size > actual_value_size {
+            // Pad out the value with zeros.
+            asm.push(Stack::Push(0).into());
+            actual_value_size += 1;
         }
 
         Ok(Location::Value)

--- a/pintc/src/predicate/analyse/type_check/check_exprs.rs
+++ b/pintc/src/predicate/analyse/type_check/check_exprs.rs
@@ -692,19 +692,7 @@ impl Contract {
 
                         // Both args must be equatable, which at this stage is any type *except*
                         // unions; binary op type is bool.
-                        let lhs_ty_is_union = lhs_ty.is_union(&self.unions);
-                        if lhs_ty_is_union || rhs_ty.is_union(&self.unions) {
-                            handler.emit_err(Error::Compile {
-                                error: CompileError::OperatorInvalidType {
-                                    op: op.as_str(),
-                                    ty_kind: "union",
-                                    bad_ty: self
-                                        .with_ctrct(if lhs_ty_is_union { &lhs_ty } else { rhs_ty })
-                                        .to_string(),
-                                    span: span.clone(),
-                                },
-                            });
-                        } else if !lhs_ty.eq(&self.new_types, rhs_ty) {
+                        if !lhs_ty.eq(&self.new_types, rhs_ty) {
                             // Only emit an error if neither side is nil nor error, nor an
                             // initialiser constraint as per above.
                             if !lhs_ty.is_nil()

--- a/pintc/src/types.rs
+++ b/pintc/src/types.rs
@@ -734,9 +734,11 @@ impl Type {
                 ty_to: Box::new((*ty_to).abi(handler, contract)?),
             }),
 
-            // This, of course, is incorrect. It's just a placeholder until we can support ABI gen
-            // for storage vectors
+            // These, of course, are incorrect. It's just a placeholder until we can support ABI gen
+            // for them, which is non-trivial.
             Type::Vector { .. } => Ok(TypeABI::Int),
+            Type::Union { .. } => Ok(TypeABI::Int),
+
             _ => unimplemented!("other types are not yet supported"),
         }
     }

--- a/pintc/tests/unions/bad_conditional.pnt
+++ b/pintc/tests/unions/bad_conditional.pnt
@@ -21,8 +21,6 @@ predicate test {
 
 // typecheck_failure <<<
 // operator invalid type error
-// @91..109: invalid union type `::pet` for operator `==`
-// operator invalid type error
 // @126..143: invalid non-numeric type `::pet` for operator `>`
 // operator invalid type error
 // @160..185: invalid non-numeric type `::pet` for operator `<=`

--- a/pintc/tests/unions/no_value_union.pnt
+++ b/pintc/tests/unions/no_value_union.pnt
@@ -1,7 +1,7 @@
 union either = left | right;
 
 predicate test {
-    var x: either; // DISABLED until we 'fix' initialisers. = either::right;
+    var x: either = either::right;
     constraint match x {
         either::left => true,
         either::right => false,
@@ -9,7 +9,7 @@ predicate test {
 }
 
 predicate decl_test {
-    var x: either; // DISABLED until we 'fix' initialisers. = either::right;
+    var x: either = either::right;
     match x {
         either::left => {
             constraint true;
@@ -25,11 +25,13 @@ predicate decl_test {
 //
 // predicate ::test {
 //     var ::x: ::either;
+//     constraint (::x == ::either::right);
 //     constraint match ::x { ::either::left => true, ::either::right => false };
 // }
 //
 // predicate ::decl_test {
 //     var ::x: ::either;
+//     constraint (::x == ::either::right);
 //     match ::x {
 //         ::either::left => {
 //             constraint true
@@ -46,12 +48,14 @@ predicate decl_test {
 //
 // predicate ::test {
 //     var ::x: ::either;
+//     constraint (::x == ::either::right);
 //     constraint ((UnTag(::x) == 0) ? true : false);
 //     constraint __eq_set(__mut_keys(), {0});
 // }
 //
 // predicate ::decl_test {
 //     var ::x: ::either;
+//     constraint (::x == ::either::right);
 //     constraint (!(UnTag(::x) == 0) || true);
 //     constraint ((UnTag(::x) == 0) || (!(UnTag(::x) == 1) || false));
 //     constraint __eq_set(__mut_keys(), {0});

--- a/pintc/tests/unions/simple.pnt
+++ b/pintc/tests/unions/simple.pnt
@@ -49,17 +49,13 @@ predicate test {
     }
 
     // Constraining an address to either zero or something.
-    //
-    // DISABLED until we 'fix' initialisers.  These initialisers would generate constraints like
-    // `no_bad_addr == maybe_addr::no_bad_addr` but `==` is illegal for unions.
-    //
-    //var no_base_addr: maydr = maybe_addr::no_addr;
-    //var a_base_addr: maydr = maybe_addr::addr(0x1111111111111111111111111111111111111111111111111111111111111111);
+    var no_base_addr: maydr = maybe_addr::no_addr;
+    var a_base_addr: maydr = maybe_addr::addr(0x1111111111111111111111111111111111111111111111111111111111111111);
 
-    //var actual_addr = match no_base_addr {
-    //    maybe_addr::no_addr => 0x0000000000000000000000000000000000000000000000000000000000000000,
-    //    maybe_addr::addr(a) => a,
-    //};
+    var actual_addr = match no_base_addr {
+        maybe_addr::no_addr => 0x0000000000000000000000000000000000000000000000000000000000000000,
+        maybe_addr::addr(a) => a,
+    };
 }
 
 // parsed <<<
@@ -71,9 +67,15 @@ predicate test {
 // predicate ::test {
 //     var ::x: ::thing;
 //     var ::d: int;
+//     var ::no_base_addr: ::maydr;
+//     var ::a_base_addr: ::maydr;
+//     var ::actual_addr;
 //     constraint match ::x { ::thing::a(b) => ::b, ::thing::b(n) => (::n > 0), ::thing::c(t) => ((::t.0 + ::t.1) == 11) };
 //     constraint (match ::x { ::thing::b(b) => ::b, else => 22 } > 0);
 //     constraint match ::x { ::thing::a(b) => ::b, ::thing::b(n) => constraint (::n > 0); ((::n * 2) < 10), ::thing::c(t) => constraint (::t.0 == 33); constraint (::t.1 != 44); true };
+//     constraint (::no_base_addr == ::maybe_addr::no_addr);
+//     constraint (::a_base_addr == ::maybe_addr::addr(0x1111111111111111111111111111111111111111111111111111111111111111));
+//     constraint (::actual_addr == match ::no_base_addr { ::maybe_addr::no_addr => 0x0000000000000000000000000000000000000000000000000000000000000000, ::maybe_addr::addr(a) => ::a });
 //     match ::x {
 //         ::thing::a(b) => {
 //         }
@@ -97,9 +99,15 @@ predicate test {
 // predicate ::test {
 //     var ::x: ::thing;
 //     var ::d: int;
+//     var ::no_base_addr: ::maybe_addr;
+//     var ::a_base_addr: ::maybe_addr;
+//     var ::actual_addr: b256;
 //     constraint ((UnTag(::x) == 0) ? UnVal(::x, bool) : ((UnTag(::x) == 1) ? (UnVal(::x, int) > 0) : ((UnVal(::x, {int, int}).0 + UnVal(::x, {int, int}).1) == 11)));
 //     constraint (((UnTag(::x) == 1) ? UnVal(::x, int) : 22) > 0);
 //     constraint ((UnTag(::x) == 0) ? UnVal(::x, bool) : ((UnTag(::x) == 1) ? ((UnVal(::x, int) * 2) < 10) : true));
+//     constraint (::no_base_addr == ::maybe_addr::no_addr);
+//     constraint (::a_base_addr == ::maybe_addr::addr(0x1111111111111111111111111111111111111111111111111111111111111111));
+//     constraint (::actual_addr == ((UnTag(::no_base_addr) == 0) ? 0x0000000000000000000000000000000000000000000000000000000000000000 : UnVal(::no_base_addr, b256)));
 //     constraint ((UnTag(::x) == 0) || (!(UnTag(::x) == 2) || ((UnVal(::x, {int, int}).0 * UnVal(::x, {int, int}).1) == 66)));
 //     constraint ((UnTag(::x) == 0) || (!(UnTag(::x) == 2) || (::d == (UnVal(::x, {int, int}).0 - UnVal(::x, {int, int}).1))));
 //     constraint ((UnTag(::x) == 0) || ((UnTag(::x) == 2) || (::d == 55)));

--- a/tests/validation_tests/union_compare.pnt
+++ b/tests/validation_tests/union_compare.pnt
@@ -1,0 +1,21 @@
+union pet = cats(int) | dogs(int) | emu;
+union maybe_addr = no_addr | addr(b256);
+
+predicate test {
+    var a: pet;
+    var b = pet::dogs(2);
+
+    // Direct comparisons of variants.
+    constraint pet::cats(11) == a;
+    constraint a != pet::cats(22);
+    constraint b != pet::emu;
+
+    // Constraining an address to either zero or something.
+    var no_base_addr = maybe_addr::no_addr;
+    var a_base_addr = maybe_addr::addr(0x1111111111111111111111111111111111111111111111111111111111111111);
+
+    var actual_addr = match no_base_addr {
+        maybe_addr::no_addr => 0x0000000000000000000000000000000000000000000000000000000000000000,
+        maybe_addr::addr(a) => a,
+    };
+}

--- a/tests/validation_tests/union_compare.toml
+++ b/tests/validation_tests/union_compare.toml
@@ -1,9 +1,9 @@
 [[data]]
 predicate_to_solve = { predicate = "::test" }
 decision_variables = [
-  [0, 11], # ::a: ::pet::cats(11);
-  [1, 2], # ::b: ::pet::dogs(2);
-  [0, 0, 0, 0, 0], # ::no_base_addr: ::maybe_addr::no_addr;
+  [0, 11],                                                                                 # ::a: ::pet::cats(11);
+  [1, 2],                                                                                  # ::b: ::pet::dogs(2);
+  [0, 0, 0, 0, 0],                                                                         # ::no_base_addr: ::maybe_addr::no_addr;
   [1, 1229782938247303441, 1229782938247303441, 1229782938247303441, 1229782938247303441], # ::a_base_addr: ::maybe_addr::addr(0x111...)
-  [0, 0, 0, 0], # ::actual_addr: 0x000...
+  [0, 0, 0, 0],                                                                            # ::actual_addr: 0x000...
 ]

--- a/tests/validation_tests/union_compare.toml
+++ b/tests/validation_tests/union_compare.toml
@@ -1,0 +1,9 @@
+[[data]]
+predicate_to_solve = { predicate = "::test" }
+decision_variables = [
+  [0, 11], # ::a: ::pet::cats(11);
+  [1, 2], # ::b: ::pet::dogs(2);
+  [0, 0, 0, 0, 0], # ::no_base_addr: ::maybe_addr::no_addr;
+  [1, 1229782938247303441, 1229782938247303441, 1229782938247303441, 1229782938247303441], # ::a_base_addr: ::maybe_addr::addr(0x111...)
+  [0, 0, 0, 0], # ::actual_addr: 0x000...
+]

--- a/tests/validation_tests/union_matches.pnt
+++ b/tests/validation_tests/union_matches.pnt
@@ -1,0 +1,45 @@
+union thing = a(bool) | b(int) | c({int, int});
+
+predicate test {
+    var x: thing;
+
+    // Boolean match expression.
+    constraint match x {
+        thing::a(b) => b,
+        thing::b(n) => n > 0,
+        thing::c(t) => t.0 + t.1 == 11
+    };
+
+    // Integer match expression in a constraint with `else`.
+    constraint match x {
+        thing::b(b) => b,
+        else => 22,
+    } > 0;
+
+    // Boolean match expression with blocks & constraints.
+    constraint match x {
+        thing::a(b) => b,
+        thing::b(n) => {
+            constraint n > 0;
+            n * 2 < 10
+        },
+        thing::c(t) => {
+            constraint t.0 == 33;
+            constraint t.1 != 44;
+            true
+        }
+    };
+
+    // Non-expression match.  Also refers to other var `d`.
+    var d: int;
+    match x {
+        thing::a(b) => {},
+        thing::c(t) => {
+            constraint t.0 * t.1 == 66;
+            constraint d == t.0 - t.1;
+        }
+        else => {
+            constraint d == 55;
+        }
+    }
+}

--- a/tests/validation_tests/union_matches.toml
+++ b/tests/validation_tests/union_matches.toml
@@ -1,0 +1,6 @@
+[[data]]
+predicate_to_solve = { predicate = "::test" }
+decision_variables = [
+  [1, 3, 0], # ::x - setting to be a thing::b(3).  'b' tag is 1, value is 3 with zero padding.
+  [55], # ::d
+]

--- a/tests/validation_tests/union_matches.toml
+++ b/tests/validation_tests/union_matches.toml
@@ -2,5 +2,5 @@
 predicate_to_solve = { predicate = "::test" }
 decision_variables = [
   [1, 3, 0], # ::x - setting to be a thing::b(3).  'b' tag is 1, value is 3 with zero padding.
-  [55], # ::d
+  [55],      # ::d
 ]


### PR DESCRIPTION
By fudging the ABI gen to just be an Int (fix later, tech debt ahoy!) the compiler is now able to build contracts with unions.

And by ensuring that union variants are padded out with zeros properly we can have direct `==` comparisons again, and therefore union `var`s with initialisers.

Closes #894.