### PR TITLE
Refactor internal errors

### DIFF
--- a/pintc/src/asm_gen.rs
+++ b/pintc/src/asm_gen.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{CompileError, Error, ErrorEmitted, Handler},
+    error::{ErrorEmitted, Handler},
     expr::{Expr, ExternalIntrinsic, Immediate, IntrinsicKind},
     predicate::{ConstraintDecl, Contract, Predicate},
     span::empty_span,
@@ -76,12 +76,10 @@ pub fn compile_contract(
     // Predicates should be sorted topologically based on the dependency graph. That way, predicate
     // addresses that are required by other predicates are known in time.
     let Ok(sorted_nodes) = petgraph::algo::toposort(&dep_graph, None) else {
-        return Err(handler.emit_err(Error::Compile {
-            error: CompileError::Internal {
-                msg: "dependency cycles between predicates should have been caught before",
-                span: empty_span(),
-            },
-        }));
+        return Err(handler.emit_internal_err(
+            "dependency cycles between predicates should have been caught before".to_string(),
+            empty_span(),
+        ));
     };
 
     // This map keeps track of the compiled predicates and their addresses. We will use this later
@@ -116,12 +114,10 @@ pub fn compile_contract(
                 .remove(&pred.name)
                 .map(|(compiled_predicate, _)| (pred.name.clone(), compiled_predicate))
                 .ok_or_else(|| {
-                    handler.emit_err(Error::Compile {
-                        error: CompileError::Internal {
-                            msg: "predicate must exist in the compiled_predicates map",
-                            span: empty_span(),
-                        },
-                    })
+                    handler.emit_internal_err(
+                        "predicate must exist in the compiled_predicates map".to_string(),
+                        empty_span(),
+                    )
                 })
         })
         .collect::<Result<_, _>>()?;

--- a/pintc/src/error/compile_error.rs
+++ b/pintc/src/error/compile_error.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{ErrorLabel, ReportableError},
-    span::{empty_span, Span, Spanned},
+    span::{Span, Spanned},
 };
 use std::path::PathBuf;
 use thiserror::Error;
@@ -8,8 +8,6 @@ use yansi::Color;
 
 #[derive(Error, Debug)]
 pub enum CompileError {
-    #[error("compiler internal error: {msg}")]
-    Internal { msg: &'static str, span: Span },
     #[error("couldn't read {file}: {error}")]
     FileIO {
         error: std::io::Error,
@@ -1231,18 +1229,6 @@ impl ReportableError for CompileError {
                 color: Color::Red,
             }],
 
-            Internal { msg, span } => {
-                if span == &empty_span() {
-                    Vec::new()
-                } else {
-                    vec![ErrorLabel {
-                        message: msg.to_string(),
-                        span: span.clone(),
-                        color: Color::Red,
-                    }]
-                }
-            }
-
             FileIO { .. } => Vec::new(),
         }
     }
@@ -1369,8 +1355,7 @@ impl ReportableError for CompileError {
                     .to_string(),
             ),
 
-            Internal { .. }
-            | FileIO { .. }
+            FileIO { .. }
             | MacroNotFound { .. }
             | MacroUndefinedParam { .. }
             | SymbolNotFound { .. }
