### PR TITLE
Fix a math-based example of a failing contraint in pint book

### DIFF
--- a/docs/book/src/smart_contracts/index.md
+++ b/docs/book/src/smart_contracts/index.md
@@ -56,7 +56,7 @@ Here's an example that shows how to declare a predicate named `test` with three 
 The predicate `test` also declares a constraint that enforces that the square of `foo` is at most
 `1024`, meaning that any proposed solution must assign a value for `foo` that satisfies this
 condition. For example, if `foo` is set to `7`, this is constraint would be satisfied. If `foo` is
-set to `11`, this constraint would not be satisfied. We will go over constraints in more detail in
+set to `42`, this constraint would not be satisfied. We will go over constraints in more detail in
 [Chapter 4.6](../basics/constraints.md).
 
 You can think of the type annotation on each predicate parameter as an implicit "constraint". For


### PR DESCRIPTION
For reference, here's the code snippet from the book:

<img width="344" alt="image" src="https://github.com/user-attachments/assets/37705ff6-afda-444e-a2db-c8eb6bbd524c">
