### PR TITLE
Use a slotmap for union decls in `Contract`.

### DIFF
--- a/pintc/src/asm_gen/asm_builder.rs
+++ b/pintc/src/asm_gen/asm_builder.rs
@@ -659,7 +659,7 @@ impl<'a> AsmBuilder<'a> {
         let expected_args = kind.args();
         for (expected, arg) in expected_args.iter().zip(args.iter()) {
             let found = arg.get_ty(contract);
-            if !expected.eq(&contract.new_types, found) {
+            if !expected.eq(contract, found) {
                 handler.emit_err(Error::Compile {
                     error: CompileError::Internal {
                         msg: "unexpected intrinsic arg type",
@@ -1063,7 +1063,7 @@ impl<'a> AsmBuilder<'a> {
         handler: &Handler,
         asm: &mut Asm,
         union_expr_key: &ExprKey,
-        tag: &crate::types::Path,
+        tag: &str,
         value: &Option<ExprKey>,
         contract: &Contract,
         pred: &Predicate,
@@ -1071,7 +1071,7 @@ impl<'a> AsmBuilder<'a> {
         // Find the tag string in the union decl and convert to an index.
         let union_ty = union_expr_key.get_ty(contract);
         let tag_num = union_ty
-            .get_union_variant_names(&contract.unions)
+            .get_union_variant_names(contract)
             .into_iter()
             .enumerate()
             .find_map(|(idx, variant_name)| (variant_name == tag[2..]).then_some(idx))

--- a/pintc/src/expr.rs
+++ b/pintc/src/expr.rs
@@ -1,7 +1,7 @@
 use crate::{
-    predicate::{CallKey, ExprKey},
+    predicate::{CallKey, ExprKey, UnionKey},
     span::{empty_span, Span, Spanned},
-    types::{Path, PrimitiveKind, Type},
+    types::{PrimitiveKind, Type},
 };
 pub(crate) use intrinsics::{ExternalIntrinsic, InternalIntrinsic, IntrinsicKind};
 
@@ -28,19 +28,19 @@ pub enum Expr {
         span: Span,
     },
     UnionVariant {
-        path: Path,
+        path: String,
         path_span: Span,
         value: Option<ExprKey>,
         span: Span,
     },
-    Path(Path, Span),
+    Path(String, Span),
     StorageAccess {
         name: String,
         mutable: bool,
         span: Span,
     },
     ExternalStorageAccess {
-        interface_instance: Path,
+        interface_instance: String,
         name: String,
         span: Span,
     },
@@ -57,7 +57,7 @@ pub enum Expr {
     },
     MacroCall {
         call: CallKey,
-        path: Path,
+        path: String,
         span: Span,
     },
     IntrinsicCall {
@@ -136,7 +136,7 @@ pub enum TupleAccess {
 
 #[derive(Clone, Debug)]
 pub struct MatchBranch {
-    pub(super) name: Path,
+    pub(super) name: String,
     pub(super) name_span: Span,
     pub(super) binding: Option<Ident>,
     pub(super) constraints: Vec<ExprKey>,
@@ -164,7 +164,7 @@ pub enum Immediate {
         tag_num: i64,
         value_size: usize,
         value: Option<Box<Immediate>>,
-        ty_path: Path,
+        decl: UnionKey,
     },
 }
 
@@ -198,10 +198,7 @@ impl Immediate {
                 span,
             },
 
-            Immediate::UnionVariant { ty_path, .. } => Type::Union {
-                path: ty_path.to_string(),
-                span,
-            },
+            Immediate::UnionVariant { decl, .. } => Type::Union { decl: *decl, span },
 
             _ => Type::Primitive {
                 kind: match self {

--- a/pintc/src/expr/display.rs
+++ b/pintc/src/expr/display.rs
@@ -264,11 +264,21 @@ impl DisplayWithContract for super::Immediate {
             }
             super::Immediate::UnionVariant {
                 tag_num,
-                ty_path,
                 value,
+                decl,
                 ..
             } => {
-                write!(f, "{ty_path}::<{tag_num}>")?;
+                let union = &contract.unions[*decl];
+                write!(
+                    f,
+                    "{}::{}",
+                    union.name.name,
+                    union
+                        .variants
+                        .get(*tag_num as usize)
+                        .map(|v| v.variant_name.name.as_str())
+                        .unwrap_or("UNKNOWN_VARIANT")
+                )?;
                 if let Some(value) = value {
                     write!(f, "({})", contract.with_ctrct(value.as_ref()))?;
                 }

--- a/pintc/src/macros.rs
+++ b/pintc/src/macros.rs
@@ -4,7 +4,7 @@ use crate::{
     lexer::Token,
     predicate::{Contract, ExprKey, Predicate, Var},
     span::Span,
-    types::{Path, UnionDecl},
+    types::UnionDecl,
 };
 
 use fxhash::FxHashMap;
@@ -47,7 +47,7 @@ impl fmt::Display for MacroDecl {
 
 #[derive(Debug)]
 pub(crate) struct MacroCall {
-    pub(crate) name: Path,
+    pub(crate) name: String,
     pub(crate) mod_path: Vec<String>,
     pub(crate) args: Vec<Vec<(usize, Token, usize)>>,
     pub(crate) span: Span,
@@ -291,8 +291,8 @@ fn splice_get_array_range_size(
             Expr::Path(path, _) => contract
                 .unions
                 .iter()
-                .filter(|union| union.is_enumeration_union())
-                .find_map(|UnionDecl { name, variants, .. }| {
+                .filter(|(_key, union)| union.is_enumeration_union())
+                .find_map(|(_, UnionDecl { name, variants, .. })| {
                     (&name.name == path).then(|| {
                         (
                             variants.len(),
@@ -313,7 +313,7 @@ fn splice_get_array_range_size(
 
 #[derive(Default)]
 pub(crate) struct MacroExpander {
-    call_history: Vec<(Path, usize)>, // Path to macro and number of args.
+    call_history: Vec<(String, usize)>, // Path to macro and number of args.
     call_parents: FxHashMap<usize, usize>, // Indices into self.call_history.
 }
 

--- a/pintc/src/parser/context.rs
+++ b/pintc/src/parser/context.rs
@@ -8,7 +8,7 @@ use crate::{
         PredicateInstance, StorageVar, SymbolTable, Var,
     },
     span::{self, Span},
-    types::{Path, PrimitiveKind, Type},
+    types::{PrimitiveKind, Type},
 };
 use std::collections::BTreeMap;
 
@@ -422,7 +422,7 @@ impl<'a> ParserContext<'a> {
         last: Ident,
         maybe_enum: bool,
         span: Span,
-    ) -> Path {
+    ) -> String {
         if !els.is_empty() {
             let path: Vec<_> = els.iter().map(|el| el.to_string()).collect();
             self.next_paths.push(NextModPath {
@@ -457,7 +457,7 @@ impl<'a> ParserContext<'a> {
         last: Ident,
         maybe_enum: bool,
         span: Span,
-    ) -> Path {
+    ) -> String {
         // Check if any of the use statement matches the path. This requires
         // that the alias (if it exists) or the last ident in the use statement
         // matches the first ident in the path.

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -13,7 +13,7 @@ use crate::{
         StorageVar,
     },
     span::Spanned,
-    types::{NewTypeDecl, Path, PrimitiveKind, Type, UnionDecl, UnionVariant},
+    types::{NewTypeDecl, PrimitiveKind, Type, UnionDecl, UnionVariant},
 };
 
 grammar<'a>(
@@ -400,7 +400,7 @@ UnionDecl: () = {
             variants,
             span: (context.span_from)(l, r),
         };
-        context.contract.unions.push(union_decl);
+        context.contract.unions.insert(union_decl);
     }
 }
 
@@ -525,8 +525,8 @@ TypeAtom: Type = {
         Type::Error(span)
     },
     <MapType>,
-    <l:@L> <path:Path> <r:@R> => Type::Custom {
-        path,
+    <l:@L> <name:Path> <r:@R> => Type::Custom {
+        name,
         span: (context.span_from)(l, r),
     },
 }
@@ -1142,11 +1142,11 @@ Range: ExprKey = {
     }
 }
 
-Path: Path = PathWithLast<Ident>;
+Path: String = PathWithLast<Ident>;
 
-MacroPath: Path = PathWithLast<IdentFromToken<"macro_name">>;
+MacroPath: String = PathWithLast<IdentFromToken<"macro_name">>;
 
-PathWithLast<Last>: Path = {
+PathWithLast<Last>: String = {
     <l:@L> "::" <els:(<Ident> "::")*> <last:Last> <r:@R> => {
         let span = (context.span_from)(l, r);
         context.parse_absolute_path(els, last, true, span)

--- a/pintc/src/predicate/analyse.rs
+++ b/pintc/src/predicate/analyse.rs
@@ -46,8 +46,10 @@ impl Contract {
             return Err(handler.cancel());
         }
 
+        handler.scope(|handler| self.lower_custom_types(handler))?;
+
+        // TODO: remove the following, merge into lower_custom_types()?
         let _ = handler.scope(|handler| self.check_undefined_types(handler));
-        let _ = handler.scope(|handler| self.lower_custom_types(handler));
         let _ = handler.scope(|handler| self.check_storage_types(handler));
         let _ = handler.scope(|handler| self.type_check_all(handler));
         let _ = handler.scope(|handler| self.check_types_of_variables(handler));
@@ -78,7 +80,7 @@ impl Contract {
         // performing N-1 evaluation passes for N consts should resolve all dependencies and in
         // most cases will be done in only 1 or 2 passes.
 
-        let mut evaluator = Evaluator::new(&self.unions);
+        let mut evaluator = Evaluator::new(self);
         let mut new_immediates = Vec::default();
 
         // Use a temporary error handler to manage in-progress errors.

--- a/pintc/src/predicate/analyse/type_check/check_decls.rs
+++ b/pintc/src/predicate/analyse/type_check/check_decls.rs
@@ -219,7 +219,7 @@ impl Contract {
         {
             let union_ty = match_expr.get_ty(self).clone();
 
-            if !union_ty.is_union(&self.unions) {
+            if !union_ty.is_union() {
                 handler.emit_err(Error::Compile {
                     error: CompileError::MatchExprNotUnion {
                         found_ty: self.with_ctrct(union_ty).to_string(),
@@ -270,10 +270,10 @@ impl Contract {
                 }
 
                 let variant_count = variants_set.len();
-                if let Some(union_variant_count) = union_ty.get_union_variant_count(&self.unions) {
+                if let Some(union_variant_count) = union_ty.get_union_variant_count(self) {
                     if variant_count < union_variant_count && else_branch.is_none() {
                         // We don't have all variants covered.
-                        let mut missing_variants = union_ty.get_union_variant_names(&self.unions);
+                        let mut missing_variants = union_ty.get_union_variant_names(self);
                         missing_variants.retain(|var_name| !variants_set.contains(var_name));
                         handler.emit_err(Error::Compile {
                             error: CompileError::MatchBranchMissing {

--- a/pintc/src/predicate/analyse/type_check/custom_types.rs
+++ b/pintc/src/predicate/analyse/type_check/custom_types.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{CompileError, Error, ErrorEmitted, Handler},
-    predicate::{Const, Contract, Expr, Interface, InterfaceVar, StorageVar},
+    predicate::{Contract, UnionKey},
     span::{empty_span, Span},
     types::{NewTypeDecl, Type, UnionDecl},
 };
@@ -8,15 +8,128 @@ use crate::{
 use fxhash::FxHashMap;
 
 impl Contract {
-    /// Lower every `Type::Custom` type in a contract to a `Type::Alias` type if the custom type
-    /// actually matches one of the new type declarations in the contract.
+    /// Lower every `Type::Custom` type in a contract to either a `Type::Alias` or `Type::Union`.
+    /// No custom types should be left anywhere in the contract afterwards.
     pub(in crate::predicate::analyse) fn lower_custom_types(
         &mut self,
         handler: &Handler,
     ) -> Result<(), ErrorEmitted> {
         self.check_recursive_newtypes(handler)?;
-        self.lower_custom_types_in_newtypes(handler)?;
+        self.lower_nested_newtypes(handler)?;
         self.lower_custom_types_in_contract();
+
+        //self.lower_custom_types_in_newtypes(handler)?;
+
+        Ok(())
+    }
+
+    // Replace any nested aliases with a direct alias, cutting out the middle-man.  E.g.,
+    // type count = int;
+    // type amount = count;
+    // type quantity = amount;
+    //   =>
+    // type amount = int;
+    // type quantity = int;
+    fn lower_nested_newtypes(&mut self, handler: &Handler) -> Result<(), ErrorEmitted> {
+        fn replace_alias_target(
+            alias_map: &fxhash::FxHashMap<String, Type>,
+            target_ty: &mut Type,
+        ) -> bool {
+            let mut modified = false;
+
+            match target_ty {
+                Type::Custom { name, .. } => {
+                    // If it's know then replace it.  We leave unknown custom types alone and
+                    // they'll get picked up later in the type checker.
+                    if let Some(new_ty) = alias_map.get(name) {
+                        *target_ty = new_ty.clone();
+                        modified = true;
+                    }
+                }
+
+                Type::Alias { ty, .. } => {
+                    // Replace the target type with this unwrapped type.
+                    *target_ty = ty.as_ref().clone();
+                    modified = true;
+                }
+
+                // Recurse.
+                Type::Array { ty, .. } => {
+                    modified = replace_alias_target(alias_map, ty);
+                }
+                Type::Tuple { fields, .. } => {
+                    // We need a .try_any() here.
+                    modified = fields.iter_mut().fold(false, |acc, (_, ty)| {
+                        if acc {
+                            acc
+                        } else {
+                            replace_alias_target(alias_map, ty)
+                        }
+                    });
+                }
+                Type::Map { ty_from, ty_to, .. } => {
+                    modified = replace_alias_target(alias_map, ty_from)
+                        || replace_alias_target(alias_map, ty_to);
+                }
+                Type::Vector { ty, .. } => {
+                    modified = replace_alias_target(alias_map, ty);
+                }
+
+                // We handle unions separately.
+                Type::Union { .. } => {}
+
+                // Ignore.
+                Type::Error(_) | Type::Unknown(_) | Type::Any(_) | Type::Primitive { .. } => {}
+            }
+
+            modified
+        }
+
+        for loop_check in 0.. {
+            let mut modified = false;
+
+            // Make a map of all named types, either aliases or unions.  This is a fairly expensive
+            // cloning of a bunch of stuff, but generally it only happens once and it's actually used.
+            let alias_map = fxhash::FxHashMap::from_iter(
+                self.new_types
+                    .iter()
+                    .map(|NewTypeDecl { name, ty, .. }| (name.name.clone(), ty.clone()))
+                    .chain(
+                        self.unions
+                            .iter()
+                            .map(|(decl, UnionDecl { name, span, .. })| {
+                                (
+                                    name.name.clone(),
+                                    Type::Union {
+                                        decl,
+                                        span: span.clone(),
+                                    },
+                                )
+                            }),
+                    ),
+            );
+
+            // Loop for all the current alias decls and replace the first nested type we find.
+            for NewTypeDecl { ty, .. } in &mut self.new_types {
+                if replace_alias_target(&alias_map, ty) {
+                    modified = true;
+                    break;
+                }
+            }
+
+            if !modified {
+                break;
+            }
+
+            if loop_check > 10_000 {
+                return Err(handler.emit_err(Error::Compile {
+                    error: CompileError::Internal {
+                        msg: "infinite loop in lower_nested_newtypes()",
+                        span: empty_span(),
+                    },
+                }));
+            }
+        }
 
         Ok(())
     }
@@ -35,12 +148,8 @@ impl Contract {
                     .iter()
                     .try_for_each(|(_, ty)| inspect_type_names(handler, contract, seen_names, ty)),
 
-                Type::Union { path, .. } => {
-                    // This was a custom type which has been confirmed to be a union.
-                    let Some(union_decl) = contract.unions.iter().find(|ud| &ud.name.name == path)
-                    else {
-                        unreachable!("union type with unknown path");
-                    };
+                Type::Union { decl, .. } => {
+                    let union_decl = &contract.unions[*decl];
 
                     for variant in &union_decl.variants {
                         if let Some(ty) = &variant.ty {
@@ -52,7 +161,7 @@ impl Contract {
                 }
 
                 Type::Custom {
-                    path,
+                    name: custom_name,
                     span: custom_ty_span,
                 } => {
                     // Look-up the name to confirm it's a new-type.
@@ -61,15 +170,15 @@ impl Contract {
                             .new_types
                             .iter()
                             .find_map(|NewTypeDecl { name, ty, span }| {
-                                (path == &name.name).then_some((ty, span))
+                                (custom_name == &name.name).then_some((ty, span))
                             })
                     {
                         // This is a new-type; have we seen it before?
-                        if let Some(seen_span) = seen_names.get(path.as_str()) {
+                        if let Some(seen_span) = seen_names.get(custom_name.as_str()) {
                             // We have!  Bad news.
                             Err(handler.emit_err(Error::Compile {
                                 error: CompileError::RecursiveNewType {
-                                    name: path.to_string(),
+                                    name: custom_name.to_string(),
                                     decl_span: (*seen_span).clone(),
                                     use_span: custom_ty_span.clone(),
                                 },
@@ -77,9 +186,9 @@ impl Contract {
                         } else {
                             // We need to add then remove the new path to the 'seen' list; if we
                             // don't remove it we'll get false positives.
-                            seen_names.insert(path.as_str(), new_ty_span);
+                            seen_names.insert(custom_name.as_str(), new_ty_span);
                             let res = inspect_type_names(handler, contract, seen_names, new_ty);
-                            seen_names.remove(path.as_str());
+                            seen_names.remove(custom_name.as_str());
                             res
                         }
                     } else {
@@ -113,118 +222,123 @@ impl Contract {
     /// Lower every `Type::Custom` type in a new type declarations to a `Type::Alias` type if the
     /// custom type actually matches one of the new type declarations in the contract. All
     /// remaining custom types after this method runs should refer to enums.
-    fn lower_custom_types_in_newtypes(&mut self, handler: &Handler) -> Result<(), ErrorEmitted> {
-        // Search for a custom type with a specific name and return a mut ref to it.
-        fn get_custom_type_mut_ref<'a>(
-            custom_path: &str,
-            ty: &'a mut Type,
-        ) -> Option<&'a mut Type> {
-            match ty {
-                Type::Array { ty, .. } => get_custom_type_mut_ref(custom_path, ty),
-                Type::Tuple { fields, .. } => fields
-                    .iter_mut()
-                    .find_map(|(_, fld_ty)| get_custom_type_mut_ref(custom_path, fld_ty)),
-                Type::Custom { path, .. } => (path == custom_path).then_some(ty),
-                Type::Alias { ty, .. } => get_custom_type_mut_ref(custom_path, ty),
-                Type::Map { ty_from, ty_to, .. } => get_custom_type_mut_ref(custom_path, ty_from)
-                    .or_else(|| get_custom_type_mut_ref(custom_path, ty_to)),
-                Type::Vector { ty, .. } => get_custom_type_mut_ref(custom_path, ty),
-                Type::Error(_)
-                | Type::Unknown(_)
-                | Type::Any(_)
-                | Type::Primitive { .. }
-                | Type::Union { .. } => None,
-            }
-        }
+    //fn lower_custom_types_in_newtypes(&mut self, handler: &Handler) -> Result<(), ErrorEmitted> {
+    //    // Search for a custom type with a specific name and return a mut ref to it.
+    //    fn get_custom_type_mut_ref<'a>(
+    //        custom_path: &str,
+    //        ty: &'a mut Type,
+    //    ) -> Option<&'a mut Type> {
+    //        match ty {
+    //            Type::Array { ty, .. } => get_custom_type_mut_ref(custom_path, ty),
+    //            Type::Tuple { fields, .. } => fields
+    //                .iter_mut()
+    //                .find_map(|(_, fld_ty)| get_custom_type_mut_ref(custom_path, fld_ty)),
+    //            Type::Custom { path, .. } => (path == custom_path).then_some(ty),
+    //            Type::Alias { ty, .. } => get_custom_type_mut_ref(custom_path, ty),
+    //            Type::Map { ty_from, ty_to, .. } => get_custom_type_mut_ref(custom_path, ty_from)
+    //                .or_else(|| get_custom_type_mut_ref(custom_path, ty_to)),
+    //            Type::Vector { ty, .. } => get_custom_type_mut_ref(custom_path, ty),
+    //            Type::Error(_)
+    //            | Type::Unknown(_)
+    //            | Type::Any(_)
+    //            | Type::Primitive { .. }
+    //            | Type::Union { .. } => None,
+    //        }
+    //    }
+    //
+    //    // Any custom types referred to *within new types* need to be converted to type aliases.
+    //    // E.g.,
+    //    //   type A = int;
+    //    //   type B = { A, A };
+    //    //
+    //    // B will have `Type::Custom("A")` which need to be `Type::Alias("A", int)`
+    //
+    //    for new_type_idx in 0..self.new_types.len() {
+    //        // We're replacing only a single new type at a time, if found in other new-types.
+    //        let new_type = self.new_types[new_type_idx].clone();
+    //
+    //        // Replace the next found custom type which needs to be replaced with a an alias.
+    //        // There may be multiple replacements required per iteration, so we'll visit every
+    //        // current new-type decl per iteration until none are updated.
+    //        for loop_check in 0.. {
+    //            let mut modified = false;
+    //
+    //            for NewTypeDecl { ref mut ty, .. } in &mut self.new_types {
+    //                if let Some(custom_ty) = get_custom_type_mut_ref(&new_type.name.name, ty) {
+    //                    *custom_ty = Type::Alias {
+    //                        name: new_type.name.name.clone(),
+    //                        ty: Box::new(new_type.ty.clone()),
+    //                        span: new_type.span.clone(),
+    //                    };
+    //
+    //                    modified = true;
+    //                }
+    //            }
+    //
+    //            if !modified {
+    //                break;
+    //            }
+    //
+    //            if loop_check > 10_000 {
+    //                return Err(handler.emit_err(Error::Compile {
+    //                    error: CompileError::Internal {
+    //                        msg: "infinite loop in lower_custom_types_in_newtypes()",
+    //                        span: empty_span(),
+    //                    },
+    //                }));
+    //            }
+    //        }
+    //    }
+    //
+    //    Ok(())
+    //}
 
-        // Any custom types referred to *within new types* need to be converted to type aliases.
-        // E.g.,
-        //   type A = int;
-        //   type B = { A, A };
-        //   // B will have `Type::Custom("A")` which need to be `Type::Alias("A", int)`
-
-        for new_type_idx in 0..self.new_types.len() {
-            // We're replacing only a single new type at a time, if found in other new-types.
-            let new_type = self.new_types[new_type_idx].clone();
-
-            // Replace the next found custom type which needs to be replaced with a an alias.
-            // There may be multiple replacements required per iteration, so we'll visit every
-            // current new-type decl per iteration until none are updated.
-            for loop_check in 0.. {
-                let mut modified = false;
-
-                for NewTypeDecl { ref mut ty, .. } in &mut self.new_types {
-                    if let Some(custom_ty) = get_custom_type_mut_ref(&new_type.name.name, ty) {
-                        *custom_ty = Type::Alias {
-                            path: new_type.name.name.clone(),
-                            ty: Box::new(new_type.ty.clone()),
-                            span: new_type.span.clone(),
-                        };
-
-                        modified = true;
-                    }
-                }
-
-                if !modified {
-                    break;
-                }
-
-                if loop_check > 10_000 {
-                    return Err(handler.emit_err(Error::Compile {
-                        error: CompileError::Internal {
-                            msg: "infinite loop in lower_custom_types_in_newtypes()",
-                            span: empty_span(),
-                        },
-                    }));
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Lower every `Type::Custom` type in a contract to a `Type::Alias` type if the custom type
-    /// actually matches one of the new type declarations in the contract. All remaining custom
-    /// types after this method runs should refer to enums.
+    /// Lower every `Type::Custom` type in a contract to a proper type.
     fn lower_custom_types_in_contract(&mut self) {
         use std::borrow::BorrowMut;
 
         // Given a mutable reference to a `Type` and a list of new type declarations `new_types`,
         // replace it or its subtypes with a `Type::Alias` when a `Type::Custom` is encountered
         // that matches the name of a declaration in `new_types`.
-        fn replace_custom_type(new_types: &[NewTypeDecl], union_names: &[String], ty: &mut Type) {
+        fn replace_custom_type(
+            new_types: &fxhash::FxHashMap<String, Type>,
+            union_keys: &fxhash::FxHashMap<String, UnionKey>,
+            ty: &mut Type,
+        ) {
             match ty {
-                Type::Array { ty, .. } => {
-                    replace_custom_type(new_types, union_names, ty.borrow_mut())
-                }
-                Type::Tuple { fields, .. } => fields
-                    .iter_mut()
-                    .for_each(|(_, ty)| replace_custom_type(new_types, union_names, ty)),
-                Type::Custom { path, span } => {
-                    let path = path.clone();
-                    if let Some((new_ty, new_span)) =
-                        new_types.iter().find_map(|NewTypeDecl { name, ty, span }| {
-                            (name.name == path).then_some((ty, span))
-                        })
-                    {
+                Type::Custom { name, span } => {
+                    if let Some(new_ty) = new_types.get(name) {
                         *ty = Type::Alias {
-                            path,
+                            name: name.clone(),
                             ty: Box::new(new_ty.clone()),
-                            span: new_span.clone(),
+                            span: span.clone(),
                         };
-                    } else if union_names.iter().any(|name| name == &path) {
+                    } else if let Some(decl_key) = union_keys.get(name) {
                         *ty = Type::Union {
-                            path,
+                            decl: *decl_key,
                             span: span.clone(),
                         }
                     }
                 }
-                Type::Alias { ty, .. } => replace_custom_type(new_types, union_names, ty),
-                Type::Map { ty_from, ty_to, .. } => {
-                    replace_custom_type(new_types, union_names, ty_from);
-                    replace_custom_type(new_types, union_names, ty_to);
+
+                // Recurse for these types.
+                Type::Array { ty, .. } => {
+                    replace_custom_type(new_types, union_keys, ty.borrow_mut())
                 }
-                Type::Vector { ty, .. } => replace_custom_type(new_types, union_names, ty),
+
+                Type::Tuple { fields, .. } => fields
+                    .iter_mut()
+                    .for_each(|(_, ty)| replace_custom_type(new_types, union_keys, ty)),
+
+                Type::Alias { ty, .. } => replace_custom_type(new_types, union_keys, ty),
+
+                Type::Map { ty_from, ty_to, .. } => {
+                    replace_custom_type(new_types, union_keys, ty_from);
+                    replace_custom_type(new_types, union_keys, ty_to);
+                }
+
+                Type::Vector { ty, .. } => replace_custom_type(new_types, union_keys, ty),
+
                 Type::Error(_)
                 | Type::Unknown(_)
                 | Type::Any(_)
@@ -233,74 +347,19 @@ impl Contract {
             }
         }
 
-        let union_names = self
-            .unions
-            .iter()
-            .map(|UnionDecl { name, .. }| name.name.clone())
-            .collect::<Vec<_>>();
-
-        for UnionDecl { variants, .. } in &mut self.unions {
-            for variant in variants {
-                if let Some(variant_ty) = &mut variant.ty {
-                    replace_custom_type(&self.new_types, &union_names, variant_ty);
-                }
-            }
-        }
-
-        // Replace custom types in predicates
-        self.preds.values_mut().for_each(|pred| {
-            // Replace custom types in vars and states
-            pred.vars
-                .update_types(|_, ty| replace_custom_type(&self.new_types, &union_names, ty));
-            pred.states
-                .update_types(|_, ty| replace_custom_type(&self.new_types, &union_names, ty));
-
-            // Replace custom types in any `as` cast expression
-            self.exprs.update_exprs(|_, expr| {
-                if let Expr::Cast { ty, .. } = expr {
-                    replace_custom_type(&self.new_types, &union_names, ty.borrow_mut());
-                }
-            });
-        });
-
-        // Replace custom types in `const` declarations
-        self.consts.values_mut().for_each(|Const { decl_ty, .. }| {
-            replace_custom_type(&self.new_types, &union_names, decl_ty)
-        });
-
-        // Replace custom types in every storage variable in the contract
-        if let Some((storage_vars, _)) = self.storage.as_mut() {
-            storage_vars.iter_mut().for_each(|StorageVar { ty, .. }| {
-                replace_custom_type(&self.new_types, &union_names, ty);
-            })
-        }
-
-        // Replace custom types in interfaces
-        self.interfaces.iter_mut().for_each(
-            |Interface {
-                 storage,
-                 predicate_interfaces,
-                 ..
-             }| {
-                // Replace custom types in every storage variable in the interface
-                if let Some((storage_vars, _)) = storage.as_mut() {
-                    storage_vars.iter_mut().for_each(|StorageVar { ty, .. }| {
-                        replace_custom_type(&self.new_types, &union_names, ty);
-                    });
-                }
-
-                // Replace custom types in every decision variable in the interface. These belong
-                // to the various predicate interfaces
-                predicate_interfaces
-                    .iter_mut()
-                    .for_each(|predicate_interface| {
-                        predicate_interface.vars.iter_mut().for_each(
-                            |InterfaceVar { ty, .. }| {
-                                replace_custom_type(&self.new_types, &union_names, ty)
-                            },
-                        );
-                    });
-            },
+        let new_types = fxhash::FxHashMap::from_iter(
+            self.new_types
+                .iter()
+                .map(|NewTypeDecl { name, ty, .. }| (name.name.clone(), ty.clone())),
         );
+
+        let union_keys = fxhash::FxHashMap::from_iter(
+            self.unions
+                .iter()
+                .map(|(key, UnionDecl { name, .. })| (name.name.clone(), key)),
+        );
+
+        // Replace every single custom type in the contract.
+        self.update_types(|ty| replace_custom_type(&new_types, &union_keys, ty), false);
     }
 }

--- a/pintc/src/predicate/display.rs
+++ b/pintc/src/predicate/display.rs
@@ -90,7 +90,7 @@ impl Display for Contract {
             writeln!(f, "const {path}{};", self.with_ctrct(cnst))?;
         }
 
-        for r#union in &self.unions {
+        for r#union in self.unions.values() {
             writeln!(f, "{};", self.with_ctrct(union))?;
         }
 

--- a/pintc/src/predicate/optimize/const_folding.rs
+++ b/pintc/src/predicate/optimize/const_folding.rs
@@ -16,7 +16,7 @@ pub(crate) fn const_folding(contract: &mut Contract) {
 pub(crate) fn fold_consts(contract: &mut Contract) {
     let mut replace_map: FxHashMap<ExprKey, (Expr, Type)> = FxHashMap::default();
 
-    let evaluator = Evaluator::new(&contract.unions);
+    let evaluator = Evaluator::new(contract);
 
     for pred_key in contract.preds.keys().collect::<Vec<_>>() {
         for expr_key in contract.exprs(pred_key) {

--- a/pintc/src/predicate/optimize/dead_code_elimination.rs
+++ b/pintc/src/predicate/optimize/dead_code_elimination.rs
@@ -56,7 +56,7 @@ pub(crate) fn dead_state_elimination(contract: &mut Contract) {
 /// If any constraint evaluates to false, all constraints are removed and replaced with a single
 /// instance of `constraint false`
 pub(crate) fn dead_constraint_elimination(handler: &Handler, contract: &mut Contract) {
-    let evaluator = Evaluator::new(&contract.unions);
+    let evaluator = Evaluator::new(contract);
 
     for pred_key in contract.preds.keys().collect::<Vec<_>>() {
         if let Some(pred) = contract.preds.get(pred_key) {
@@ -117,7 +117,7 @@ pub(crate) fn dead_constraint_elimination(handler: &Handler, contract: &mut Cont
 ///
 /// If any select condition is a const the appropriate branch replaces the select expression
 pub(crate) fn dead_select_elimination(contract: &mut Contract) {
-    let evaluator = Evaluator::new(&contract.unions);
+    let evaluator = Evaluator::new(contract);
     let mut replace_map: FxHashMap<ExprKey /* select */, ExprKey /* branch */> =
         FxHashMap::default();
 

--- a/pintc/src/predicate/states.rs
+++ b/pintc/src/predicate/states.rs
@@ -2,14 +2,14 @@ use super::{Contract, DisplayWithPred, ExprKey, Ident, Predicate};
 use crate::{
     error::{ErrorEmitted, Handler},
     span::Span,
-    types::{Path, Type},
+    types::Type,
 };
 use std::fmt::{self, Formatter};
 
 /// A state specification with an optional type.
 #[derive(Clone, Debug)]
 pub struct State {
-    pub name: Path,
+    pub name: String,
     pub expr: ExprKey,
     pub span: Span,
 }

--- a/pintc/src/predicate/transform/lower/lower_storage_accesses.rs
+++ b/pintc/src/predicate/transform/lower/lower_storage_accesses.rs
@@ -316,7 +316,7 @@ fn get_base_storage_key(
                 None, // local storage
                 *mutable,
                 if storage_var.ty.is_any_primitive()
-                    || storage_var.ty.is_union(&contract.unions)
+                    || storage_var.ty.is_union()
                     || storage_var.ty.is_map()
                     || storage_var.ty.is_vector()
                 {
@@ -355,7 +355,7 @@ fn get_base_storage_key(
                 // constrained by their own contracts.
                 false,
                 if storage_var.ty.is_any_primitive()
-                    || storage_var.ty.is_union(&contract.unions)
+                    || storage_var.ty.is_union()
                     || storage_var.ty.is_map()
                     || storage_var.ty.is_vector()
                 {
@@ -376,7 +376,7 @@ fn get_base_storage_key(
                 // next key element is the index itself
                 key.push(*index);
                 if !(expr_ty.is_any_primitive()
-                    || expr_ty.is_union(&contract.unions)
+                    || expr_ty.is_union()
                     || expr_ty.is_map()
                     || expr_ty.is_vector())
                 {

--- a/pintc/src/predicate/transform/unroll.rs
+++ b/pintc/src/predicate/transform/unroll.rs
@@ -163,7 +163,7 @@ fn unroll_generator(
 
         let mut satisfied = true;
         {
-            let evaluator = Evaluator::from_values(&contract.unions, values_map.clone());
+            let evaluator = Evaluator::from_values(contract, values_map.clone());
 
             // Check each condition, if available, against the values map above
             for condition in &conditions {

--- a/pintc/src/predicate/vars.rs
+++ b/pintc/src/predicate/vars.rs
@@ -2,7 +2,7 @@ use super::{Contract, DisplayWithPred, Ident, Predicate};
 use crate::{
     error::{ErrorEmitted, Handler},
     span::Span,
-    types::{Path, Type},
+    types::Type,
 };
 use pint_abi_types::VarABI;
 use std::fmt::{self, Formatter};
@@ -10,7 +10,7 @@ use std::fmt::{self, Formatter};
 /// A decision variable with an optional type.
 #[derive(Clone, Debug)]
 pub struct Var {
-    pub name: Path,
+    pub name: String,
     pub is_pub: bool,
     pub span: Span,
 }

--- a/pintc/src/types/display.rs
+++ b/pintc/src/types/display.rs
@@ -1,12 +1,6 @@
 use crate::predicate::{Contract, DisplayWithContract};
 use std::fmt::{Display, Formatter, Result};
 
-impl DisplayWithContract for super::Path {
-    fn fmt(&self, f: &mut Formatter, _contract: &Contract) -> Result {
-        write!(f, "{self}")
-    }
-}
-
 impl Display for super::PrimitiveKind {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
@@ -66,12 +60,16 @@ impl DisplayWithContract for super::Type {
                 write!(f, "}}")
             }
 
-            super::Type::Custom { path, .. } | super::Type::Union { path, .. } => {
-                write!(f, "{path}")
+            super::Type::Custom { name, .. } => {
+                write!(f, "{name}")
             }
 
-            super::Type::Alias { path, ty, .. } => {
-                write!(f, "{path} ({})", contract.with_ctrct(ty.as_ref()))
+            super::Type::Union { decl, .. } => {
+                write!(f, "{}", contract.unions[*decl].name.name.as_str())
+            }
+
+            super::Type::Alias { name, ty, .. } => {
+                write!(f, "{name} ({})", contract.with_ctrct(ty.as_ref()))
             }
 
             super::Type::Map { ty_from, ty_to, .. } => {

--- a/pintc/tests/basic_tests/aliases.pnt
+++ b/pintc/tests/basic_tests/aliases.pnt
@@ -5,6 +5,8 @@ type MyArray = bool[5];
 type MyMap = (b256 => int);
 type MyB256 = b256;
 type MyNestedAlias = MyInt;
+type MyExtraNestedAlias = MyNestedAlias;
+type MyIncredibleTuple = { MyExtraNestedAlias, MyNestedAlias };
 type MyAliasedMap = (MyB256 => MyTuple);
 type MyComplexMap = (MyBool => MyMap);
 
@@ -21,6 +23,8 @@ predicate test {
    var q: MyArray;
    var r: MyB256;
    var s: MyNestedAlias;
+   var t: MyExtraNestedAlias;
+   var u: MyIncredibleTuple;
 }
 
 // parsed <<<
@@ -31,6 +35,8 @@ predicate test {
 // type ::MyMap = ( b256 => int );
 // type ::MyB256 = b256;
 // type ::MyNestedAlias = ::MyInt;
+// type ::MyExtraNestedAlias = ::MyNestedAlias;
+// type ::MyIncredibleTuple = {::MyExtraNestedAlias, ::MyNestedAlias};
 // type ::MyAliasedMap = ( ::MyB256 => ::MyTuple );
 // type ::MyComplexMap = ( ::MyBool => ::MyMap );
 // storage {
@@ -46,6 +52,8 @@ predicate test {
 //     var ::q: ::MyArray;
 //     var ::r: ::MyB256;
 //     var ::s: ::MyNestedAlias;
+//     var ::t: ::MyExtraNestedAlias;
+//     var ::u: ::MyIncredibleTuple;
 // }
 // >>>
 
@@ -56,9 +64,11 @@ predicate test {
 // type ::MyArray = bool[5];
 // type ::MyMap = ( b256 => int );
 // type ::MyB256 = b256;
-// type ::MyNestedAlias = ::MyInt (int);
-// type ::MyAliasedMap = ( ::MyB256 (b256) => ::MyTuple ({int, int}) );
-// type ::MyComplexMap = ( ::MyBool (bool) => ::MyMap (( b256 => int )) );
+// type ::MyNestedAlias = int;
+// type ::MyExtraNestedAlias = int;
+// type ::MyIncredibleTuple = {int, int};
+// type ::MyAliasedMap = ( b256 => {int, int} );
+// type ::MyComplexMap = ( bool => ( b256 => int ) );
 // storage {
 //     x: ( b256 => int ),
 //     y: ( b256 => {int, int} ),
@@ -72,6 +82,8 @@ predicate test {
 //     var ::q: bool[5];
 //     var ::r: b256;
 //     var ::s: int;
+//     var ::t: int;
+//     var ::u: {int, int};
 //     constraint __eq_set(__mut_keys(), {0});
 // }
 // >>>

--- a/pintc/tests/consts/simple.pnt
+++ b/pintc/tests/consts/simple.pnt
@@ -64,15 +64,15 @@ predicate test {
 // const ::b: b256 = 0x2222222222222222222222222222222222222222222222222222222222222222;
 // const ::h: {int, bool} = {1010, false};
 // const ::e: bool = true;
-// const ::k: ::JacketColour = ::JacketColour::<1>;
+// const ::k: ::JacketColour = ::JacketColour::Bone;
 // const ::d: b256 = 0x4444444444444444444444444444444444444444444444444444444444444444;
 // const ::a: int = 11;
 // const ::g: int[_] = [88, 99];
-// const ::j: ::JacketColour = ::JacketColour::<5>;
+// const ::j: ::JacketColour = ::JacketColour::Beige;
 // const ::f: {int, int} = {66, 77};
 // const ::c: int = 33;
 // union ::JacketColour = Cream | Bone | White | OffWhite | Ivory | Beige;
-// 
+//
 // predicate ::test {
 //     var ::q: int;
 //     var ::r: b256;
@@ -85,7 +85,7 @@ predicate test {
 //     constraint (::s == 77);
 //     constraint (::t == 99);
 //     constraint ((::u == false) && (::u != true));
-//     constraint ((::v != ::JacketColour::<5>) && (::v != ::JacketColour::<1>));
+//     constraint ((::v != ::JacketColour::Beige) && (::v != ::JacketColour::Bone));
 //     constraint __eq_set(__mut_keys(), {0});
 // }
 // >>>

--- a/pintc/tests/contracts/multifile/main.pnt
+++ b/pintc/tests/contracts/multifile/main.pnt
@@ -34,7 +34,7 @@ predicate Bar {
 // flattened <<<
 // union ::baz::MyUnion = A | B;
 // type ::baz::MyType = ::baz::MyUnion;
-// 
+//
 // predicate ::Bar {
 //     var ::y: int;
 //     var ::e1: ::baz::MyUnion;
@@ -43,9 +43,9 @@ predicate Bar {
 //     var ::f2: ::baz::MyUnion;
 //     constraint (::y == 4);
 //     constraint (::e1 == ::baz::MyUnion::A);
-//     constraint (::f1 == ::baz::MyType::B);
+//     constraint (::f1 == ::baz::MyUnion::B);
 //     constraint (::e2 == ::baz::MyUnion::B);
-//     constraint (::f2 == ::baz::MyType::A);
+//     constraint (::f2 == ::baz::MyUnion::A);
 //     constraint __eq_set(__mut_keys(), {0});
 // }
 // >>>

--- a/pintc/tests/contracts/simple.pnt
+++ b/pintc/tests/contracts/simple.pnt
@@ -37,7 +37,7 @@ predicate Bar {
 // flattened <<<
 // union ::MyUnion = A | B;
 // type ::MyType = ::MyUnion;
-// 
+//
 // predicate ::Foo {
 //     var ::x: int;
 //     var ::y: ::MyUnion;
@@ -45,11 +45,11 @@ predicate Bar {
 //     constraint (::x == 3);
 //     constraint __eq_set(__mut_keys(), {0});
 // }
-// 
+//
 // predicate ::Bar {
 //     var ::x: int;
 //     var ::y: ::MyUnion;
-//     constraint (::y == ::MyType::A);
+//     constraint (::y == ::MyUnion::A);
 //     constraint (::x < 2);
 //     constraint __eq_set(__mut_keys(), {0});
 // }

--- a/pintc/tests/root_types/custom.pnt
+++ b/pintc/tests/root_types/custom.pnt
@@ -17,7 +17,7 @@ predicate Foo {
 
 // flattened <<<
 // type ::myAlias = int;
-// type ::myCustom = ::myAlias (int);
+// type ::myCustom = int;
 //
 // predicate ::Foo {
 //     var ::a: int;

--- a/pintc/tests/root_types/exprs.pnt
+++ b/pintc/tests/root_types/exprs.pnt
@@ -63,7 +63,7 @@ predicate Foo {
 // type ::myNestedSelect = int[5];
 // type ::myNestedTuple = int[2];
 // type ::myNestedArray = int[1];
-// type ::complexType = {::myNestedCast (int[4]), ::myNestedSelect (int[5])}[1];
+// type ::complexType = {int[4], int[5]}[1];
 //
 // predicate ::Foo {
 //     var ::a: int[4];

--- a/pintc/tests/root_types/interfaces.pnt
+++ b/pintc/tests/root_types/interfaces.pnt
@@ -37,7 +37,7 @@ predicate test {
 
 // flattened <<<
 // type ::num = int;
-// type ::ary = ::num (int)[3];
+// type ::ary = int[3];
 // interface ::i {
 //     storage {
 //         x: int[3],

--- a/pintc/tests/storage/bad_storage_types.pnt
+++ b/pintc/tests/storage/bad_storage_types.pnt
@@ -36,6 +36,4 @@ storage {
 // @143..155: found type {int, int}[] in storage
 // type not allowed in storage
 // @164..178: found type ( int => int )[] in storage
-// type not allowed in storage
-// @23..45: found type ::MyAlias (::MyUnion) in storage
 // >>>

--- a/pintc/tests/storage/new_type_map.pnt
+++ b/pintc/tests/storage/new_type_map.pnt
@@ -22,7 +22,7 @@ storage {
 // flattened <<<
 // type ::MyMap = ( int => int );
 // type ::MyInt = int;
-// type ::MyNestMap = ( ::MyInt (int) => int );
+// type ::MyNestMap = ( int => int );
 // storage {
 //     m: ( int => int ),
 //     n: int,

--- a/pintc/tests/types/const_tuples_with_enums.pnt
+++ b/pintc/tests/types/const_tuples_with_enums.pnt
@@ -14,7 +14,7 @@ predicate test {
 // >>>
 
 // flattened <<<
-// const ::y: {::x, ::x} = {::x::<0>, ::x::<1>};
+// const ::y: {::x, ::x} = {::x::a, ::x::b};
 // union ::x = a | b;
 //
 // predicate ::test {

--- a/pintc/tests/types/nested_enums.pnt
+++ b/pintc/tests/types/nested_enums.pnt
@@ -69,7 +69,7 @@ predicate Foo {
 // >>>
 
 // flattened <<<
-// const ::papa: {child: {age: int, pet: ::Animal}, pet: ::Animal} = {child: {age: 33, pet: ::Animal::<0>}, pet: ::Animal::<1>};
+// const ::papa: {child: {age: int, pet: ::Animal}, pet: ::Animal} = {child: {age: 33, pet: ::Animal::Cat}, pet: ::Animal::Dog};
 // union ::Animal = Cat | Dog;
 // union ::Parent = Mum | Dad({child: {age: int, pet: ::Animal}, pet: ::Animal});
 // type ::Father = {child: {age: int, pet: ::Animal}, pet: ::Animal};
@@ -78,7 +78,7 @@ predicate Foo {
 //         pub var left: {child: {age: int, pet: ::Animal}, pet: ::Animal};
 //     }
 // }
-// 
+//
 // predicate ::Foo {
 //     var ::bob: {child: {age: int, pet: ::Animal}, pet: ::Animal};
 //     var ::friends_pets: ::Animal[3];

--- a/pintc/tests/types/new_type.pnt
+++ b/pintc/tests/types/new_type.pnt
@@ -118,7 +118,7 @@ predicate test {
 //         pub var x: ::TheLetterA;
 //     }
 // }
-// 
+//
 // predicate ::test {
 //     var ::t: ::TheLetterA;
 //     pub var ::pt: ::TheLetterA;
@@ -132,9 +132,9 @@ predicate test {
 //     var ::p: {x: int, y: int};
 //     var ::q: int;
 //     state ::x: int = __storage_get({0});
-//     constraint (::t == ::A::T);
-//     constraint (__pub_var(__this_pathway(), {0}) == ::A::T);
-//     constraint (::u == ::A::U);
+//     constraint (::t == ::TheLetterA::T);
+//     constraint (__pub_var(__this_pathway(), {0}) == ::TheLetterA::T);
+//     constraint (::u == ::TheLetterA::U);
 //     constraint (::v == ::TheLetterA::V);
 //     constraint (::i == 11);
 //     constraint (::j == {22, 33});

--- a/pintc/tests/types/new_type_in_new_type.pnt
+++ b/pintc/tests/types/new_type_in_new_type.pnt
@@ -26,9 +26,9 @@ predicate test {
 
 // flattened <<<
 // type ::A = int;
-// type ::B = ::A (int)[2];
-// type ::C = {::A (int), ::A (int)};
-// type ::D = {::C ({::A (int), ::A (int)}), ::C ({::A (int), ::A (int)})};
+// type ::B = int[2];
+// type ::C = {int, int};
+// type ::D = {{int, int}, {int, int}};
 //
 // predicate ::test {
 //     var ::x: int[2];

--- a/pintc/tests/types/new_type_in_tuple.pnt
+++ b/pintc/tests/types/new_type_in_tuple.pnt
@@ -36,8 +36,8 @@ predicate test {
 
 // flattened <<<
 // type ::A = int;
-// type ::B = {x: ::A (int), y: ::A (int)};
-// type ::C = ::A (int)[3];
+// type ::B = {x: int, y: int};
+// type ::C = int[3];
 //
 // predicate ::test {
 //     var ::a: int;

--- a/pintc/tests/types/new_type_mismatch.pnt
+++ b/pintc/tests/types/new_type_mismatch.pnt
@@ -19,5 +19,5 @@ predicate test {
 // typecheck_failure <<<
 // variable initialization type error
 // @66..70: variable initializer has unexpected type `bool`
-// @0..12: expecting type `::I (int)`
+// @62..63: expecting type `::I (int)`
 // >>>

--- a/pintc/tests/unions/const_eval.pnt
+++ b/pintc/tests/unions/const_eval.pnt
@@ -24,7 +24,7 @@ predicate test {
 
 // flattened <<<
 // const ::b: bool[11] = [true, true, false, true, false, false, false, true, false, false, false];
-// const ::a: ::node = ::node::<1>({11, false});
+// const ::a: ::node = ::node::sure({11, false});
 // union ::node = nope | sure({int, bool});
 //
 // predicate ::test {


### PR DESCRIPTION
This is an attempt to improve code quality around unions, and in general to try to lessen the amount of path/string compares we're using in the type system.  There's still more to do but this is a start and it took me ages since everything in this area is so fragile, so I'll push what I have here now.

It's supposed to be addressing some of #879 but I'm not sure it does really.  There may still be issues around nested aliases and unions.

This main difference here is that the `Type::Union` now has a key into a slotmap for the declaration rather than a name string.

Other changes:
- Nested new types are flattened completely early on.
- Custom types are lowered more aggressively before type checking.  Hopefully they can be practically removed post-type checking soon.
- `types::Path` is gone, we now just use a `String`.  This removes any illusions that `Path` was anything other than just a string.