@@ -1575,7 +1560,6 @@ impl Spanned for CompileError {
         use CompileError::*;
         match self {
             FileIO { span, .. }
-            | Internal { span, .. }
             | DualModulity { span, .. }
             | NoFileFoundForPath { span, .. }
             | MacroDeclClash { span, .. }

--- a/pintc/src/error/handler.rs
+++ b/pintc/src/error/handler.rs
@@ -1,4 +1,4 @@
-use crate::{error::Error, warning::Warning};
+use crate::{error::Error, span::Span, warning::Warning};
 use core::cell::RefCell;
 
 /// A handler with which you can emit diagnostics.
@@ -23,6 +23,10 @@ impl Handler {
     pub fn emit_err(&self, err: Error) -> ErrorEmitted {
         self.inner.borrow_mut().errors.push(err);
         ErrorEmitted { _priv: () }
+    }
+
+    pub fn emit_internal_err(&self, msg: String, span: Span) -> ErrorEmitted {
+        self.emit_err(Error::Internal { msg, span })
     }
 
     /// Emit the warning `warn`.

--- a/pintc/src/expr/evaluate.rs
+++ b/pintc/src/expr/evaluate.rs
@@ -131,12 +131,10 @@ impl Evaluator {
                     (Imm::Real(expr), UnaryOp::Neg) => Ok(Imm::Real(-expr)),
                     (Imm::Int(expr), UnaryOp::Neg) => Ok(Imm::Int(-expr)),
                     (Imm::Bool(expr), UnaryOp::Not) => Ok(Imm::Bool(!expr)),
-                    _ => Err(handler.emit_err(Error::Compile {
-                        error: CompileError::Internal {
-                            msg: "type error: invalid unary op for expression",
-                            span: empty_span(),
-                        },
-                    })),
+                    _ => Err(handler.emit_internal_err(
+                        "type error: invalid unary op for expression".to_string(),
+                        empty_span(),
+                    )),
                 }
             }
 
@@ -160,12 +158,10 @@ impl Evaluator {
                         BinOp::GreaterThan => Ok(Imm::Bool(lhs > rhs)),
                         BinOp::GreaterThanOrEqual => Ok(Imm::Bool(lhs >= rhs)),
 
-                        _ => Err(handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "type error: invalid binary op for reals",
-                                span: empty_span(),
-                            },
-                        })),
+                        _ => Err(handler.emit_internal_err(
+                            "type error: invalid binary op for reals".to_string(),
+                            empty_span(),
+                        )),
                     },
 
                     (Imm::Int(lhs), Imm::Int(rhs)) => match op {
@@ -184,12 +180,10 @@ impl Evaluator {
                         BinOp::GreaterThan => Ok(Imm::Bool(lhs > rhs)),
                         BinOp::GreaterThanOrEqual => Ok(Imm::Bool(lhs >= rhs)),
 
-                        _ => Err(handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "type error: invalid binary op for ints",
-                                span: empty_span(),
-                            },
-                        })),
+                        _ => Err(handler.emit_internal_err(
+                            "type error: invalid binary op for ints".to_string(),
+                            empty_span(),
+                        )),
                     },
 
                     (Imm::Bool(lhs), Imm::Bool(rhs)) => match op {
@@ -205,12 +199,10 @@ impl Evaluator {
                         BinOp::LogicalAnd => Ok(Imm::Bool(lhs && rhs)),
                         BinOp::LogicalOr => Ok(Imm::Bool(lhs || rhs)),
 
-                        _ => Err(handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "type error: invalid binary op for bools",
-                                span: empty_span(),
-                            },
-                        })),
+                        _ => Err(handler.emit_internal_err(
+                            "type error: invalid binary op for bools".to_string(),
+                            empty_span(),
+                        )),
                     },
 
                     (Imm::B256(lhs), Imm::B256(rhs)) => match op {
@@ -218,21 +210,18 @@ impl Evaluator {
                         BinOp::Equal => Ok(Imm::Bool(lhs == rhs)),
                         BinOp::NotEqual => Ok(Imm::Bool(lhs != rhs)),
 
-                        _ => Err(handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "type error: invalid binary op for B256",
-                                span: empty_span(),
-                            },
-                        })),
+                        _ => Err(handler.emit_internal_err(
+                            "type error: invalid binary op for B256".to_string(),
+                            empty_span(),
+                        )),
                     },
 
-                    _ => Err(handler.emit_err(Error::Compile {
-                        error: CompileError::Internal {
-                            msg: "compile-time evaluation binary op between some types \
-                              not currently supported",
-                            span: empty_span(),
-                        },
-                    })),
+                    _ => Err(handler.emit_internal_err(
+                        "compile-time evaluation binary op between some types \
+                              not currently supported"
+                            .to_string(),
+                        empty_span(),
+                    )),
                 }
             }
 
