### PR TITLE
feat: Expose `pint build` command args for use downstream

### DIFF
--- a/pint-cli/Cargo.toml
+++ b/pint-cli/Cargo.toml
@@ -12,6 +12,9 @@ repository.workspace = true
 name = "pint"
 path = "src/main.rs"
 
+[lib]
+path = "src/lib.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }

--- a/pint-cli/src/build.rs
+++ b/pint-cli/src/build.rs
@@ -13,7 +13,7 @@ use std::{
 
 /// Build a package, writing the generated artifacts to `out/`.
 #[derive(Parser, Debug)]
-pub(crate) struct Args {
+pub struct Args {
     /// The path to the package manifest.
     ///
     /// If not provided, the current directory is checked and then each parent

--- a/pint-cli/src/lib.rs
+++ b/pint-cli/src/lib.rs
@@ -1,0 +1,61 @@
+use anyhow::Context;
+use clap::{CommandFactory, Parser, Subcommand};
+
+pub mod build;
+pub mod new;
+mod plugin;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "pint",
+    about = "Pint's package manager and CLI plugin host",
+    version
+)]
+pub struct Pint {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Debug, Subcommand)]
+enum Cmd {
+    #[command(alias = "b")]
+    Build(build::Args),
+    New(new::Args),
+    /// Print all pint plugins found in `PATH`.
+    Plugins,
+    /// A catch-all for unknown pint plugins and their arguments.
+    ///
+    /// Checks for a plugin exe named `pint-<unknown-subcommand>` and tries to
+    /// execute it with the remaining args.
+    #[clap(external_subcommand)]
+    Plugin(Vec<String>),
+}
+
+// Manually print the help output for missing/unknown commands or plugins.
+fn print_help_output() -> anyhow::Result<()> {
+    let mut cli = Pint::command();
+    cli.print_help()?;
+    Ok(())
+}
+
+/// Run the `pint` CLI given the set of parsed commands/args.
+pub fn run(pint: Pint) -> anyhow::Result<()> {
+    match pint.cmd {
+        Cmd::New(arg) => new::cmd(arg),
+        Cmd::Build(arg) => build::cmd(arg),
+        Cmd::Plugins => {
+            plugin::print_all();
+            Ok(())
+        }
+        Cmd::Plugin(args) if !args.is_empty() => {
+            let Some(plugin_exe_path) = plugin::find_exe(&args[0]) else {
+                // There's no plugin with the given name, so print help output.
+                print_help_output()?;
+                anyhow::bail!("no known command or plugin {:?}", &args[0]);
+            };
+            let output = plugin::exec(&plugin_exe_path, &args[1..])?;
+            std::process::exit(output.status.code().context("unknown exit status")?);
+        }
+        _ => print_help_output(),
+    }
+}

--- a/pint-cli/src/lib.rs
+++ b/pint-cli/src/lib.rs
@@ -42,7 +42,10 @@ fn print_help_output() -> anyhow::Result<()> {
 pub fn run(pint: Pint) -> anyhow::Result<()> {
     match pint.cmd {
         Cmd::New(arg) => new::cmd(arg),
-        Cmd::Build(arg) => build::cmd(arg),
+        Cmd::Build(arg) => {
+            let (_plan, _built_pkgs) = build::cmd(arg)?;
+            Ok(())
+        }
         Cmd::Plugins => {
             plugin::print_all();
             Ok(())

--- a/pint-cli/src/main.rs
+++ b/pint-cli/src/main.rs
@@ -1,67 +1,8 @@
-use anyhow::Context;
-use clap::{builder::styling::Style, CommandFactory, Parser, Subcommand};
-
-mod build;
-mod new;
-mod plugin;
-
-#[derive(Parser, Debug)]
-#[command(
-    name = "pint",
-    about = "Pint's package manager and CLI plugin host",
-    version
-)]
-struct Pint {
-    #[command(subcommand)]
-    cmd: Cmd,
-}
-
-#[derive(Debug, Subcommand)]
-enum Cmd {
-    #[command(alias = "b")]
-    Build(build::Args),
-    New(new::Args),
-    /// Print all pint plugins found in `PATH`.
-    Plugins,
-    /// A catch-all for unknown pint plugins and their arguments.
-    ///
-    /// Checks for a plugin exe named `pint-<unknown-subcommand>` and tries to
-    /// execute it with the remaining args.
-    #[clap(external_subcommand)]
-    Plugin(Vec<String>),
-}
-
-// Manually print the help output for missing/unknown commands or plugins.
-fn print_help_output() -> anyhow::Result<()> {
-    let mut cli = Pint::command();
-    cli.print_help()?;
-    Ok(())
-}
-
-fn run() -> anyhow::Result<()> {
-    let pint = Pint::parse();
-    match pint.cmd {
-        Cmd::New(arg) => new::cmd(arg),
-        Cmd::Build(arg) => build::cmd(arg),
-        Cmd::Plugins => {
-            plugin::print_all();
-            Ok(())
-        }
-        Cmd::Plugin(args) if !args.is_empty() => {
-            let Some(plugin_exe_path) = plugin::find_exe(&args[0]) else {
-                // There's no plugin with the given name, so print help output.
-                print_help_output()?;
-                anyhow::bail!("no known command or plugin {:?}", &args[0]);
-            };
-            let output = plugin::exec(&plugin_exe_path, &args[1..])?;
-            std::process::exit(output.status.code().context("unknown exit status")?);
-        }
-        _ => print_help_output(),
-    }
-}
+use clap::{builder::styling::Style, Parser};
 
 fn main() {
-    if let Err(err) = run() {
+    let pint = pint_cli::Pint::parse();
+    if let Err(err) = pint_cli::run(pint) {
         let bold = Style::new().bold();
         eprintln!("{}Error:{} {err:?}", bold.render(), bold.render_reset());
         std::process::exit(1);

--- a/pint-cli/src/new.rs
+++ b/pint-cli/src/new.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 /// Create a new package.
 #[derive(Parser, Debug)]
-pub(crate) struct Args {
+pub struct Args {
     /// Specify the "contract" package kind.
     ///
     /// This is the default behaviour.

--- a/pint-pkg/src/build.rs
+++ b/pint-pkg/src/build.rs
@@ -194,6 +194,11 @@ impl<'p> PlanBuilder<'p> {
         }
         Ok(self.built_pkgs)
     }
+
+    /// Consume the builder and return the set of `BuiltPkgs` that have already been built.
+    pub fn into_built_pkgs(self) -> BuiltPkgs {
+        self.built_pkgs
+    }
 }
 
 impl<'p, 'b> PrebuiltPkg<'p, 'b> {


### PR DESCRIPTION
This enables the downstream `pint-deploy` tool to also receive uniform "build" arguments that match what the `pint build` command expects.

The following PR contains the motivating work: https://github.com/essential-contributions/essential-integration/pull/128