### PR TITLE
Add `salt` to `pint build` and `pintc`

### DIFF
--- a/pint-abi-gen-tests/build.rs
+++ b/pint-abi-gen-tests/build.rs
@@ -12,7 +12,7 @@ fn build_test_pkg(manifest: ManifestFile) {
     let members = [(name, manifest)].into_iter().collect();
     let plan = pint_pkg::plan::from_members(&members).expect("failed to plan compilation");
     let built_pkgs = pint_pkg::build::build_plan(&plan)
-        .build_all(false /* skip_optimize */)
+        .build_all(Default::default(), false /* skip_optimize */)
         .expect("failed to build package");
 
     // Retrieve the built target package.

--- a/pint-cli/src/build.rs
+++ b/pint-cli/src/build.rs
@@ -2,7 +2,10 @@
 
 use anyhow::Context;
 use clap::{builder::styling::Style, Parser};
-use pint_pkg::{build::BuiltPkg, manifest::ManifestFile};
+use pint_pkg::{
+    build::BuiltPkg,
+    manifest::{ManifestFile, PackageKind},
+};
 use std::path::{Path, PathBuf};
 
 /// Build a package, writing the generated artifacts to `out/`.
@@ -14,6 +17,14 @@ pub(crate) struct Args {
     /// recursively until a manifest is found.
     #[arg(long = "manifest-path")]
     manifest_path: Option<PathBuf>,
+    /// A 256-bit unsigned integer in hexadeciaml format that represents the contract "salt".
+    ///
+    /// The "salt" is hashed along with the contract's bytecode in order to make the address of the
+    /// contract unique.
+    ///
+    /// If "salt" is provided for a library package, an error is emitted.
+    #[arg(long, value_parser = parse_hex)]
+    salt: Option<[u8; 32]>,
     /// Print the flattened pint program.
     #[arg(long = "print-optimized")]
     print_optimized: bool,
@@ -23,6 +34,23 @@ pub(crate) struct Args {
     /// Don't print anything that wasn't explicitly requested.
     #[arg(long)]
     silent: bool,
+}
+
+/// Parses a `&str` that represents a 256-bit unsigned integer in hexadecimal format and converts
+/// it into a `[u8; 32]`.
+///
+/// Emits an error if the conversion is not possible.
+fn parse_hex(value: &str) -> Result<[u8; 32], String> {
+    if value.len() == 64 && value.chars().all(|c| c.is_ascii_hexdigit()) {
+        let mut salt = [0u8; 32];
+        for i in 0..32 {
+            salt[i] = u8::from_str_radix(&value[2 * i..2 * i + 2], 16)
+                .map_err(|_| "Invalid hexadecimal value")?;
+        }
+        Ok(salt)
+    } else {
+        Err("Salt must be a 256-bit hexadecimal string (64 hex characters)".to_string())
+    }
 }
 
 // Find the file within the current directory or parent directories with the given name.
@@ -58,6 +86,12 @@ pub(crate) fn cmd(args: Args) -> anyhow::Result<()> {
 
     // Prepare the compilation plan.
     let manifest = ManifestFile::from_path(&manifest_path).context("failed to load manifest")?;
+    if let PackageKind::Library = manifest.pkg.kind {
+        if args.salt.is_some() {
+            anyhow::bail!("specifying `salt` for a library package is not allowed");
+        }
+    }
+
     let name = manifest.pkg.name.to_string();
     let members = [(name, manifest)].into_iter().collect();
     // TODO: Print fetching process here when remote deps included.
@@ -82,7 +116,7 @@ pub(crate) fn cmd(args: Args) -> anyhow::Result<()> {
         }
 
         // Build the package.
-        let _built = match prebuilt.build(args.skip_optimize) {
+        let _built = match prebuilt.build(args.salt.unwrap_or_default(), args.skip_optimize) {
             Ok(built) => {
                 built.print_warnings();
                 built

--- a/pintc/src/asm_gen.rs
+++ b/pintc/src/asm_gen.rs
@@ -24,6 +24,7 @@ pub struct CompiledContract {
 /// Convert a `Contract` into `CompiledContract`
 pub fn compile_contract(
     handler: &Handler,
+    salt: [u8; 32],
     contract: &Contract,
 ) -> Result<CompiledContract, ErrorEmitted> {
     // This is a dependency graph between predicates. Predicates may depend on other predicates via
@@ -130,7 +131,7 @@ pub fn compile_contract(
     } else {
         Ok(CompiledContract {
             names,
-            salt: Default::default(), // Salt is not used by pint yet.
+            salt,
             predicates,
         })
     }

--- a/pintc/src/asm_gen/tests.rs
+++ b/pintc/src/asm_gen/tests.rs
@@ -33,7 +33,7 @@ pub(super) fn compile(code: &str) -> CompiledContract {
             },
         )
         .unwrap();
-    compile_contract(&handler, &contract).unwrap()
+    compile_contract(&handler, Default::default(), &contract).unwrap()
 }
 
 #[test]

--- a/pintc/src/cli.rs
+++ b/pintc/src/cli.rs
@@ -8,6 +8,9 @@ pub struct Args {
     #[arg(long = "output", short = 'o')]
     pub output: Option<String>,
 
+    #[arg(long, value_parser = parse_hex_salt)]
+    pub salt: Option<[u8; 32]>,
+
     #[arg(long = "print-parsed")]
     pub print_parsed: bool,
 
@@ -22,4 +25,21 @@ pub struct Args {
 
     #[arg(long = "skip-optimize", hide = true)]
     pub skip_optimize: bool,
+}
+
+/// Parses a `&str` that represents a 256-bit unsigned integer in hexadecimal format and converts
+/// it into a `[u8; 32]`.
+///
+/// Emits an error if the conversion is not possible.
+fn parse_hex_salt(value: &str) -> Result<[u8; 32], String> {
+    if value.len() == 64 && value.chars().all(|c| c.is_ascii_hexdigit()) {
+        let mut salt = [0u8; 32];
+        for i in 0..32 {
+            salt[i] = u8::from_str_radix(&value[2 * i..2 * i + 2], 16)
+                .map_err(|_| "Invalid hexadecimal value")?;
+        }
+        Ok(salt)
+    } else {
+        Err("Salt must be a 256-bit hexadecimal string (64 hex characters)".to_string())
+    }
 }

--- a/pintc/src/cli.rs
+++ b/pintc/src/cli.rs
@@ -8,7 +8,7 @@ pub struct Args {
     #[arg(long = "output", short = 'o')]
     pub output: Option<String>,
 
-    #[arg(long, value_parser = parse_hex_salt)]
+    #[arg(long, value_parser = parse_hex)]
     pub salt: Option<[u8; 32]>,
 
     #[arg(long = "print-parsed")]
@@ -28,18 +28,20 @@ pub struct Args {
 }
 
 /// Parses a `&str` that represents a 256-bit unsigned integer in hexadecimal format and converts
-/// it into a `[u8; 32]`.
+/// it into a `[u8; 32]`. If the string has less than 64 hexadecimal digits, left pad with zeros.
 ///
 /// Emits an error if the conversion is not possible.
-fn parse_hex_salt(value: &str) -> Result<[u8; 32], String> {
-    if value.len() == 64 && value.chars().all(|c| c.is_ascii_hexdigit()) {
-        let mut salt = [0u8; 32];
-        for i in 0..32 {
-            salt[i] = u8::from_str_radix(&value[2 * i..2 * i + 2], 16)
-                .map_err(|_| "Invalid hexadecimal value")?;
-        }
-        Ok(salt)
-    } else {
-        Err("Salt must be a 256-bit hexadecimal string (64 hex characters)".to_string())
+fn parse_hex(value: &str) -> Result<[u8; 32], String> {
+    if value.len() > 64 || !value.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("Salt must be a hexadecimal number with up to 64 digts (256 bits)".to_string());
     }
+
+    // Pad the value to 64 characters by prepending zeros if needed
+    let padded_value = format!("{:0>64}", value);
+    let mut salt = [0u8; 32];
+    for i in 0..32 {
+        salt[i] = u8::from_str_radix(&padded_value[2 * i..2 * i + 2], 16)
+            .map_err(|_| "Invalid hexadecimal value")?;
+    }
+    Ok(salt)
 }

--- a/pintc/src/main.rs
+++ b/pintc/src/main.rs
@@ -59,7 +59,9 @@ fn main() -> anyhow::Result<()> {
         }
     };
 
-    match handler.scope(|handler| compile_contract(handler, &contract)) {
+    match handler
+        .scope(|handler| compile_contract(handler, args.salt.unwrap_or_default(), &contract))
+    {
         Ok(compiled_contract) => {
             if args.print_asm {
                 println!("{compiled_contract}");

--- a/pintc/tests/cli.rs
+++ b/pintc/tests/cli.rs
@@ -151,8 +151,18 @@ fn explicit_salt() {
     let mut input_file = tempfile::NamedTempFile::new().unwrap();
     write!(input_file.as_file_mut(), "predicate test() {{}}").unwrap();
 
+    // Salt has 64 digits
     let output = pintc_command(&format!(
         "{} --salt 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+        input_file.path().to_str().unwrap(),
+    ));
+
+    check(&output.stderr, expect_test::expect![""]);
+    check(&output.stdout, expect_test::expect![""]);
+
+    // Salt has less than 64 digits
+    let output = pintc_command(&format!(
+        "{} --salt 123456789ABCDEF",
         input_file.path().to_str().unwrap(),
     ));
 
@@ -165,33 +175,18 @@ fn explicit_salt_err() {
     let mut input_file = tempfile::NamedTempFile::new().unwrap();
     write!(input_file.as_file_mut(), "predicate test() {{}}").unwrap();
 
-    // Salt too short
-    let output = pintc_command(&format!(
-        "{} --salt 0123456789ABCDEF0123456789ABCDEF0123456789ABC",
-        input_file.path().to_str().unwrap(),
-    ));
-    check(
-        &output.stderr,
-        expect_test::expect![[r#"
-        error: invalid value '0123456789ABCDEF0123456789ABCDEF0123456789ABC' for '--salt <SALT>': Salt must be a 256-bit hexadecimal string (64 hex characters)
-
-        For more information, try '--help'.
-    "#]],
-    );
-    check(&output.stdout, expect_test::expect![""]);
-
     // Salt too long
     let output = pintc_command(&format!(
-        "{} --salt 0123456789ABCDEF0123456789ABCDEF0123456789ABC",
+        "{} --salt 3456789ABCDEF0123456789ABCDEF0123456789ABC0123456789ABCDEF0123456789ABCDEF01234",
         input_file.path().to_str().unwrap(),
     ));
     check(
         &output.stderr,
         expect_test::expect![[r#"
-        error: invalid value '0123456789ABCDEF0123456789ABCDEF0123456789ABC' for '--salt <SALT>': Salt must be a 256-bit hexadecimal string (64 hex characters)
+            error: invalid value '3456789ABCDEF0123456789ABCDEF0123456789ABC0123456789ABCDEF0123456789ABCDEF01234' for '--salt <SALT>': Salt must be a hexadecimal number with up to 64 digts (256 bits)
 
-        For more information, try '--help'.
-    "#]],
+            For more information, try '--help'.
+        "#]],
     );
     check(&output.stdout, expect_test::expect![""]);
 
@@ -203,10 +198,10 @@ fn explicit_salt_err() {
     check(
         &output.stderr,
         expect_test::expect![[r#"
-        error: invalid value 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY' for '--salt <SALT>': Salt must be a 256-bit hexadecimal string (64 hex characters)
+            error: invalid value 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY' for '--salt <SALT>': Salt must be a hexadecimal number with up to 64 digts (256 bits)
 
-        For more information, try '--help'.
-    "#]],
+            For more information, try '--help'.
+        "#]],
     );
     check(&output.stdout, expect_test::expect![""]);
 

--- a/tests/validation_tests.rs
+++ b/tests/validation_tests.rs
@@ -79,7 +79,7 @@ async fn validation_e2e() -> anyhow::Result<()> {
 
         // Flattened contract -> Assembly (aka collection of compiled predicates)
         let compiled_contract = unwrap_or_continue!(
-            pintc::asm_gen::compile_contract(&handler, &flattened),
+            pintc::asm_gen::compile_contract(&handler, Default::default(), &flattened),
             "asm gen",
             failed_tests,
             path,


### PR DESCRIPTION
Closes #932 

* Adds `--salt` to `pint build`
* Adds `--salt` to `pintc`
* The salt value must exist and must be a string representing a 256-bit unsigned integer. Otherwise, an error is emitted. If less than 64 digits are provided, the salt value is left padded with zeros.
* If `--salt` is passed to `pint build` and the package being built is a library, then an error is emitted.