@@ -430,12 +419,10 @@ impl Evaluator {
                     .iter()
                     .find(|(_, union)| union.name.name == ty_path)
                     .ok_or_else(|| {
-                        handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "Union decl for variant not found",
-                                span: path_span.clone(),
-                            },
-                        })
+                        handler.emit_internal_err(
+                            "Union decl for variant not found".to_string(),
+                            path_span.clone(),
+                        )
                     })?;
 
                 let union_ty = Type::Union {
@@ -449,12 +436,10 @@ impl Evaluator {
                     .enumerate()
                     .find_map(|(idx, variant_name)| (variant_name == path[2..]).then_some(idx))
                     .ok_or_else(|| {
-                        handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "Union tag not found in union decl",
-                                span: empty_span(),
-                            },
-                        })
+                        handler.emit_internal_err(
+                            "Union tag not found in union decl".to_string(),
+                            empty_span(),
+                        )
                     })? as i64;
 
                 let value = value
@@ -477,13 +462,12 @@ impl Evaluator {
                     if let Imm::UnionVariant { tag_num, .. } = imm {
                         Ok(Imm::Int(tag_num))
                     } else {
-                        Err(handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "unexpected expression during compile-time \
-                                    evaluation of union expr (tag)",
-                                span: span.clone(),
-                            },
-                        }))
+                        Err(handler.emit_internal_err(
+                            "unexpected expression during compile-time \
+                                    evaluation of union expr (tag)"
+                                .to_string(),
+                            span.clone(),
+                        ))
                     }
                 }),
 
@@ -499,13 +483,12 @@ impl Evaluator {
                     {
                         Ok(imm_val.as_ref().clone())
                     } else {
-                        Err(handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "unexpected expression during compile-time \
-                                    evaluation of union expr (value)",
-                                span: span.clone(),
-                            },
-                        }))
+                        Err(handler.emit_internal_err(
+                            "unexpected expression during compile-time \
+                                    evaluation of union expr (value)"
+                                .to_string(),
+                            span.clone(),
+                        ))
                     }
                 }),
 
@@ -527,13 +510,12 @@ impl Evaluator {
                             Ok(Imm::Bool(ub >= value && lb <= value))
                         }
 
-                        _ => Err(handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "unexpected expression during compile-time evaluation \
-                            evaluation of in expr with range",
-                                span: empty_span(),
-                            },
-                        })),
+                        _ => Err(handler.emit_internal_err(
+                            "unexpected expression during compile-time evaluation \
+                            evaluation of in expr with range"
+                                .to_string(),
+                            empty_span(),
+                        )),
                     }
                 } else {
                     let collection = self.evaluate_key(collection, handler, contract)?;
@@ -541,13 +523,12 @@ impl Evaluator {
                     match collection {
                         Imm::Array(collection) => Ok(Imm::Bool(collection.contains(&value))),
 
-                        _ => Err(handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "unexpected expression during compile-time evaluation \
-                            evaluation of in expr",
-                                span: empty_span(),
-                            },
-                        })),
+                        _ => Err(handler.emit_internal_err(
+                            "unexpected expression during compile-time evaluation \
+                            evaluation of in expr"
+                                .to_string(),
+                            empty_span(),
+                        )),
                     }
                 }
             }
@@ -561,12 +542,10 @@ impl Evaluator {
             | Expr::ExternalPredicateCall { .. }
             | Expr::Range { .. }
             | Expr::Generator { .. }
-            | Expr::Match { .. } => Err(handler.emit_err(Error::Compile {
-                error: CompileError::Internal {
-                    msg: "unexpected expression during compile-time evaluation",
-                    span: empty_span(),
-                },
-            })),
+            | Expr::Match { .. } => Err(handler.emit_internal_err(
+                "unexpected expression during compile-time evaluation".to_string(),
+                empty_span(),
+            )),
         }
     }
 }

