### PR TITLE
Allow, in the parser, maps to have arrays as keys by handling the token `[[`

### DIFF
--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -721,6 +721,7 @@ UnaryOp: ExprKey = {
         )
     },
     <PostfixOp>,
+    <StoragePostfixOp>,
 }
 
 PostfixOp: ExprKey = {
@@ -770,6 +771,67 @@ PostfixOp: ExprKey = {
     <Term>,
 }
 
+// Handle storage post fix ops separately since they're quite restricted
+StoragePostfixOp: ExprKey = {
+    <l:@L> <expr:StoragePostfixOp> "[" <index:Expr> "]" <r:@R> => {
+        let span = (context.span_from)(l, r);
+        context.contract.exprs.insert(
+            Expr::Index {
+                expr,
+                index,
+                span: span.clone(),
+            },
+            Type::Unknown(span),
+        )
+    },
+    <l:@L> <expr:StoragePostfixOp> "[[" <elements:SepList<Expr, ",">> "]""]" <r:@R> => {
+        // This special case is useful for when we have a map that is indexed with an array
+        // expression
+        let inner_span = (context.span_from)(l + 1, r - 1);
+        let inner_expr = context.build_array_expr(elements, inner_span.clone());
+
+        let inner_expr_key = context
+            .contract
+            .exprs
+            .insert(inner_expr, Type::Unknown(inner_span));
+
+        let span = (context.span_from)(l, r);
+        context.contract.exprs.insert(
+            Expr::Index {
+                expr,
+                index: inner_expr_key,
+                span: span.clone(),
+            },
+            Type::Unknown(span),
+        )
+    },
+    <l:@L> <expr:StoragePostfixOp> "[" "]" <r:@R> => {
+        let span = (context.span_from)(l, r);
+        handler.emit_err(Error::Parse {
+            error: ParseError::EmptyIndexAccess { span: span.clone() },
+        });
+
+        // Recover with a malformed expression
+        context
+            .contract
+            .exprs
+            .insert(Expr::Error(span.clone()), Type::Unknown(span))
+    },
+    <l:@L> <tuple:StoragePostfixOp> "." <name:Ident> <r:@R> => {
+        context.parse_tuple_field_op_with_ident(tuple, name, (l, r))
+    },
+    <l:@L> <tuple:StoragePostfixOp> "." <m:@L> <num_str:"int_lit"> <r:@R> => {
+        context.parse_tuple_field_op_with_int(handler, tuple, num_str, (l, m, r))
+    },
+    <l:@L> <tuple:StoragePostfixOp> "." <m:@L> <num_str:"real_lit"> <r:@R> => {
+        context.parse_tuple_field_op_with_real(handler, tuple, num_str, (l, m, r))
+    },
+    <p:StoragePath> => {
+        let span = p.span().clone();
+        context.contract.exprs.insert(p, Type::Unknown(span))
+    },
+}
+
 Term: ExprKey = {
     <e:TermInner> => {
         let span = e.span().clone();
@@ -803,7 +865,6 @@ TermInner: Expr = {
     TupleExpr,
     UnionExpr,
     <l:@L> <path:Path> <r:@R> => Expr::Path(path, (context.span_from)(l, r)),
-    StoragePath,
 }
 
 GeneratorRange: (Ident, ExprKey) = {
@@ -1178,6 +1239,8 @@ StoragePath: Expr = {
         }
     },
 }
+
+
 
 Immediate: Immediate = {
     <l:@L> <s:"int_lit"> <r:@R> => context.parse_int_immediate(handler, s, (l, r)),

--- a/pintc/tests/arrays/double_bracket.pnt
+++ b/pintc/tests/arrays/double_bracket.pnt
@@ -1,3 +1,8 @@
+storage {
+    b0: (int[2] => {int, (int[3] => int)}),
+    b1: (int[2][2] => int),
+    b2: {int, ( int[2][2] => int[2] )},
+}
 
 predicate test() {
   let a0 = [[1]];
@@ -22,9 +27,29 @@ predicate test() {
   let a16 = [[[1, 1], [1, 1]], [[1, 1], [1, 1]]];
   let a17 = [[[1], [1], ]];
   let a18 = [[[[1, 1], [1, 1], ]], [[[1, 1], [1, 1], ]]];
+
+  let b0_access_1 = storage::b0[[1, 2]].1[[5, 6, 7]];
+  let b0_access_2 = storage::b0[ [1, 2]].1;
+  let b0_access_3 = storage::b0[[1, 2] ] .1 [ [5, 6, 7]];
+  let b0_access_4 = storage::b0[[1, 2]];
+
+  let b1_access_1 = storage::b1[[[2, 2], [3, 4]]];
+  let b1_access_2 = storage::b1[[ [2, 2], [3, 4]]];
+  let b1_access_3 = storage::b1[ [[2, 2], [3, 4]]];
+  let b1_access_4 = storage::b1[[[2, 2], [3, 4] ] ];
+  let b1_access_5 = storage::b1[[[2, 2], [3, 4] ]];
+
+  let b2_access_0 = storage::b2.1[[[2, 2], [3, 4] ]];
+  let b2_access_1 = storage::b2.1[[[2, 2], [3, 4] ]][1];
 }
 
 // parsed <<<
+// storage {
+//     b0: ( int[2] => {int, ( int[3] => int )} ),
+//     b1: ( int[2][2] => int ),
+//     b2: {int, ( int[2][2] => int[2] )},
+// }
+// 
 // predicate ::test(
 // ) {
 //     let ::a0 = [[1]];
@@ -46,31 +71,31 @@ predicate test() {
 //     let ::a16 = [[[1, 1], [1, 1]], [[1, 1], [1, 1]]];
 //     let ::a17 = [[[1], [1]]];
 //     let ::a18 = [[[[1, 1], [1, 1]]], [[[1, 1], [1, 1]]]];
+//     let ::b0_access_1 = storage::b0[[1, 2]].1[[5, 6, 7]];
+//     let ::b0_access_2 = storage::b0[[1, 2]].1;
+//     let ::b0_access_3 = storage::b0[[1, 2]].1[[5, 6, 7]];
+//     let ::b0_access_4 = storage::b0[[1, 2]];
+//     let ::b1_access_1 = storage::b1[[[2, 2], [3, 4]]];
+//     let ::b1_access_2 = storage::b1[[[2, 2], [3, 4]]];
+//     let ::b1_access_3 = storage::b1[[[2, 2], [3, 4]]];
+//     let ::b1_access_4 = storage::b1[[[2, 2], [3, 4]]];
+//     let ::b1_access_5 = storage::b1[[[2, 2], [3, 4]]];
+//     let ::b2_access_0 = storage::b2.1[[[2, 2], [3, 4]]];
+//     let ::b2_access_1 = storage::b2.1[[[2, 2], [3, 4]]][1];
 // }
 // >>>
 
-// flattened <<<
-// predicate ::test(
-// ) {
-//     let ::a0: int[1][1] = [[1]];
-//     let ::a1: int[2][1] = [[1, 1]];
-//     let ::a2: int[1][2] = [[1], [1]];
-//     let ::a3: int[2][2] = [[1, 1], [1]];
-//     let ::a4: int[2][3] = [[1, 1], [1], [1]];
-//     let ::a5: int[1][1] = [[1]];
-//     let ::a6: int[2][1] = [[1, 1]];
-//     let ::a7: int[1][2] = [[1], [1]];
-//     let ::a8: int[2][2] = [[1, 1], [1, 1]];
-//     let ::a9: int[2][3] = [[1, 1], [1, 1], [1, 1]];
-//     let ::a10: int[1][1] = [[1]];
-//     let ::a11: int[2][1] = [[1, 1]];
-//     let ::a12: int[1][2] = [[1], [1]];
-//     let ::a13: int[2][2] = [[1, 1], [1, 1]];
-//     let ::a14: int[2][3] = [[1, 1], [1, 1], [1, 1]];
-//     let ::a15: int[1][1][1] = [[[1]]];
-//     let ::a16: int[2][2][2] = [[[1, 1], [1, 1]], [[1, 1], [1, 1]]];
-//     let ::a17: int[1][2][1] = [[[1], [1]]];
-//     let ::a18: int[2][2][1][2] = [[[[1, 1], [1, 1]]], [[[1, 1], [1, 1]]]];
-//     constraint __eq_set(__mut_keys(), {0});
-// }
+// These failures are expected until all non-storage types are supported as storage map keys
+// typecheck_failure <<<
+// type not allowed in storage
+// @18..52: found type ( int[2] => {int, ( int[3] => int )} ) in storage
+// type not allowed in storage
+// @62..80: found type ( int[2][2] => int ) in storage
+// type not allowed in storage
+// @90..120: found type {int, ( int[2][2] => int[2] )} in storage
+// predicate parameters cannot have storage types
+// @760..800: found parameter of storage type ( int[3] => int ) here
+// predicate parameters cannot have storage types
+// @862..899: found parameter of storage type {int, ( int[3] => int )} here
+// type of parameter depends on the storage type `( int[3] => int )`
 // >>>


### PR DESCRIPTION
Closes #962 

Had to pull out `StoragePostFixOp` as a separate parser because it's much more restricted. That's how I avoided a conflict with `PredicateCallExpr`. I think this is fine and probably more correct anyways since storage access expressions only support the index operator and the `.` operator.