### PR TITLE
Add more `pint` printing flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ dependencies = [
 name = "pint-pkg"
 version = "0.6.0"
 dependencies = [
+ "clap",
  "essential-hash",
  "essential-types",
  "petgraph",

--- a/docs/book/src/pint-reference/cli.md
+++ b/docs/book/src/pint-reference/cli.md
@@ -43,6 +43,28 @@ Options:
 
           If not provided, the current directory is checked and then each parent recursively until a manifest is found.
 
+      --salt <SALT>
+          A 256-bit unsigned integer in hexadeciaml format that represents the contract "salt". The value is left padded with zeros if it has less than 64 hexadecimal digits.
+
+          The "salt" is hashed along with the contract's bytecode in order to make the address of the contract unique.
+
+          If "salt" is provided for a library package, an error is emitted.
+
+      --print-parsed
+          Print the parsed package
+
+      --print-flat
+          Print the flattened package
+
+      --print-optimized
+          Print the optimized package
+
+      --print-asm
+          Print the assembly generated for the package
+
+      --silent
+          Don't print anything that wasn't explicitly requested
+
   -h, --help
           Print help (see a summary with '-h')
 ```

--- a/pint-abi-gen-tests/build.rs
+++ b/pint-abi-gen-tests/build.rs
@@ -12,7 +12,7 @@ fn build_test_pkg(manifest: ManifestFile) {
     let members = [(name, manifest)].into_iter().collect();
     let plan = pint_pkg::plan::from_members(&members).expect("failed to plan compilation");
     let built_pkgs = pint_pkg::build::build_plan(&plan)
-        .build_all(Default::default(), false /* skip_optimize */)
+        .build_all(&Default::default())
         .expect("failed to build package");
 
     // Retrieve the built target package.

--- a/pint-cli/src/build.rs
+++ b/pint-cli/src/build.rs
@@ -6,7 +6,10 @@ use pint_pkg::{
     build::BuiltPkg,
     manifest::{ManifestFile, PackageKind},
 };
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 /// Build a package, writing the generated artifacts to `out/`.
 #[derive(Parser, Debug)]
@@ -105,14 +108,14 @@ pub(crate) fn cmd(args: Args) -> anyhow::Result<()> {
     }
 
     let name = manifest.pkg.name.to_string();
-    let members = [(name, manifest)].into_iter().collect();
+    let members = [(name, manifest.clone())].into_iter().collect();
     // TODO: Print fetching process here when remote deps included.
     let plan = pint_pkg::plan::from_members(&members).context("failed to plan compilation")?;
 
     // Build the given compilation plan.
     let mut builder = pint_pkg::build::build_plan(&plan);
     let options = pint_pkg::build::BuildOptions {
-        salt: args.salt.unwrap_or_default(),
+        salts: HashMap::from_iter([(manifest, args.salt.unwrap_or_default())]),
         print_parsed: args.print_parsed,
         print_flat: args.print_flat,
         print_optimized: args.print_optimized,

--- a/pint-manifest/src/lib.rs
+++ b/pint-manifest/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 use thiserror::Error;
 
 /// A manifest loaded from a file.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ManifestFile {
     /// The deserialized manifest.
     manifest: Manifest,

--- a/pint-pkg/Cargo.toml
+++ b/pint-pkg/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+clap = { workspace = true }
 essential-hash = { workspace = true }
 essential-types = { workspace = true }
 petgraph = { workspace = true }

--- a/pint-pkg/src/build.rs
+++ b/pint-pkg/src/build.rs
@@ -41,7 +41,7 @@ pub struct BuildOptions {
     /// contract unique.
     ///
     /// If "salt" is provided for a library package, an error is emitted.
-    pub salt: [u8; 32],
+    pub salts: HashMap<manifest::ManifestFile, [u8; 32]>,
     /// Print the parsed pint program.
     pub print_parsed: bool,
     /// Print the flattened pint program.
@@ -423,8 +423,13 @@ fn build_pkg(
             };
 
             // Generate the assembly and the predicates.
-            let Ok(contract) = handler.scope(|h| compile_contract(h, options.salt, &optimized))
-            else {
+            let Ok(contract) = handler.scope(|h| {
+                compile_contract(
+                    h,
+                    *options.salts.get(manifest).unwrap_or(&[0; 32]),
+                    &optimized,
+                )
+            }) else {
                 let kind = BuildPkgErrorKind::from(PintcError::AsmGen);
                 return Err(BuildPkgError { handler, kind });
             };

--- a/pint-pkg/tests/build.rs
+++ b/pint-pkg/tests/build.rs
@@ -7,6 +7,7 @@ use pint_pkg::{
     build::{build_plan, BuiltPkg},
     manifest::PackageKind,
 };
+use std::collections::HashMap;
 use util::{edit_manifest, insert_dep, new_pkg, with_temp_dir};
 
 mod util;
@@ -35,11 +36,13 @@ fn build_default_library() {
 fn build_default_contract_with_salt() {
     with_temp_dir(|dir| {
         let foo = new_pkg(&dir.join("foo"), PackageKind::Contract);
-        let members = [(foo.pkg.name.to_string(), foo)].into_iter().collect();
+        let members = [(foo.pkg.name.to_string(), foo.clone())]
+            .into_iter()
+            .collect();
         let plan = pint_pkg::plan::from_members(&members).unwrap();
         let built = build_plan(&plan)
             .build_all(&pint_pkg::build::BuildOptions {
-                salt: [42; 32],
+                salts: HashMap::from_iter([(foo, [42; 32])]),
                 ..Default::default()
             })
             .unwrap();


### PR DESCRIPTION
Closes #956 
Closes #960 

Output of
```
 pint b --print-parsed --print-flat --print-optimized --print-asm
```
is
<img width="786" alt="image" src="https://github.com/user-attachments/assets/2345d7bf-ebfd-419b-8a80-d821f2ff9e11">