--- a/pintc/src/macros.rs
+++ b/pintc/src/macros.rs
@@ -176,12 +176,10 @@ pub(crate) fn splice_args(
                     });
                 }
             } else {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "type is array but failed to get range expr.",
-                        span: Span::new(call.span.context(), range),
-                    },
-                });
+                handler.emit_internal_err(
+                    "type is array but failed to get range expr.".to_string(),
+                    Span::new(call.span.context(), range),
+                );
             }
         } else {
             handler.emit_err(Error::Compile {

--- a/pintc/src/parser.rs
+++ b/pintc/src/parser.rs
@@ -198,12 +198,8 @@ impl<'a> ProjectParser<'a> {
 
             // If the loop has gone for too long then there's an internal error. Arbitrary limit...
             if loop_count > 10_000 {
-                self.handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "Infinite loop in project parser",
-                        span: empty_span(),
-                    },
-                });
+                self.handler
+                    .emit_internal_err("Infinite loop in project parser".to_string(), empty_span());
                 return self;
             }
         }

--- a/pintc/src/predicate/analyse.rs
+++ b/pintc/src/predicate/analyse.rs
@@ -129,15 +129,6 @@ impl Contract {
             return Err(handler.cancel());
         }
 
-        let emit_internal = |msg| {
-            handler.emit_err(Error::Compile {
-                error: CompileError::Internal {
-                    msg,
-                    span: empty_span(),
-                },
-            })
-        };
-
         // For each of the newly evaluated intialisers we need to update the expressions in the
         // consts map.
         let all_const_immediates = evaluator.into_values();
@@ -159,10 +150,16 @@ impl Contract {
                 if let Some(cnst) = self.consts.get_mut(&new_path) {
                     cnst.expr = new_expr_key;
                 } else {
-                    emit_internal("missing const decl for immediate update");
+                    handler.emit_internal_err(
+                        "missing const decl for immediate update".to_string(),
+                        empty_span(),
+                    );
                 }
             } else {
-                emit_internal("missing immediate value for const expr update");
+                handler.emit_internal_err(
+                    "missing immediate value for const expr update".to_string(),
+                    empty_span(),
+                );
             }
         }
 
@@ -180,11 +177,17 @@ impl Contract {
                         | Inference::Dependant(_)
                         | Inference::Dependencies(_)
                         | Inference::BoundDependencies { .. } => {
-                            emit_internal("const inferred a dependant type");
+                            handler.emit_internal_err(
+                                "const inferred a dependant type".to_string(),
+                                empty_span(),
+                            );
                         }
                     }
                 } else {
-                    emit_internal("missing immediate value for const decl_ty update");
+                    handler.emit_internal_err(
+                        "missing immediate value for const decl_ty update".to_string(),
+                        empty_span(),
+                    );
                 }
             }
         }

--- a/pintc/src/predicate/analyse/type_check/check_exprs.rs
+++ b/pintc/src/predicate/analyse/type_check/check_exprs.rs
@@ -121,21 +121,17 @@ impl Contract {
         expr_key: ExprKey,
     ) -> Result<Inference, ErrorEmitted> {
         let expr: &Expr = expr_key.try_get(self).ok_or_else(|| {
-            handler.emit_err(Error::Compile {
-                error: CompileError::Internal {
-                    msg: "orphaned expr key when type checking",
-                    span: empty_span(),
-                },
-            })
+            handler.emit_internal_err(
+                "orphaned expr key when type checking".to_string(),
+                empty_span(),
+            )
         })?;
 
         match expr {
-            Expr::Error(span) => Err(handler.emit_err(Error::Compile {
-                error: CompileError::Internal {
-                    msg: "unable to type check from error expression",
-                    span: span.clone(),
-                },
-            })),
+            Expr::Error(span) => Err(handler.emit_internal_err(
+                "unable to type check from error expression".to_string(),
+                span.clone(),
+            )),
 
             Expr::Immediate { value, span } => Ok(self.infer_immediate(handler, value, span)),
 
@@ -247,14 +243,10 @@ impl Contract {
                 span,
             } => Ok(self.infer_generator_expr(handler, kind, gen_ranges, conditions, *body, span)),
 
-            Expr::UnionTag { .. } | Expr::UnionValue { .. } => {
-                Err(handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "union utility expressions should not exist during type checking",
-                        span: empty_span(),
-                    },
-                }))
-            }
+            Expr::UnionTag { .. } | Expr::UnionValue { .. } => Err(handler.emit_internal_err(
+                "union utility expressions should not exist during type checking".to_string(),
+                empty_span(),
+            )),
         }
 
         // TODO return err if handler is non-empty?
