### PR TITLE
Add an explicit check for const array initialisers of the wrong dimension.

### DIFF
--- a/pintc/src/predicate/analyse/array_check.rs
+++ b/pintc/src/predicate/analyse/array_check.rs
@@ -1,6 +1,6 @@
 use super::{Contract, Evaluator, ExprKey};
 use crate::{
-    error::{CompileError, Error, ErrorEmitted, Handler},
+    error::{CompileError, Error, ErrorEmitted, Handler, LargeTypeError},
     expr::{BinaryOp, Expr, Immediate},
     predicate::PredKey,
     span::Spanned,
@@ -23,7 +23,12 @@ fn get_array_size_from_type(
 
 impl Contract {
     pub(crate) fn check_array_lengths(&self, handler: &Handler, pred_key: PredKey) {
-        fn check_array_type(contract: &Contract, handler: &Handler, ty: &Type) {
+        fn check_array_type(
+            contract: &Contract,
+            handler: &Handler,
+            ty: &Type,
+            init: Option<ExprKey>,
+        ) {
             if ty.is_array() {
                 if let Ok(n) = get_array_size_from_type(contract, handler, ty) {
                     if n < 1 {
@@ -33,6 +38,29 @@ impl Contract {
                             },
                         });
                     }
+
+                    // We know we have an array expression.  If we have an initialiser then the
+                    // type checker must agree that it's an array, but currently it doesn't check
+                    // the lengths are correct.
+                    if let Some(init) = init {
+                        let init_ty = init.get_ty(contract);
+                        if let Some(init_len) = init_ty.get_array_size() {
+                            if init_len != n {
+                                handler.emit_err(Error::Compile {
+                                    error: CompileError::InitTypeError {
+                                        init_kind: "const",
+                                        large_err: Box::new(LargeTypeError::InitTypeError {
+                                            init_kind: "const",
+                                            expected_ty: contract.with_ctrct(ty).to_string(),
+                                            found_ty: contract.with_ctrct(init_ty).to_string(),
+                                            expected_ty_span: ty.span().clone(),
+                                            init_span: contract.expr_key_to_span(init),
+                                        }),
+                                    },
+                                });
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -40,15 +68,15 @@ impl Contract {
         let pred = &self.preds[pred_key];
 
         for param in &pred.params {
-            check_array_type(self, handler, &param.ty);
+            check_array_type(self, handler, &param.ty, None);
         }
 
         for expr_key in self.exprs(pred_key) {
-            check_array_type(self, handler, expr_key.get_ty(self));
+            check_array_type(self, handler, expr_key.get_ty(self), None);
         }
 
         for (_name, cnst) in self.consts.iter() {
-            check_array_type(self, handler, &cnst.decl_ty);
+            check_array_type(self, handler, &cnst.decl_ty, Some(cnst.expr));
         }
     }
 

--- a/pintc/src/predicate/analyse/array_check.rs
+++ b/pintc/src/predicate/analyse/array_check.rs
@@ -46,6 +46,10 @@ impl Contract {
         for expr_key in self.exprs(pred_key) {
             check_array_type(self, handler, expr_key.get_ty(self));
         }
+
+        for (_name, cnst) in self.consts.iter() {
+            check_array_type(self, handler, &cnst.decl_ty);
+        }
     }
 
     pub(crate) fn check_array_indexing(&self, handler: &Handler, pred_key: PredKey) {

--- a/pintc/tests/arrays/bad_const_array_init.pnt
+++ b/pintc/tests/arrays/bad_const_array_init.pnt
@@ -1,0 +1,17 @@
+const g: int[2] = [11, 22, 33];
+
+predicate test() { }
+
+// parsed <<<
+// const ::g: int[2] = [11, 22, 33];
+// 
+// predicate ::test(
+// ) {
+// }
+// >>>
+
+// flattening_failure <<<
+// const initialization type error
+// @18..30: const initializer has unexpected type `int[_]`
+// @9..15: expecting type `int[2]`
+// >>>

--- a/pintc/tests/arrays/bad_const_index.pnt
+++ b/pintc/tests/arrays/bad_const_index.pnt
@@ -1,18 +1,27 @@
+const b: int[2] = [11, 22];
+
 predicate test(n: int, a: int[10]) {
     constraint a[true] == 3;
+    constraint b[true] == 22;
 }
 
 // parsed <<<
+// const ::b: int[2] = [11, 22];
+//
 // predicate ::test(
 //     ::n: int,
 //     ::a: int[10],
 // ) {
 //     constraint (::a[true] == 3);
+//     constraint (::b[true] == 22);
 // }
 // >>>
 
 // typecheck_failure <<<
 // attempt to index an array with a mismatched value
-// @54..58: array access must be with an int value
+// @83..87: array access must be with an int value
+// found access using type `bool`
+// attempt to index an array with a mismatched value
+// @112..116: array access must be with an int value
 // found access using type `bool`
 // >>>

--- a/pintc/tests/arrays/bad_const_length.pnt
+++ b/pintc/tests/arrays/bad_const_length.pnt
@@ -1,9 +1,13 @@
+const g: int[0] = [11];
+
 predicate test(
     n: int,
     a: int[0]
 ) { }
 
 // parsed <<<
+// const ::g: int[0] = [11];
+//
 // predicate ::test(
 //     ::n: int,
 //     ::a: int[0],
@@ -13,5 +17,7 @@ predicate test(
 
 // flattening_failure <<<
 // attempt to use an invalid constant as an array length
-// @39..40: this must be a strictly positive integer value
+// @64..65: this must be a strictly positive integer value
+// attempt to use an invalid constant as an array length
+// @13..14: this must be a strictly positive integer value
 // >>>

--- a/pintc/tests/arrays/compare_different_sizes.pnt
+++ b/pintc/tests/arrays/compare_different_sizes.pnt
@@ -1,3 +1,6 @@
+const g: int[2] = [222, 333];
+const h: int[3] = [444, 555, 666];
+
 predicate test(a: int[4], b: int[5], c: int[2]) {
     constraint b == [11, 22, 33, 44, 55];
     constraint c == [66, 77];
@@ -5,9 +8,15 @@ predicate test(a: int[4], b: int[5], c: int[2]) {
     constraint a == b;
     constraint a != c;
     constraint c != [88, 99, 111];
+
+    constraint g == h;
+    constraint h == c;
 }
 
 // parsed <<<
+// const ::h: int[3] = [444, 555, 666];
+// const ::g: int[2] = [222, 333];
+//
 // predicate ::test(
 //     ::a: int[4],
 //     ::b: int[5],
@@ -18,17 +27,25 @@ predicate test(a: int[4], b: int[5], c: int[2]) {
 //     constraint (::a == ::b);
 //     constraint (::a != ::c);
 //     constraint (::c != [88, 99, 111]);
+//     constraint (::g == ::h);
+//     constraint (::h == ::c);
 // }
 // >>>
 
 // flattening_failure <<<
 // comparison between differently sized arrays
-// @184..202: cannot compare arrays of different sizes
+// @309..315: cannot compare arrays of different sizes
+// the left-hand side argument of the `==` operator has 3 elements while the right-hand side argument has 2 elements
+// comparison between differently sized arrays
+// @286..292: cannot compare arrays of different sizes
+// the left-hand side argument of the `==` operator has 2 elements while the right-hand side argument has 3 elements
+// comparison between differently sized arrays
+// @250..268: cannot compare arrays of different sizes
 // the left-hand side argument of the `!=` operator has 2 elements while the right-hand side argument has 3 elements
 // comparison between differently sized arrays
-// @161..167: cannot compare arrays of different sizes
+// @227..233: cannot compare arrays of different sizes
 // the left-hand side argument of the `!=` operator has 4 elements while the right-hand side argument has 2 elements
 // comparison between differently sized arrays
-// @138..144: cannot compare arrays of different sizes
+// @204..210: cannot compare arrays of different sizes
 // the left-hand side argument of the `==` operator has 4 elements while the right-hand side argument has 5 elements
 // >>>

--- a/pintc/tests/arrays/index_enum_with_int.pnt
+++ b/pintc/tests/arrays/index_enum_with_int.pnt
@@ -1,21 +1,29 @@
 union Num = Zero | One | Two | Three;
 
+const g: int[Num] = [11, 22, 33, 44];
+
 predicate test(ary: int[Num]) {
     constraint ary[1] == 1;
+    constraint g[2] == 33;
 }
 
 // parsed <<<
+// const ::g: int[::Num] = [11, 22, 33, 44];
 // union ::Num = Zero | One | Two | Three;
 // 
 // predicate ::test(
 //     ::ary: int[::Num],
 // ) {
 //     constraint (::ary[1] == 1);
+//     constraint (::g[2] == 33);
 // }
 // >>>
 
 // typecheck_failure <<<
 // attempt to index an array with a mismatched value
-// @90..91: array access must be with a `::Num` variant
+// @129..130: array access must be with a `::Num` variant
+// found access using type `int`
+// attempt to index an array with a mismatched value
+// @155..156: array access must be with a `::Num` variant
 // found access using type `int`
 // >>>

--- a/pintc/tests/arrays/index_int_with_enum.pnt
+++ b/pintc/tests/arrays/index_int_with_enum.pnt
@@ -1,21 +1,29 @@
 union Num = Zero | One | Two | Three;
 
+const g: int[2] = [11, 22];
+
 predicate test(ary: int[4]) {
     constraint ary[Num::One] == 1;
+    constraint g[Num::Zero] == 11;
 }
 
 // parsed <<<
+// const ::g: int[2] = [11, 22];
 // union ::Num = Zero | One | Two | Three;
 // 
 // predicate ::test(
 //     ::ary: int[4],
 // ) {
 //     constraint (::ary[::Num::One] == 1);
+//     constraint (::g[::Num::Zero] == 11);
 // }
 // >>>
 
 // typecheck_failure <<<
 // attempt to index an array with a mismatched value
-// @88..96: array access must be with an int value
+// @117..125: array access must be with an int value
+// found access using type `::Num`
+// attempt to index an array with a mismatched value
+// @150..159: array access must be with an int value
 // found access using type `::Num`
 // >>>

--- a/pintc/tests/arrays/out_of_bounds_index.pnt
+++ b/pintc/tests/arrays/out_of_bounds_index.pnt
@@ -1,16 +1,30 @@
+const a: int[2] = [11, 22];
+
 predicate test(b: int[4]) {
     constraint b[4] == 2;
+    constraint a[3] == 33;
+    constraint a[0xffffffffffffffff] == 44;
 }
 
 // parsed <<<
+// const ::a: int[2] = [11, 22];
+// 
 // predicate ::test(
 //     ::b: int[4],
 // ) {
 //     constraint (::b[4] == 2);
+//     constraint (::a[3] == 33);
+//     constraint (::a[-1] == 44);
 // }
 // >>>
 
 // flattening_failure <<<
 // attempt to access array with out of bounds index
-// @45..46: array index is out of bounds
+// @127..145: array index is out of bounds
+// attempt to access array with out of bounds index
+// @100..101: array index is out of bounds
+// attempt to access array with out of bounds index
+// @74..75: array index is out of bounds
+// attempt to use an invalid constant as an array length
+// @127..145: this must be a strictly positive integer value
 // >>>

--- a/pintc/tests/arrays/out_of_bounds_index_multidimensional.pnt
+++ b/pintc/tests/arrays/out_of_bounds_index_multidimensional.pnt
@@ -1,16 +1,26 @@
+const g: int[2][2] = [ [11, 22], [33, 44]];
+
 predicate test(b: int[4][2]) {
     constraint b[5][1] == 2;
+    constraint g[2][1] == 55;
 }
 
 // parsed <<<
+// const ::g: int[2][2] = [[11, 22], [33, 44]];
+// 
 // predicate ::test(
 //     ::b: int[2][4],
 // ) {
 //     constraint (::b[5][1] == 2);
+//     constraint (::g[2][1] == 55);
 // }
 // >>>
 
 // flattening_failure <<<
 // attempt to access array with out of bounds index
-// @48..49: array index is out of bounds
+// @122..123: array index is out of bounds
+// attempt to access array with out of bounds index
+// @93..94: array index is out of bounds
+// attempt to access array with out of bounds index
+// @122..123: array index is out of bounds
 // >>>

--- a/pintc/tests/arrays/out_of_bounds_index_multidimensional_second.pnt
+++ b/pintc/tests/arrays/out_of_bounds_index_multidimensional_second.pnt
@@ -1,16 +1,26 @@
+const g: int[2][2] = [ [11, 22], [33, 44]];
+
 predicate test(b: int[4][2]) {
     constraint b[1][3] == 2;
+    constraint g[1][2] == 55;
 }
 
 // parsed <<<
+// const ::g: int[2][2] = [[11, 22], [33, 44]];
+//
 // predicate ::test(
 //     ::b: int[2][4],
 // ) {
 //     constraint (::b[1][3] == 2);
+//     constraint (::g[1][2] == 55);
 // }
 // >>>
 
 // flattening_failure <<<
 // attempt to access array with out of bounds index
-// @51..52: array index is out of bounds
+// @125..126: array index is out of bounds
+// attempt to access array with out of bounds index
+// @96..97: array index is out of bounds
+// attempt to access array with out of bounds index
+// @125..126: array index is out of bounds
 // >>>


### PR DESCRIPTION
Closed #908.  The problem in that example -- `const a: int[2] = [1, 1, 1];` -- is that it type checks.  I haven't tried to fix that, but I've put an explicit check for it in the `array_check` module.

This problem will be exacerbated when we support variable sized arrays.  Declared types will most likely need to be `int[]` when the size isn't known at compile time and type checking will have to remain ambivalent to size.  Specialised checks like this PR or runtime checks will then need to ensure arrays are correct.