### PR TITLE
Add support for `match` decls *and* exprs in macro bodies.

### DIFF
--- a/pintc/src/macros.rs
+++ b/pintc/src/macros.rs
@@ -52,6 +52,7 @@ pub(crate) struct MacroCall {
     pub(crate) args: Vec<Vec<(usize, Token, usize)>>,
     pub(crate) span: Span,
     pub(crate) parent_tag: Option<usize>,
+    pub(crate) is_at_decl: bool,
 }
 
 impl fmt::Display for MacroCall {

--- a/pintc/src/parser.rs
+++ b/pintc/src/parser.rs
@@ -361,17 +361,31 @@ impl<'a> ProjectParser<'a> {
     ) -> (Option<ExprKey>, Vec<NextModPath>) {
         let local_scope = format!("anon@{}", self.unique_idx);
         self.unique_idx += 1;
-        parse_with!(
-            self,
-            lexer::Lexer::from_tokens(tokens, src_path, mod_path),
-            pint_parser::MacroBodyParser::new(),
-            src_path,
-            mod_path,
-            Some(&local_scope),
-            Some((macro_call.name.clone(), macro_call.span.clone())),
-            Some(current_pred),
-            self.handler,
-        )
+        if macro_call.is_at_decl {
+            parse_with!(
+                self,
+                lexer::Lexer::from_tokens(tokens, src_path, mod_path),
+                pint_parser::MacroBodyAtDeclParser::new(),
+                src_path,
+                mod_path,
+                Some(&local_scope),
+                Some((macro_call.name.clone(), macro_call.span.clone())),
+                Some(current_pred),
+                self.handler,
+            )
+        } else {
+            parse_with!(
+                self,
+                lexer::Lexer::from_tokens(tokens, src_path, mod_path),
+                pint_parser::MacroBodyAtExprParser::new(),
+                src_path,
+                mod_path,
+                Some(&local_scope),
+                Some((macro_call.name.clone(), macro_call.span.clone())),
+                Some(current_pred),
+                self.handler,
+            )
+        }
     }
 
     fn analyse_and_add_paths(

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -8,8 +8,9 @@ use crate::{
         UseTree::{self, Path as UseTreePath},
     },
     predicate::{
-        BlockStatement, Const, ConstraintDecl, ExprKey, IfDecl, InterfaceDecl, InterfaceInstance,
-        InterfaceVar, MatchDecl, MatchDeclBranch, Predicate, PredicateInterface, StorageVar,
+        BlockStatement, CallKey, Const, ConstraintDecl, ExprKey, IfDecl, InterfaceDecl,
+        InterfaceInstance, InterfaceVar, MatchDecl, MatchDeclBranch, Predicate, PredicateInterface,
+        StorageVar,
     },
     span::Spanned,
     types::{EnumDecl, NewTypeDecl, Path, PrimitiveKind, Type, UnionDecl, UnionVariant},
@@ -53,13 +54,14 @@ PredicateInnerDecl: () = {
     VarDecl ";",
 }
 
-// Decls allowed inside macro bodies, which is ALL of them except `MacroDecl`.
+// Decls allowed inside macro bodies, which is ALL of them except `MacroDecl`, since we don't want
+// nested macros (yet?), and `MatchDecl`.  We have a conflict between match decls and match exprs in
+// macros, so we special case them.  See MacroBodyAtDecl and MacroBodyAtExpr below.
 DeclInnerMacroBody: () = {
     ConstDecl ";",
     ConstraintDecl ";",
     EnumDecl ";",
     IfDecl,
-    //MatchDecl,        We can't have match decls _and_ match expressions in bodies, there's a conflict.  Needs special casing.
     Interface,
     InterfaceInstance ";",
     MacroCallDecl ";",
@@ -417,10 +419,7 @@ UnionDecl: () = {
 
 UnionVariant: UnionVariant = {
     <variant_name:Ident> <ty:("(" <Type> ")")?> => {
-        UnionVariant {
-            variant_name,
-            ty,
-        }
+        UnionVariant { variant_name, ty }
     }
 }
 
@@ -457,11 +456,45 @@ MacroParamList: (Vec<Ident>, Option<Ident>) = {
 MacroParam: Ident = IdentFromToken<"macro_param">;
 
 MacroCallDecl: () = {
-    MacroCallExpr => (),
+    <keys:MacroCallExpr> => {
+        // Update the call data to tag it as a decl rather than an expr.
+        if let Some((_, call_data)) = context
+            .macro_calls
+            .get_mut(
+                &context
+                    .current_pred_key
+                    .expect("updating macro call as decl should have a predicate key"),
+            )
+            .unwrap()
+            .get_mut(keys.0)
+        {
+            call_data.is_at_decl = true;
+        }
+    }
 }
 
-pub MacroBody: Option<ExprKey> = {
+// We have two separate macro body parsers here.  One is for macros called as decls and the other
+// for macros called as exprs.  This is because we have `match` decl and `match` expr rules and
+// they'll conflict if placed in the same context (i.e., the macro body).
+//
+// So `MacroBodyAtExpr` will parse all the `DeclInnerMacroBody` decls (like `constraint`) and then a
+// final expr and return it.  It must be used to parse macro calls which are made as expressions.
+// `MacroBodyAtDecl` will parse the same decls *plus* `match` decls and doesn't return an
+// expression.  And so it must be used to parse macro calls which are 'top-level' decls.
+
+// We keep the expr as optional though to help quash *parser* error messages about the missing expr
+// if it's not there, and report it as missing later on.
+pub MacroBodyAtExpr: Option<ExprKey> = {
     "{" DeclInnerMacroBody* <Expr?> "}"
+}
+
+pub MacroBodyAtDecl: Option<ExprKey> = {
+    "{" MacroBodyInnerDecls* "}" => None,
+}
+
+MacroBodyInnerDecls: () = {
+    DeclInnerMacroBody,
+    MatchDecl,
 }
 
 /////////////
@@ -805,7 +838,7 @@ Term: ExprKey = {
         let span = e.span().clone();
         context.contract.exprs.insert(e, Type::Unknown(span))
     },
-    MacroCallExpr,
+    <keys:MacroCallExpr> => keys.1,
     CondExpr,
     MatchExpr,
     "(" <Expr> ")",
@@ -985,7 +1018,7 @@ MatchElse: MatchElse = {
     }
 }
 
-MacroCallExpr: ExprKey = {
+MacroCallExpr: (CallKey, ExprKey) = {
     <l:@L> <name:MacroPath> <tag:"macro_tag"?> <args:"macro_call_args"> <r:@L> => {
         let call_key = context
             .current_pred()
@@ -999,6 +1032,7 @@ MacroCallExpr: ExprKey = {
             args,
             span: span.clone(),
             parent_tag: tag.flatten(),
+            is_at_decl: false,
         };
         let call_expr_key = context.contract.exprs.insert(
             Expr::MacroCall {
@@ -1017,7 +1051,7 @@ MacroCallExpr: ExprKey = {
             )
             .unwrap()
             .insert(call_key, (call_expr_key, call_data));
-        call_expr_key
+        (call_key, call_expr_key)
     },
 }
 

--- a/pintc/tests/macros/variadic_chain.pnt
+++ b/pintc/tests/macros/variadic_chain.pnt
@@ -16,7 +16,7 @@ macro @chain_next($prev, $last) {
 }
 
 predicate test {
-    @chain(x; y; z);
+    constraint @chain(x; y; z) < 100;
 }
 
 // parsed <<<
@@ -24,6 +24,7 @@ predicate test {
 //     var ::x: int;
 //     var ::y: int;
 //     var ::z: int;
+//     constraint (::z < 100);
 //     constraint (::y > (::x + 10));
 //     constraint (::z > (::y + 10));
 // }
@@ -34,6 +35,7 @@ predicate test {
 //     var ::x: int;
 //     var ::y: int;
 //     var ::z: int;
+//     constraint (::z < 100);
 //     constraint (::y > (::x + 10));
 //     constraint (::z > (::y + 10));
 //     constraint __eq_set(__mut_keys(), {0});

--- a/pintc/tests/unions/macros.pnt
+++ b/pintc/tests/unions/macros.pnt
@@ -1,0 +1,52 @@
+union value = nuh | uhuh(int);
+
+macro @match_decl($val, $max) {
+    match $val {
+        value::uhuh(n) => {
+            constraint n < $max;
+        }
+        else => {}
+    }
+}
+
+macro @match_expr($val, $inc) {
+    match $val {
+        value::uhuh(n) => n + $inc,
+        else => 1
+    }
+}
+
+predicate test {
+    var thing: value;
+
+    @match_decl(thing; 11);
+
+    constraint @match_expr(thing; 22) < 33;
+}
+
+// parsed <<<
+// union ::value = nuh | uhuh(int);
+//
+// predicate ::test {
+//     var ::thing: ::value;
+//     constraint (match ::thing { ::value::uhuh(n) => (::n + 22), else => 1 } < 33);
+//     match ::thing {
+//         ::value::uhuh(n) => {
+//             constraint (::n < 11)
+//         }
+//         else => {
+//         }
+//     }
+// }
+// >>>
+
+// flattened <<<
+// union ::value = nuh | uhuh(int);
+//
+// predicate ::test {
+//     var ::thing: ::value;
+//     constraint (((UnTag(::thing) == 1) ? (UnVal(::thing, int) + 22) : 1) < 33);
+//     constraint (!(UnTag(::thing) == 1) || (UnVal(::thing, int) < 11));
+//     constraint __eq_set(__mut_keys(), {0});
+// }
+// >>>


### PR DESCRIPTION
As usual when changing the macro system in any way, this introduces a couple of hacks.  Unfortunately it adds another entry point to the parser which increases the build time.  It also looks pretty ugly in `parser.rs` where we call the parsers in the `parse_with!()` macro.  But it's working.

Closes #878.