@@ -279,12 +271,10 @@ impl Contract {
             // Get the assumed type.
             let ary_ty = imm.get_ty(Some(span));
             let Type::Array { ty: el0_ty, .. } = &ary_ty else {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "array immediate does NOT have an array type?",
-                        span: span.clone(),
-                    },
-                });
+                handler.emit_internal_err(
+                    "array immediate does NOT have an array type?".to_string(),
+                    span.clone(),
+                );
                 return Inference::Type(Type::Error(span.clone()));
             };
 
@@ -444,12 +434,10 @@ impl Contract {
 
         match op {
             UnaryOp::Error => {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "unable to type check unary op error",
-                        span: span.clone(),
-                    },
-                });
+                handler.emit_internal_err(
+                    "unable to type check unary op error".to_string(),
+                    span.clone(),
+                );
                 Inference::Type(Type::Error(span.clone()))
             }
 
@@ -1308,12 +1296,10 @@ impl Contract {
                         span: span.clone(),
                     })
                 } else {
-                    handler.emit_err(Error::Compile {
-                        error: CompileError::Internal {
-                            msg: "range ty is not numeric or array?",
-                            span: span.clone(),
-                        },
-                    });
+                    handler.emit_internal_err(
+                        "range ty is not numeric or array?".to_string(),
+                        span.clone(),
+                    );
                     Inference::Type(Type::Error(span.clone()))
                 }
             } else {
@@ -1428,12 +1414,10 @@ impl Contract {
             if let Some(el_ty) = ary_ty.get_array_el_type() {
                 Inference::Type(el_ty.clone())
             } else {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "failed to get array element type in infer_index_expr()",
-                        span: span.clone(),
-                    },
-                });
+                handler.emit_internal_err(
+                    "failed to get array element type in infer_index_expr()".to_string(),
+                    span.clone(),
+                );
 
                 Inference::Type(Type::Error(span.clone()))
             }
@@ -1455,13 +1439,12 @@ impl Contract {
             } else if let Some(to_ty) = ary_ty.get_map_ty_to() {
                 Inference::Type(to_ty.clone())
             } else {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "failed to get array element type \
-                          in infer_index_expr()",
-                        span: span.clone(),
-                    },
-                });
+                handler.emit_internal_err(
+                    "failed to get array element type \
+                          in infer_index_expr()"
+                        .to_string(),
+                    span.clone(),
+                );
 
                 Inference::Type(Type::Error(span.clone()))
             }
@@ -1524,12 +1507,10 @@ impl Contract {
             if tuple_ty.is_tuple() {
                 match field {
                     TupleAccess::Error => {
-                        handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "unable to type check tuple field access error",
-                                span: span.clone(),
-                            },
-                        });
+                        handler.emit_internal_err(
+                            "unable to type check tuple field access error".to_string(),
+                            span.clone(),
+                        );
                         Inference::Type(Type::Error(span.clone()))
                     }
 

--- a/pintc/src/predicate/analyse/type_check/check_paths.rs
+++ b/pintc/src/predicate/analyse/type_check/check_paths.rs
@@ -22,12 +22,10 @@ impl Contract {
             if !decl_ty.is_unknown() {
                 Inference::Type(decl_ty.clone())
             } else {
-                handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "const decl has unknown type *after* evaluation",
-                        span: span.clone(),
-                    },
-                });
+                handler.emit_internal_err(
+                    "const decl has unknown type *after* evaluation".to_string(),
+                    span.clone(),
+                );
                 Inference::Type(Type::Error(span.clone()))
             }
         } else if let Some(ty) = self
@@ -92,12 +90,10 @@ impl Contract {
                         Inference::Type(Type::Error(span.clone()))
                     }
                 } else {
-                    handler.emit_err(Error::Compile {
-                        error: CompileError::Internal {
-                            msg: "attempting to infer item without required predicate ref",
-                            span: span.clone(),
-                        },
-                    });
+                    handler.emit_internal_err(
+                        "attempting to infer item without required predicate ref".to_string(),
+                        span.clone(),
+                    );
                     Inference::Type(Type::Error(span.clone()))
                 }
             }

--- a/pintc/src/predicate/analyse/type_check/custom_types.rs
+++ b/pintc/src/predicate/analyse/type_check/custom_types.rs
@@ -122,12 +122,10 @@ impl Contract {
             }
 
             if loop_check > 10_000 {
-                return Err(handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "infinite loop in lower_nested_newtypes()",
-                        span: empty_span(),
-                    },
-                }));
+                return Err(handler.emit_internal_err(
+                    "infinite loop in lower_nested_newtypes()".to_string(),
+                    empty_span(),
+                ));
             }
         }
 

--- a/pintc/src/predicate/optimize/const_folding.rs
+++ b/pintc/src/predicate/optimize/const_folding.rs
@@ -1,7 +1,7 @@
 use fxhash::FxHashMap;
 
 use crate::{
-    error::{CompileError, Error, Handler},
+    error::Handler,
     expr::{evaluate::Evaluator, BinaryOp, Expr, Immediate, UnaryOp},
     predicate::{Contract, ExprKey},
     span::{empty_span, Spanned},
@@ -21,12 +21,7 @@ pub(crate) fn const_folding(handler: &Handler, contract: &mut Contract) {
 
         // If the loop has gone for too long then there's an internal error. Arbitrary limit...
         if loop_count > 10_000 {
-            handler.emit_err(Error::Compile {
-                error: CompileError::Internal {
-                    msg: "Infinite loop in const_folding",
-                    span: empty_span(),
-                },
-            });
+            handler.emit_internal_err("Infinite loop in const_folding".to_string(), empty_span());
             break;
         }
     }

--- a/pintc/src/predicate/transform/lower/lower_storage_accesses.rs
+++ b/pintc/src/predicate/transform/lower/lower_storage_accesses.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{CompileError, Error, ErrorEmitted, Handler},
+    error::{ErrorEmitted, Handler},
     expr::{BinaryOp, Expr, ExternalIntrinsic, InternalIntrinsic, IntrinsicKind, TupleAccess},
     predicate::{ConstraintDecl, Contract, ExprKey, PredKey},
     span::empty_span,
@@ -254,12 +254,10 @@ fn get_base_storage_key(
                 match args[0].try_get(contract) {
                     Some(Expr::LocalStorageAccess { name, .. }) => {
                         if !contract.storage_var(name).1.ty.is_vector() {
-                            return Err(handler.emit_err(Error::Compile {
-                                error: CompileError::Internal {
-                                    msg: "argument to __vec_len must be of type storage vector",
-                                    span: empty_span(),
-                                },
-                            }));
+                            return Err(handler.emit_internal_err(
+                                "argument to __vec_len must be of type storage vector".to_string(),
+                                empty_span(),
+                            ));
                         }
                     }
                     Some(Expr::ExternalStorageAccess {
@@ -271,32 +269,24 @@ fn get_base_storage_key(
                             .ty
                             .is_vector()
                         {
-                            return Err(handler.emit_err(Error::Compile {
-                                error: CompileError::Internal {
-                                    msg: "argument to __vec_len must be of type storage vector",
-                                    span: empty_span(),
-                                },
-                            }));
+                            return Err(handler.emit_internal_err(
+                                "argument to __vec_len must be of type storage vector".to_string(),
+                                empty_span(),
+                            ));
                         }
                     }
                     _ => {
-                        return Err(handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "argument to __vec_len must be storage access",
-                                span: empty_span(),
-                            },
-                        }));
+                        return Err(handler.emit_internal_err(
+                            "argument to __vec_len must be storage access".to_string(),
+                            empty_span(),
+                        ));
                     }
                 };
 
                 get_base_storage_key(handler, &args[0], contract)
             } else {
-                Err(handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "Invalid storage intrinsic",
-                        span: empty_span(),
-                    },
-                }))
+                Err(handler
+                    .emit_internal_err("Invalid storage intrinsic".to_string(), empty_span()))
             }
         }
         Expr::LocalStorageAccess { name, mutable, .. } => {
@@ -366,12 +356,10 @@ fn get_base_storage_key(
                 }
             } else {
                 let Type::Array { ty, .. } = expr.get_ty(contract) else {
-                    return Err(handler.emit_err(Error::Compile {
-                        error: CompileError::Internal {
-                            msg: "type must exist and be an array type",
-                            span: empty_span(),
-                        },
-                    }));
+                    return Err(handler.emit_internal_err(
+                        "type must exist and be an array type".to_string(),
+                        empty_span(),
+                    ));
                 };
 
                 // Increment the last element of the key by `index * array element size`
@@ -407,12 +395,10 @@ fn get_base_storage_key(
 
             // Grab the fields of the tuple
             let Type::Tuple { ref fields, .. } = tuple.get_ty(contract) else {
-                return Err(handler.emit_err(Error::Compile {
-                    error: CompileError::Internal {
-                        msg: "type must exist and be a tuple type",
-                        span: empty_span(),
-                    },
-                }));
+                return Err(handler.emit_internal_err(
+                    "type must exist and be a tuple type".to_string(),
+                    empty_span(),
+                ));
             };
 
             // The field index is based on the type definition
@@ -427,12 +413,10 @@ fn get_base_storage_key(
                     })
                     .expect("field name must exist, this was checked in type checking"),
                 TupleAccess::Error => {
-                    return Err(handler.emit_err(Error::Compile {
-                        error: CompileError::Internal {
-                            msg: "unexpected TupleAccess::Error",
-                            span: empty_span(),
-                        },
-                    }))
+                    return Err(handler.emit_internal_err(
+                        "unexpected TupleAccess::Error".to_string(),
+                        empty_span(),
+                    ))
                 }
             };
 
@@ -458,11 +442,9 @@ fn get_base_storage_key(
             Ok((addr, mutable, key))
         }
 
-        _ => Err(handler.emit_err(Error::Compile {
-            error: CompileError::Internal {
-                msg: "unexpected expression in a storage access expression",
-                span: empty_span(),
-            },
-        })),
+        _ => Err(handler.emit_internal_err(
+            "unexpected expression in a storage access expression".to_string(),
+            empty_span(),
+        )),
     }
 }

--- a/pintc/src/predicate/transform/unroll.rs
+++ b/pintc/src/predicate/transform/unroll.rs
@@ -174,12 +174,10 @@ fn unroll_generator(
                     }
                     Immediate::Bool(true) => {}
                     _ => {
-                        return Err(handler.emit_err(Error::Compile {
-                            error: CompileError::Internal {
-                                msg: "type error: boolean expression expected",
-                                span: empty_span(),
-                            },
-                        }))
+                        return Err(handler.emit_internal_err(
+                            "type error: boolean expression expected".to_string(),
+                            empty_span(),
+                        ))
                     }
                 }
             }

--- a/pintc/src/types.rs
+++ b/pintc/src/types.rs
@@ -579,12 +579,10 @@ impl Type {
             | Self::Unknown(span)
             | Self::Any(span)
             | Self::Custom { span, .. }
-            | Self::Alias { span, .. } => Err(handler.emit_err(Error::Compile {
-                error: CompileError::Internal {
-                    msg: "unexpected type when getting size",
-                    span: span.clone(),
-                },
-            })),
+            | Self::Alias { span, .. } => Err(handler.emit_internal_err(
+                "unexpected type when getting size".to_string(),
+                span.clone(),
+            )),
         }
     }
 
@@ -642,12 +640,10 @@ impl Type {
             | Self::Unknown(span)
             | Self::Any(span)
             | Self::Custom { span, .. }
-            | Self::Alias { span, .. } => Err(handler.emit_err(Error::Compile {
-                error: CompileError::Internal {
-                    msg: "unexpected type when calculating storage slots",
-                    span: span.clone(),
-                },
-            })),
+            | Self::Alias { span, .. } => Err(handler.emit_internal_err(
+                "unexpected type when calculating storage slots".to_string(),
+                span.clone(),
+            )),
         }
     }
 


### PR DESCRIPTION
Closes #829 (the part about asm gen `asserts` is no longer relevant since there are no more asserts there but I removed a few other things that could panic)
* Move `Internal` to `Error` instead of `CompileError`. 
* Add `emit_internal_err` to `Handler`