### PR TITLE
Add most of fixed size array map morphisms.

### DIFF
--- a/pint-abi-gen-tests/test-pkgs/unions/src/contract.pnt
+++ b/pint-abi-gen-tests/test-pkgs/unions/src/contract.pnt
@@ -16,7 +16,7 @@ storage {
     oo: lib3::foo::OO,
     array: RR[2],
     tuple: { lib2::A, lib3::foo::TT },
-    map: ( b256 => WW ),
+    bmap: ( b256 => WW ),
 }
 
 predicate Foo(
@@ -63,9 +63,9 @@ predicate Foo(
     let array = mut storage::array;
     let tuple = mut storage::tuple;
     let map_1 = mut
-    storage::map[0x2222222222222222222222222222222222222222222222222222222222222222];
+    storage::bmap[0x2222222222222222222222222222222222222222222222222222222222222222];
     let map_2 = mut
-    storage::map[0x3333333333333333333333333333333333333333333333333333333333333333];
+    storage::bmap[0x3333333333333333333333333333333333333333333333333333333333333333];
 
     constraint u1' == UU::A(69);
     constraint u2' == UU::B;

--- a/pint-abi-gen-tests/tests/unions.rs
+++ b/pint-abi-gen-tests/tests/unions.rs
@@ -79,8 +79,8 @@ async fn test_solution_foo() {
                 .entry(1, unions::RR::A(unions::lib::PP::T(unions::lib::QQ::M)))
         })
         .tuple(|tup| tup._0(unions::lib2::A::B)._1(unions::lib3::foo::TT::A))
-        .map(|map| map.entry([0x2222222222222222; 4], unions::WW::D))
-        .map(|map| map.entry([0x3333333333333333; 4], unions::WW::E(unions::UU::A(55))))
+        .bmap(|bmap| bmap.entry([0x2222222222222222; 4], unions::WW::D))
+        .bmap(|bmap| bmap.entry([0x3333333333333333; 4], unions::WW::E(unions::UU::A(55))))
         .into();
 
     // Build the same set of keys, so we can ensure they match the mutations.
@@ -98,8 +98,8 @@ async fn test_solution_foo() {
         .oo()
         .array(|arr| arr.entry(0).entry(1))
         .tuple(|tup| tup._0()._1())
-        .map(|map| map.entry([0x2222222222222222; 4]))
-        .map(|map| map.entry([0x3333333333333333; 4]))
+        .bmap(|bmap| bmap.entry([0x2222222222222222; 4]))
+        .bmap(|bmap| bmap.entry([0x3333333333333333; 4]))
         .into();
 
     // Check keys match the mutation keys.

--- a/pintc/src/asm_gen.rs
+++ b/pintc/src/asm_gen.rs
@@ -1,15 +1,13 @@
-use std::collections::HashMap;
-
 use crate::{
     error::{CompileError, Error, ErrorEmitted, Handler},
     expr::{Expr, ExternalIntrinsic, Immediate, IntrinsicKind},
     predicate::{ConstraintDecl, Contract, Predicate},
     span::{empty_span, Span},
 };
+
 use asm_builder::AsmBuilder;
 use essential_types::{predicate::Predicate as CompiledPredicate, ContentAddress};
-use fxhash::FxHashMap;
-use fxhash::FxHashSet;
+use fxhash::{FxHashMap, FxHashSet};
 use petgraph::{graph::NodeIndex, Graph};
 
 mod asm_builder;
@@ -80,7 +78,7 @@ pub fn compile_contract(
     // addresses that are required by other predicates are known in time.
     let Ok(sorted_nodes) = petgraph::algo::toposort(&dep_graph, None) else {
         return Err(handler.emit_internal_err(
-            "dependency cycles between predicates should have been caught before".to_string(),
+            "dependency cycles between predicates should have been caught before",
             empty_span(),
         ));
     };
@@ -156,7 +154,7 @@ pub fn compile_contract(
                 .map(|(compiled_predicate, _, _)| (pred.name.name.clone(), compiled_predicate))
                 .ok_or_else(|| {
                     handler.emit_internal_err(
-                        "predicate must exist in the compiled_predicates map".to_string(),
+                        "predicate must exist in the compiled_predicates map",
                         empty_span(),
                     )
                 })
@@ -182,7 +180,7 @@ pub fn compile_predicate(
     compiled_predicates: &FxHashMap<String, (CompiledPredicate, ContentAddress, Span)>,
     pred: &Predicate,
 ) -> Result<CompiledPredicate, ErrorEmitted> {
-    let no_span_predicates: HashMap<String, (CompiledPredicate, ContentAddress)> =
+    let no_span_predicates: FxHashMap<String, (CompiledPredicate, ContentAddress)> =
         compiled_predicates
             .iter()
             .map(|(k, (compiled_predicate, content_address, _span))| {

--- a/pintc/src/asm_gen/tests.rs
+++ b/pintc/src/asm_gen/tests.rs
@@ -233,8 +233,8 @@ fn select() {
             compile(
                 r#"
             predicate test(
-                c: bool, 
-                x: int, 
+                c: bool,
+                x: int,
                 y: int,
                 z: int,
             ) {
@@ -3186,22 +3186,22 @@ fn storage_external_access() {
 interface Extern1 {
     storage {
         x: int,
-        map: (int => (bool => b256)),
+        m: (int => (bool => b256)),
     }
 }
 
 interface Extern2 {
     storage {
         w: int,
-        map: (b256 => (int => bool)),
+        m: (b256 => (int => bool)),
     }
 }
 
 predicate Foo() {
     let x = Extern1@[0x1233683A8F6B8AF1707FF76F40FC5EE714872F88FAEBB8F22851E93F56770128]::storage::x;
-    let y = Extern1@[0x1233683A8F6B8AF1707FF76F40FC5EE714872F88FAEBB8F22851E93F56770128]::storage::map[3][true];
+    let y = Extern1@[0x1233683A8F6B8AF1707FF76F40FC5EE714872F88FAEBB8F22851E93F56770128]::storage::m[3][true];
     let w = Extern2@[0x0C15A3534349FC710174299BA8F0347284955B35A28C01CF45A910495FA1EF2D]::storage::w;
-    let z = Extern2@[0x0C15A3534349FC710174299BA8F0347284955B35A28C01CF45A910495FA1EF2D]::storage::map[0x1111111111111111111111111111111111111111111111111111111111111111][69];
+    let z = Extern2@[0x0C15A3534349FC710174299BA8F0347284955B35A28C01CF45A910495FA1EF2D]::storage::m[0x1111111111111111111111111111111111111111111111111111111111111111][69];
 
     constraint x' - x == 1;
     constraint y == 0x2222222222222222222222222222222222222222222222222222222222222222;
@@ -3760,3 +3760,95 @@ predicate test(k: int, l: outer, m: outer) {
         "#]],
     );
 }
+
+// Disabled until we implement program graphs and then do ASM gen for maps.
+//
+// #[test]
+// fn map_fixed_a() {
+//     check(
+//         &compile(
+//             r#"
+// predicate test(ary: int[10]) {
+//     let evens: int[10] = map x in ary {
+//         x % 2 == 1 ? x + 1 : x
+//     };
+// }
+// "#,
+//         )
+//         .to_string(),
+//         expect_test::expect![[r#"
+//             predicate ::test {
+//                 --- Constraints ---
+//                 constraint 0
+//                   Access(MutKeys)
+//                   Stack(Push(0))
+//                   Pred(EqSet)
+//                 --- State Reads ---
+//             }
+//
+//         "#]],
+//     );
+// }
+//
+// #[test]
+// fn map_fixed_b() {
+//     check(
+//         &compile(
+//             r#"
+// predicate test(ary: int[10]) {
+//     let evens: int[10] = map x in ary {
+//         x % 2 == 1 ? x + 1 : x
+//     };
+//
+//     constraint evens[4] + evens[0] == 10;
+// }
+// "#,
+//         )
+//         .to_string(),
+//         expect_test::expect![[r#"
+//         "#]],
+//     );
+// }
+//
+// #[test]
+// fn map_fixed_c() {
+//     check(
+//         &compile(
+//             r#"
+// predicate test(ary: int[10]) {
+//     let zero_map: bool[10] = map y in ary { y == 0 };
+// }
+// "#,
+//         )
+//         .to_string(),
+//         expect_test::expect![[r#"
+//             predicate ::test {
+//                 --- Constraints ---
+//                 constraint 0
+//                   Access(MutKeys)
+//                   Stack(Push(0))
+//                   Pred(EqSet)
+//                 --- State Reads ---
+//             }
+//
+//         "#]],
+//     );
+// }
+//
+// #[test]
+// fn map_fixed_d() {
+//     check(
+//         &compile(
+//             r#"
+// predicate test(ary: int[10]) {
+//     let zero_map: bool[10] = map y in ary { y == 0 };
+//
+//     constraint !zero_map[3] && zero_map[7];
+// }
+// "#,
+//         )
+//         .to_string(),
+//         expect_test::expect![[r#"
+//         "#]],
+//     );
+// }

--- a/pintc/src/error/compile_error.rs
+++ b/pintc/src/error/compile_error.rs
@@ -379,6 +379,8 @@ pub enum CompileError {
         original_span: Span,
         span: Span,
     },
+    #[error("invalid map range type")]
+    InvalidMapRangeType { found_ty: String, span: Span },
 }
 
 // This is here purely at the suggestion of Clippy, who pointed out that these error variants are
@@ -1253,6 +1255,12 @@ impl ReportableError for CompileError {
                 },
             ],
 
+            InvalidMapRangeType { found_ty, span } => vec![ErrorLabel {
+                message: format!("expecting either array or range, found `{found_ty}`"),
+                span: span.clone(),
+                color: Color::Red,
+            }],
+
             FileIO { .. } => Vec::new(),
         }
     }
@@ -1445,7 +1453,8 @@ impl ReportableError for CompileError {
             | UnknownUnionVariant { .. }
             | SuperfluousUnionExprValue { .. }
             | MissingUnionExprValue { .. }
-            | UnionVariantTypeMismatch { .. } => None,
+            | UnionVariantTypeMismatch { .. }
+            | InvalidMapRangeType { .. } => None,
         }
     }
 
@@ -1670,7 +1679,8 @@ impl Spanned for CompileError {
             | UnionVariantTypeMismatch { span, .. }
             | OperatorInvalidType { span, .. }
             | InvalidStorageAccess { span, .. }
-            | IdenticalPredicates { span, .. } => span,
+            | IdenticalPredicates { span, .. }
+            | InvalidMapRangeType { span, .. } => span,
 
             DependencyCycle { spans } => &spans[0],
 

--- a/pintc/src/error/handler.rs
+++ b/pintc/src/error/handler.rs
@@ -25,8 +25,11 @@ impl Handler {
         ErrorEmitted { _priv: () }
     }
 
-    pub fn emit_internal_err(&self, msg: String, span: Span) -> ErrorEmitted {
-        self.emit_err(Error::Internal { msg, span })
+    pub fn emit_internal_err<S: Into<String>>(&self, msg: S, span: Span) -> ErrorEmitted {
+        self.emit_err(Error::Internal {
+            msg: msg.into(),
+            span,
+        })
     }
 
     /// Emit the warning `warn`.

--- a/pintc/src/expr.rs
+++ b/pintc/src/expr.rs
@@ -123,6 +123,12 @@ pub enum Expr {
         body: ExprKey,
         span: Span,
     },
+    Map {
+        param: Ident,
+        range: ExprKey,
+        body: ExprKey,
+        span: Span,
+    },
     UnionTag {
         union_expr: ExprKey,
         span: Span,
@@ -327,6 +333,7 @@ impl Spanned for Expr {
             | Expr::In { span, .. }
             | Expr::Generator { span, .. }
             | Expr::Range { span, .. }
+            | Expr::Map { span, .. }
             | Expr::UnionTag { span, .. }
             | Expr::UnionValue { span, .. } => span,
         }
@@ -437,6 +444,11 @@ impl Expr {
             } => {
                 gen_ranges.iter_mut().for_each(|(_, expr)| replace(expr));
                 conditions.iter_mut().for_each(&mut replace);
+                replace(body);
+            }
+
+            Expr::Map { range, body, .. } => {
+                replace(range);
                 replace(body);
             }
 

--- a/pintc/src/expr/display.rs
+++ b/pintc/src/expr/display.rs
@@ -1,7 +1,6 @@
 use std::fmt::{Display, Formatter, Result};
 
 use crate::{
-    expr,
     predicate::{Contract, DisplayWithContract},
     util::{write_many_iter, write_many_with_ctrct},
 };
@@ -71,14 +70,14 @@ impl DisplayWithContract for &super::Expr {
             ),
 
             super::Expr::UnaryOp { op, expr, .. } => {
-                if matches!(op, expr::UnaryOp::NextState) {
+                if matches!(op, super::UnaryOp::NextState) {
                     write!(f, "{}'", contract.with_ctrct(expr))
                 } else {
                     match op {
-                        expr::UnaryOp::Error => write!(f, "error"),
-                        expr::UnaryOp::Neg => write!(f, "-"),
-                        expr::UnaryOp::Not => write!(f, "!"),
-                        expr::UnaryOp::NextState => unreachable!(),
+                        super::UnaryOp::Error => write!(f, "error"),
+                        super::UnaryOp::Neg => write!(f, "-"),
+                        super::UnaryOp::Not => write!(f, "!"),
+                        super::UnaryOp::NextState => unreachable!(),
                     }?;
                     expr.fmt(f, contract)
                 }
@@ -239,11 +238,22 @@ impl DisplayWithContract for &super::Expr {
                 write!(f, " {{ {} }}", contract.with_ctrct(body))
             }
 
-            expr::Expr::UnionTag { union_expr, .. } => {
+            super::Expr::Map {
+                param, range, body, ..
+            } => {
+                write!(
+                    f,
+                    "map {param} in {} {{ {} }}",
+                    contract.with_ctrct(range),
+                    contract.with_ctrct(body)
+                )
+            }
+
+            super::Expr::UnionTag { union_expr, .. } => {
                 write!(f, "UnTag({})", contract.with_ctrct(union_expr))
             }
 
-            expr::Expr::UnionValue {
+            super::Expr::UnionValue {
                 union_expr,
                 variant_ty,
                 ..
@@ -328,19 +338,19 @@ impl Display for super::Ident {
 impl Display for super::BinaryOp {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
-            expr::BinaryOp::Add => write!(f, "+"),
-            expr::BinaryOp::Div => write!(f, "/"),
-            expr::BinaryOp::Equal => write!(f, "=="),
-            expr::BinaryOp::GreaterThanOrEqual => write!(f, ">="),
-            expr::BinaryOp::GreaterThan => write!(f, ">"),
-            expr::BinaryOp::LessThanOrEqual => write!(f, "<="),
-            expr::BinaryOp::LessThan => write!(f, "<"),
-            expr::BinaryOp::LogicalAnd => write!(f, "&&"),
-            expr::BinaryOp::LogicalOr => write!(f, "||"),
-            expr::BinaryOp::Mod => write!(f, "%"),
-            expr::BinaryOp::Mul => write!(f, "*"),
-            expr::BinaryOp::NotEqual => write!(f, "!="),
-            expr::BinaryOp::Sub => write!(f, "-"),
+            super::BinaryOp::Add => write!(f, "+"),
+            super::BinaryOp::Div => write!(f, "/"),
+            super::BinaryOp::Equal => write!(f, "=="),
+            super::BinaryOp::GreaterThanOrEqual => write!(f, ">="),
+            super::BinaryOp::GreaterThan => write!(f, ">"),
+            super::BinaryOp::LessThanOrEqual => write!(f, "<="),
+            super::BinaryOp::LessThan => write!(f, "<"),
+            super::BinaryOp::LogicalAnd => write!(f, "&&"),
+            super::BinaryOp::LogicalOr => write!(f, "||"),
+            super::BinaryOp::Mod => write!(f, "%"),
+            super::BinaryOp::Mul => write!(f, "*"),
+            super::BinaryOp::NotEqual => write!(f, "!="),
+            super::BinaryOp::Sub => write!(f, "-"),
         }
     }
 }

--- a/pintc/src/expr/evaluate.rs
+++ b/pintc/src/expr/evaluate.rs
@@ -132,7 +132,7 @@ impl Evaluator {
                     (Imm::Int(expr), UnaryOp::Neg) => Ok(Imm::Int(-expr)),
                     (Imm::Bool(expr), UnaryOp::Not) => Ok(Imm::Bool(!expr)),
                     _ => Err(handler.emit_internal_err(
-                        "type error: invalid unary op for expression".to_string(),
+                        "type error: invalid unary op for expression",
                         empty_span(),
                     )),
                 }
@@ -159,7 +159,7 @@ impl Evaluator {
                         BinOp::GreaterThanOrEqual => Ok(Imm::Bool(lhs >= rhs)),
 
                         _ => Err(handler.emit_internal_err(
-                            "type error: invalid binary op for reals".to_string(),
+                            "type error: invalid binary op for reals",
                             empty_span(),
                         )),
                     },
@@ -181,7 +181,7 @@ impl Evaluator {
                         BinOp::GreaterThanOrEqual => Ok(Imm::Bool(lhs >= rhs)),
 
                         _ => Err(handler.emit_internal_err(
-                            "type error: invalid binary op for ints".to_string(),
+                            "type error: invalid binary op for ints",
                             empty_span(),
                         )),
                     },
@@ -200,7 +200,7 @@ impl Evaluator {
                         BinOp::LogicalOr => Ok(Imm::Bool(lhs || rhs)),
 
                         _ => Err(handler.emit_internal_err(
-                            "type error: invalid binary op for bools".to_string(),
+                            "type error: invalid binary op for bools",
                             empty_span(),
                         )),
                     },
@@ -211,15 +211,14 @@ impl Evaluator {
                         BinOp::NotEqual => Ok(Imm::Bool(lhs != rhs)),
 
                         _ => Err(handler.emit_internal_err(
-                            "type error: invalid binary op for B256".to_string(),
+                            "type error: invalid binary op for B256",
                             empty_span(),
                         )),
                     },
 
                     _ => Err(handler.emit_internal_err(
                         "compile-time evaluation binary op between some types \
-                              not currently supported"
-                            .to_string(),
+                              not currently supported",
                         empty_span(),
                     )),
                 }
@@ -420,7 +419,7 @@ impl Evaluator {
                     .find(|(_, union)| union.name.name == ty_path)
                     .ok_or_else(|| {
                         handler.emit_internal_err(
-                            "Union decl for variant not found".to_string(),
+                            "Union decl for variant not found",
                             path_span.clone(),
                         )
                     })?;
@@ -436,10 +435,7 @@ impl Evaluator {
                     .enumerate()
                     .find_map(|(idx, variant_name)| (variant_name == path[2..]).then_some(idx))
                     .ok_or_else(|| {
-                        handler.emit_internal_err(
-                            "Union tag not found in union decl".to_string(),
-                            empty_span(),
-                        )
+                        handler.emit_internal_err("Union tag not found in union decl", empty_span())
                     })? as i64;
 
                 let value = value
@@ -464,8 +460,7 @@ impl Evaluator {
                     } else {
                         Err(handler.emit_internal_err(
                             "unexpected expression during compile-time \
-                                    evaluation of union expr (tag)"
-                                .to_string(),
+                                    evaluation of union expr (tag)",
                             span.clone(),
                         ))
                     }
@@ -485,8 +480,7 @@ impl Evaluator {
                     } else {
                         Err(handler.emit_internal_err(
                             "unexpected expression during compile-time \
-                                    evaluation of union expr (value)"
-                                .to_string(),
+                                    evaluation of union expr (value)",
                             span.clone(),
                         ))
                     }
@@ -512,8 +506,7 @@ impl Evaluator {
 
                         _ => Err(handler.emit_internal_err(
                             "unexpected expression during compile-time evaluation \
-                            evaluation of in expr with range"
-                                .to_string(),
+                            evaluation of in expr with range",
                             empty_span(),
                         )),
                     }
@@ -525,8 +518,7 @@ impl Evaluator {
 
                         _ => Err(handler.emit_internal_err(
                             "unexpected expression during compile-time evaluation \
-                            evaluation of in expr"
-                                .to_string(),
+                            evaluation of in expr",
                             empty_span(),
                         )),
                     }
@@ -542,8 +534,9 @@ impl Evaluator {
             | Expr::ExternalPredicateCall { .. }
             | Expr::Range { .. }
             | Expr::Generator { .. }
+            | Expr::Map { .. }
             | Expr::Match { .. } => Err(handler.emit_internal_err(
-                "unexpected expression during compile-time evaluation".to_string(),
+                "unexpected expression during compile-time evaluation",
                 empty_span(),
             )),
         }
@@ -782,6 +775,22 @@ impl ExprKey {
                     kind,
                     gen_ranges,
                     conditions,
+                    body,
+                    span,
+                }
+            }
+            Expr::Map {
+                param,
+                range,
+                body,
+                span,
+            } => {
+                let range = range.plug_in(contract, values_map);
+                let body = body.plug_in(contract, values_map);
+
+                Expr::Map {
+                    param,
+                    range,
                     body,
                     span,
                 }

--- a/pintc/src/lexer.rs
+++ b/pintc/src/lexer.rs
@@ -149,11 +149,17 @@ pub enum Token {
     #[token("in")]
     In,
 
-    // Generators
+    // Generators & Morphisms
     #[token("forall")]
     ForAll,
     #[token("exists")]
     Exists,
+    #[token("map")]
+    Map,
+    #[token("fold")]
+    Fold,
+    #[token("filter")]
+    Filter,
     #[token("where")]
     Where,
 
@@ -203,14 +209,16 @@ pub type MacroBody = Vec<(usize, Token, usize)>;
 #[cfg(test)]
 pub(super) static KEYWORDS: &[Token] = &[
     Token::As,
-    Token::Bool,
     Token::B256,
+    Token::Bool,
     Token::Cond,
     Token::Const,
     Token::Constraint,
     Token::Else,
     Token::Exists,
     Token::False,
+    Token::Filter,
+    Token::Fold,
     Token::ForAll,
     Token::If,
     Token::In,
@@ -218,6 +226,7 @@ pub(super) static KEYWORDS: &[Token] = &[
     Token::Interface,
     Token::Let,
     Token::Macro,
+    Token::Map,
     Token::Match,
     Token::Mut,
     Token::Nil,
@@ -330,6 +339,9 @@ impl fmt::Display for Token {
             Token::In => write!(f, "in"),
             Token::ForAll => write!(f, "forall"),
             Token::Exists => write!(f, "exists"),
+            Token::Map => write!(f, "map"),
+            Token::Fold => write!(f, "fold"),
+            Token::Filter => write!(f, "filter"),
             Token::Where => write!(f, "where"),
             Token::Ident((ident, _)) => write!(f, "{ident}"),
             Token::IntrinsicName(ident) => write!(f, "{ident}"),

--- a/pintc/src/lexer/tests.rs
+++ b/pintc/src/lexer/tests.rs
@@ -294,6 +294,13 @@ fn generators() {
 }
 
 #[test]
+fn morphisms() {
+    assert_eq!(lex_one_success("map"), Token::Map);
+    assert_eq!(lex_one_success("fold"), Token::Fold);
+    assert_eq!(lex_one_success("filter"), Token::Filter);
+}
+
+#[test]
 fn with_error() {
     let src = r#"
 let low_val: int = 5.0;

--- a/pintc/src/macros.rs
+++ b/pintc/src/macros.rs
@@ -177,7 +177,7 @@ pub(crate) fn splice_args(
                 }
             } else {
                 handler.emit_internal_err(
-                    "type is array but failed to get range expr.".to_string(),
+                    "type is array but failed to get range expr.",
                     Span::new(call.span.context(), range),
                 );
             }

--- a/pintc/src/parser.rs
+++ b/pintc/src/parser.rs
@@ -199,7 +199,7 @@ impl<'a> ProjectParser<'a> {
             // If the loop has gone for too long then there's an internal error. Arbitrary limit...
             if loop_count > 10_000 {
                 self.handler
-                    .emit_internal_err("Infinite loop in project parser".to_string(), empty_span());
+                    .emit_internal_err("Infinite loop in project parser", empty_span());
                 return self;
             }
         }

--- a/pintc/src/parser/tests.rs
+++ b/pintc/src/parser/tests.rs
@@ -903,17 +903,17 @@ fn local_storage_access() {
     );
 
     check(
-        &run_parser!(pint, r#"predicate test() { let x = storage::map[4][3]; }"#),
+        &run_parser!(pint, r#"predicate test() { let x = storage::imap[4][3]; }"#),
         expect_test::expect![[r#"
 
             predicate ::test(
             ) {
-                let ::x = storage::map[4][3];
+                let ::x = storage::imap[4][3];
             }"#]],
     );
 
     check(
-        &run_parser!(pint, r#"constraint storage::map[69] == 0;"#),
+        &run_parser!(pint, r#"constraint storage::m[69] == 0;"#),
         expect_test::expect![[r#"
             expected `::`, `an identifier`, `const`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`, found `constraint`
             @0..10: expected `::`, `an identifier`, `const`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`
@@ -962,18 +962,18 @@ fn external_storage_access() {
     check(
         &run_parser!(
             pint,
-            r#"predicate test() { let x = Bar@[a]::storage::map[4][3]; }"#
+            r#"predicate test() { let x = Bar@[a]::storage::imap[4][3]; }"#
         ),
         expect_test::expect![[r#"
 
             predicate ::test(
             ) {
-                let ::x = ::Bar@[::a]::storage::map[4][3];
+                let ::x = ::Bar@[::a]::storage::imap[4][3];
             }"#]],
     );
 
     check(
-        &run_parser!(pint, r#"constraint ::Foo::storage::map[69] == 0;"#),
+        &run_parser!(pint, r#"constraint ::Foo::storage::m[69] == 0;"#),
         expect_test::expect![[r#"
             expected `::`, `an identifier`, `const`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`, found `constraint`
             @0..10: expected `::`, `an identifier`, `const`, `interface`, `macro`, `macro_name`, `predicate`, `storage`, `type`, `union`, or `use`
@@ -1507,8 +1507,8 @@ fn parens_exprs() {
     check(
         &run_parser!(expr, "()"),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`, found `)`
-            @12..13: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`, found `)`
+            @12..13: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`
         "#]],
     );
 
@@ -1651,8 +1651,8 @@ fn ranges() {
     check(
         &run_parser!(range, "1...2"),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`, found `.`
-            @15..16: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`, found `.`
+            @15..16: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`
         "#]],
     );
 
@@ -2376,8 +2376,8 @@ fn cond_exprs() {
     check(
         &run_parser!(expr, r#"cond { a => b, }"#),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `else`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`, found `}`
-            @26..27: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `else`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `else`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`, found `}`
+            @26..27: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `else`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`
         "#]],
     );
 
@@ -2462,8 +2462,8 @@ fn in_expr() {
             r#"predicate test() { let x = 5 in"#
         ),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`, found `end of file`
-            @31..31: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`, found `end of file`
+            @31..31: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`
         "#]],
     );
 }
@@ -2551,8 +2551,8 @@ fn forall_expr() {
             r#"predicate test() { constraint forall i in 0..3 { constraint x; true }; }"#
         ),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`, found `constraint`
-            @49..59: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`, found `constraint`
+            @49..59: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`
         "#]],
     );
 }
@@ -2639,8 +2639,8 @@ fn exists_expr() {
             r#"predicate test() { constraint exists i in 0..3 { constraint x; true }; }"#
         ),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`, found `constraint`
-            @49..59: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`, found `constraint`
+            @49..59: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`
         "#]],
     );
 }
@@ -2698,8 +2698,8 @@ fn predicate_calls() {
     check(
         &run_parser!(expr, "bar@[addr]::foo@[]()"),
         expect_test::expect![[r#"
-            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`, found `]`
-            @28..29: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `match`, `mut`, `storage`, or `{`
+            expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`, found `]`
+            @28..29: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `exists`, `forall`, `intrinsic_name`, `macro_name`, `map`, `match`, `mut`, `storage`, or `{`
         "#]],
     );
 }

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -838,6 +838,7 @@ TermInner: Expr = {
         Expr::Immediate { value: imm, span }
     },
     GeneratorExpr,
+    LoopExpr,
     IntrinsicCallExpr,
     PredicateCallExpr,
     ArrayExpr,
@@ -885,6 +886,21 @@ GeneratorExpr: Expr = {
             kind: GeneratorKind::Exists,
             gen_ranges,
             conditions: conditions.unwrap_or_default(),
+            body,
+            span: (context.span_from)(l, r),
+        }
+    }
+}
+
+LoopExpr: Expr = {
+    MapExpr,
+}
+
+MapExpr: Expr = {
+    <l:@L> "map" <param:Ident> "in" <range:Expr> "{" <body:Expr> "}" <r:@R> => {
+        Expr::Map {
+            param,
+            range,
             body,
             span: (context.span_from)(l, r),
         }
@@ -1354,6 +1370,7 @@ extern {
 
         "forall" => lexer::Token::ForAll,
         "exists" => lexer::Token::Exists,
+        "map" => lexer::Token::Map,
         "where" => lexer::Token::Where,
 
         "ident" => lexer::Token::Ident(<(String, bool)>),

--- a/pintc/src/predicate.rs
+++ b/pintc/src/predicate.rs
@@ -220,6 +220,11 @@ impl Contract {
                 self.visitor_from_key(kind, *body, f);
             }
 
+            Expr::Map { range, body, .. } => {
+                self.visitor_from_key(kind, *range, f);
+                self.visitor_from_key(kind, *body, f);
+            }
+
             Expr::UnionTag { union_expr, .. } | Expr::UnionValue { union_expr, .. } => {
                 self.visitor_from_key(kind, *union_expr, f)
             }

--- a/pintc/src/predicate/analyse.rs
+++ b/pintc/src/predicate/analyse.rs
@@ -150,14 +150,12 @@ impl Contract {
                 if let Some(cnst) = self.consts.get_mut(&new_path) {
                     cnst.expr = new_expr_key;
                 } else {
-                    handler.emit_internal_err(
-                        "missing const decl for immediate update".to_string(),
-                        empty_span(),
-                    );
+                    handler
+                        .emit_internal_err("missing const decl for immediate update", empty_span());
                 }
             } else {
                 handler.emit_internal_err(
-                    "missing immediate value for const expr update".to_string(),
+                    "missing immediate value for const expr update",
                     empty_span(),
                 );
             }
@@ -177,15 +175,13 @@ impl Contract {
                         | Inference::Dependant(_)
                         | Inference::Dependencies(_)
                         | Inference::BoundDependencies { .. } => {
-                            handler.emit_internal_err(
-                                "const inferred a dependant type".to_string(),
-                                empty_span(),
-                            );
+                            handler
+                                .emit_internal_err("const inferred a dependant type", empty_span());
                         }
                     }
                 } else {
                     handler.emit_internal_err(
-                        "missing immediate value for const decl_ty update".to_string(),
+                        "missing immediate value for const decl_ty update",
                         empty_span(),
                     );
                 }

--- a/pintc/src/predicate/analyse/type_check/check_paths.rs
+++ b/pintc/src/predicate/analyse/type_check/check_paths.rs
@@ -28,14 +28,6 @@ impl Contract {
                 );
                 Inference::Type(Type::Error(span.clone()))
             }
-        } else if let Some(ty) = self
-            .new_types
-            .iter()
-            .find_map(|NewTypeDecl { name, ty, .. }| (&name.name == path).then_some(ty))
-        {
-            // TODO: What is this matching?  When would an expression just be an alias?
-            // It's a fully matched newtype.
-            Inference::Type(ty.clone())
         } else {
             // It might be a union variant. If it isn't we get a handy list of potential
             // variant names we can return in our error.

--- a/pintc/src/predicate/analyse/type_check/check_paths.rs
+++ b/pintc/src/predicate/analyse/type_check/check_paths.rs
@@ -23,7 +23,7 @@ impl Contract {
                 Inference::Type(decl_ty.clone())
             } else {
                 handler.emit_internal_err(
-                    "const decl has unknown type *after* evaluation".to_string(),
+                    "const decl has unknown type *after* evaluation",
                     span.clone(),
                 );
                 Inference::Type(Type::Error(span.clone()))
@@ -83,7 +83,7 @@ impl Contract {
                     }
                 } else {
                     handler.emit_internal_err(
-                        "attempting to infer item without required predicate ref".to_string(),
+                        "attempting to infer item without required predicate ref",
                         span.clone(),
                     );
                     Inference::Type(Type::Error(span.clone()))

--- a/pintc/src/predicate/analyse/type_check/custom_types.rs
+++ b/pintc/src/predicate/analyse/type_check/custom_types.rs
@@ -120,10 +120,8 @@ impl Contract {
             }
 
             if loop_check > 10_000 {
-                return Err(handler.emit_internal_err(
-                    "infinite loop in lower_nested_newtypes()".to_string(),
-                    empty_span(),
-                ));
+                return Err(handler
+                    .emit_internal_err("infinite loop in lower_nested_newtypes()", empty_span()));
             }
         }
 

--- a/pintc/src/predicate/exprs.rs
+++ b/pintc/src/predicate/exprs.rs
@@ -239,6 +239,10 @@ impl ExprKey {
                     || body.can_panic(contract, pred)
             }
 
+            Expr::Map { range, body, .. } => {
+                range.can_panic(contract, pred) || body.can_panic(contract, pred)
+            }
+
             Expr::UnionTag { union_expr, .. } | Expr::UnionValue { union_expr, .. } => {
                 union_expr.can_panic(contract, pred)
             }
@@ -380,6 +384,11 @@ impl ExprKey {
                     conditions.iter().for_each(|condition| {
                         storage_accesses.extend(condition.collect_storage_accesses(contract));
                     });
+                    storage_accesses.extend(body.collect_storage_accesses(contract));
+                }
+
+                Expr::Map { range, body, .. } => {
+                    storage_accesses.extend(range.collect_storage_accesses(contract));
                     storage_accesses.extend(body.collect_storage_accesses(contract));
                 }
 
@@ -638,6 +647,11 @@ impl<'a> Iterator for ExprsIter<'a> {
                     queue_if_new!(self, cond);
                 }
 
+                queue_if_new!(self, body);
+            }
+
+            Expr::Map { range, body, .. } => {
+                queue_if_new!(self, range);
                 queue_if_new!(self, body);
             }
 

--- a/pintc/src/predicate/optimize/const_folding.rs
+++ b/pintc/src/predicate/optimize/const_folding.rs
@@ -21,7 +21,7 @@ pub(crate) fn const_folding(handler: &Handler, contract: &mut Contract) {
 
         // If the loop has gone for too long then there's an internal error. Arbitrary limit...
         if loop_count > 10_000 {
-            handler.emit_internal_err("Infinite loop in const_folding".to_string(), empty_span());
+            handler.emit_internal_err("Infinite loop in const_folding", empty_span());
             break;
         }
     }

--- a/pintc/src/predicate/transform/lower.rs
+++ b/pintc/src/predicate/transform/lower.rs
@@ -34,7 +34,7 @@ pub(crate) fn lower_casts(handler: &Handler, contract: &mut Contract) -> Result<
                 let from_ty = value.get_ty(contract);
                 if from_ty.is_unknown() {
                     handler.emit_internal_err(
-                        "expression type is `Unknown` while lowering casts".to_string(),
+                        "expression type is `Unknown` while lowering casts",
                         span.clone(),
                     );
                 }
@@ -206,7 +206,7 @@ pub(crate) fn lower_array_ranges(
                             evaluator.evaluate_key(&old_range_expr_key, handler, contract)?;
                         if !matches!(value, Immediate::Int(_) | Immediate::UnionVariant { .. }) {
                             return Err(handler.emit_internal_err(
-                                "array range expression evaluates to non int immediate".to_string(),
+                                "array range expression evaluates to non int immediate",
                                 contract.expr_key_to_span(old_range_expr_key),
                             ));
                         }
@@ -227,7 +227,7 @@ pub(crate) fn lower_array_ranges(
                     let value = evaluator.evaluate_key(&old_range_expr_key, handler, contract)?;
                     if !matches!(value, Immediate::Int(_) | Immediate::UnionVariant { .. }) {
                         return Err(handler.emit_internal_err(
-                            "array range expression evaluates to non int immediate".to_string(),
+                            "array range expression evaluates to non int immediate",
                             contract.expr_key_to_span(old_range_expr_key),
                         ));
                     }
@@ -311,7 +311,7 @@ pub(crate) fn lower_imm_accesses(
                 // We have an array access into an immediate.  Evaluate the index.
                 let Some(idx_expr) = array_idx_key.try_get(contract) else {
                     return Err(handler.emit_internal_err(
-                        "missing array index expression in lower_imm_accesses()".to_string(),
+                        "missing array index expression in lower_imm_accesses()",
                         empty_span(),
                     ));
                 };
@@ -469,10 +469,8 @@ pub(crate) fn lower_imm_accesses(
             }
 
             if loop_check > 10_000 {
-                return Err(handler.emit_internal_err(
-                    "infinite loop in lower_imm_accesses()".to_string(),
-                    empty_span(),
-                ));
+                return Err(handler
+                    .emit_internal_err("infinite loop in lower_imm_accesses()", empty_span()));
             }
         }
     }
@@ -540,16 +538,13 @@ pub(crate) fn lower_ins(handler: &Handler, contract: &mut Contract) -> Result<()
 
                         _ => {
                             handler.emit_internal_err(
-                                "invalid collection (not range or array) in `in` expr".to_string(),
+                                "invalid collection (not range or array) in `in` expr",
                                 span.clone(),
                             );
                         }
                     }
                 } else {
-                    handler.emit_internal_err(
-                        "missing collection in `in` expr".to_string(),
-                        span.clone(),
-                    );
+                    handler.emit_internal_err("missing collection in `in` expr", span.clone());
                 }
             }
         }
@@ -1031,6 +1026,7 @@ pub(super) fn coalesce_prime_ops(contract: &mut Contract) {
                 | Expr::In { .. }
                 | Expr::Range { .. }
                 | Expr::Generator { .. }
+                | Expr::Map { .. }
                 | Expr::UnionTag { .. }
                 | Expr::UnionValue { .. } => Coalescence::None,
             };
@@ -1197,7 +1193,7 @@ fn convert_match_to_if_decl(
                     .get_union_variant_ty(contract, &name)
                     .map_err(|_| {
                         handler.emit_internal_err(
-                            "match can't be converted to if -- missing union type".to_string(),
+                            "match can't be converted to if -- missing union type",
                             name_span.clone(),
                         );
                         handler.cancel()
@@ -1212,7 +1208,7 @@ fn convert_match_to_if_decl(
                         // There's a mismatch.
                         _ => {
                             handler.emit_internal_err(
-                                "match can't be converted to if -- bindings mismatch".to_string(),
+                                "match can't be converted to if -- bindings mismatch",
                                 span.clone(),
                             );
                             Err(handler.cancel())
@@ -1473,7 +1469,7 @@ fn convert_match_expr(
             // Replace the bound values within the constraint exprs, if there is a binding.
             let bound_ty = union_ty.get_union_variant_ty(contract, name).map_err(|_| {
                 handler.emit_internal_err(
-                    "match can't be converted to if -- missing union type".to_string(),
+                    "match can't be converted to if -- missing union type",
                     name_span.clone(),
                 );
                 handler.cancel()
@@ -1643,7 +1639,7 @@ fn convert_match_expr(
             // There are no then branches and no else branch which makes it impossible to create an
             // expression. (NOTE: Currently the parser makes this impossible.)
             Err(handler.emit_internal_err(
-                "Unable to convert a completely empty match expression.".to_string(),
+                "Unable to convert a completely empty match expression.",
                 contract.expr_key_to_span(match_expr_key),
             ))
         })?;
@@ -1684,7 +1680,7 @@ fn build_compare_tag_expr(
         .get_union_variant_as_num(contract, tag)
         .ok_or_else(|| {
             handler.emit_internal_err(
-                "Union tag not found in union decl".to_string(),
+                "Union tag not found in union decl",
                 contract.expr_key_to_span(union_expr),
             )
         })?;

--- a/pintc/src/predicate/transform/lower/lower_storage_accesses.rs
+++ b/pintc/src/predicate/transform/lower/lower_storage_accesses.rs
@@ -255,7 +255,7 @@ fn get_base_storage_key(
                     Some(Expr::LocalStorageAccess { name, .. }) => {
                         if !contract.storage_var(name).1.ty.is_vector() {
                             return Err(handler.emit_internal_err(
-                                "argument to __vec_len must be of type storage vector".to_string(),
+                                "argument to __vec_len must be of type storage vector",
                                 empty_span(),
                             ));
                         }
@@ -270,14 +270,14 @@ fn get_base_storage_key(
                             .is_vector()
                         {
                             return Err(handler.emit_internal_err(
-                                "argument to __vec_len must be of type storage vector".to_string(),
+                                "argument to __vec_len must be of type storage vector",
                                 empty_span(),
                             ));
                         }
                     }
                     _ => {
                         return Err(handler.emit_internal_err(
-                            "argument to __vec_len must be storage access".to_string(),
+                            "argument to __vec_len must be storage access",
                             empty_span(),
                         ));
                     }
@@ -285,8 +285,7 @@ fn get_base_storage_key(
 
                 get_base_storage_key(handler, &args[0], contract)
             } else {
-                Err(handler
-                    .emit_internal_err("Invalid storage intrinsic".to_string(), empty_span()))
+                Err(handler.emit_internal_err("Invalid storage intrinsic", empty_span()))
             }
         }
         Expr::LocalStorageAccess { name, mutable, .. } => {
@@ -356,10 +355,8 @@ fn get_base_storage_key(
                 }
             } else {
                 let Type::Array { ty, .. } = expr.get_ty(contract) else {
-                    return Err(handler.emit_internal_err(
-                        "type must exist and be an array type".to_string(),
-                        empty_span(),
-                    ));
+                    return Err(handler
+                        .emit_internal_err("type must exist and be an array type", empty_span()));
                 };
 
                 // Increment the last element of the key by `index * array element size`
@@ -395,10 +392,9 @@ fn get_base_storage_key(
 
             // Grab the fields of the tuple
             let Type::Tuple { ref fields, .. } = tuple.get_ty(contract) else {
-                return Err(handler.emit_internal_err(
-                    "type must exist and be a tuple type".to_string(),
-                    empty_span(),
-                ));
+                return Err(
+                    handler.emit_internal_err("type must exist and be a tuple type", empty_span())
+                );
             };
 
             // The field index is based on the type definition
@@ -413,10 +409,9 @@ fn get_base_storage_key(
                     })
                     .expect("field name must exist, this was checked in type checking"),
                 TupleAccess::Error => {
-                    return Err(handler.emit_internal_err(
-                        "unexpected TupleAccess::Error".to_string(),
-                        empty_span(),
-                    ))
+                    return Err(
+                        handler.emit_internal_err("unexpected TupleAccess::Error", empty_span())
+                    )
                 }
             };
 
@@ -443,7 +438,7 @@ fn get_base_storage_key(
         }
 
         _ => Err(handler.emit_internal_err(
-            "unexpected expression in a storage access expression".to_string(),
+            "unexpected expression in a storage access expression",
             empty_span(),
         )),
     }

--- a/pintc/src/predicate/transform/unroll.rs
+++ b/pintc/src/predicate/transform/unroll.rs
@@ -175,7 +175,7 @@ fn unroll_generator(
                     Immediate::Bool(true) => {}
                     _ => {
                         return Err(handler.emit_internal_err(
-                            "type error: boolean expression expected".to_string(),
+                            "type error: boolean expression expected",
                             empty_span(),
                         ))
                     }

--- a/pintc/src/predicate/transform/validate.rs
+++ b/pintc/src/predicate/transform/validate.rs
@@ -19,9 +19,7 @@ fn check_params(pred: &Predicate, handler: &Handler) {
     for param in &pred.params {
         if param.ty.is_unknown() {
             handler.emit_internal_err(
-                "final predicate var_types slotmap is missing corresponding key from \
-                    vars slotmap"
-                    .to_string(),
+                "final predicate var_types slotmap is missing corresponding key from vars slotmap",
                 param.span.clone(),
             );
         }
@@ -33,8 +31,7 @@ fn check_variables(pred: &Predicate, handler: &Handler) {
         if variable_key.get_ty(pred).is_unknown() {
             handler.emit_internal_err(
                 "final predicate variable_types slotmap is missing corresponding key from \
-                    variables slotmap"
-                    .to_string(),
+                    variables slotmap",
                 variable.span.clone(),
             );
         }
@@ -42,21 +39,17 @@ fn check_variables(pred: &Predicate, handler: &Handler) {
 }
 
 fn check_ifs_and_matches(pred: &Predicate, handler: &Handler) {
-    let emit_internal_err = |msg, span: &crate::span::Span| {
-        handler.emit_internal_err(msg, span.clone());
-    };
-
     if !pred.if_decls.is_empty() {
-        emit_internal_err(
-            "final predicate contains if declarations".to_string(),
-            &pred.if_decls[0].span,
+        handler.emit_internal_err(
+            "final predicate contains if declarations",
+            pred.if_decls[0].span.clone(),
         );
     }
 
     if !pred.match_decls.is_empty() {
-        emit_internal_err(
-            "final predicate contains match declarations".to_string(),
-            &pred.match_decls[0].span,
+        handler.emit_internal_err(
+            "final predicate contains match declarations",
+            pred.match_decls[0].span.clone(),
         );
     }
 }
@@ -80,8 +73,7 @@ fn check_expr(
                     " present in final predicate ",
                     $slotmap_str,
                     " slotmap"
-                )
-                .to_string(),
+                ),
                 $span.clone(),
             )
         };
@@ -90,16 +82,13 @@ fn check_expr(
     let expr_type = expr_key.get_ty(contract);
     if expr_type.is_unknown() {
         handler.emit_internal_err(
-            "Unknown expr type found invalid predicate expr_types slotmap key".to_string(),
+            "Unknown expr type found invalid predicate expr_types slotmap key",
             empty_span(),
         );
     }
 
     let expr = expr_key.try_get(contract).ok_or_else(|| {
-        handler.emit_internal_err(
-            "invalid predicate exprs slotmap key".to_string(),
-            empty_span(),
-        )
+        handler.emit_internal_err("invalid predicate exprs slotmap key", empty_span())
     })?;
 
     // validate the expr_type is legal
@@ -197,6 +186,7 @@ fn check_expr(
         | Expr::Cast { .. }
         | Expr::TupleFieldAccess { .. }
         | Expr::Index { .. }
+        | Expr::Map { .. }
         | Expr::UnionTag { .. }
         | Expr::UnionValue { .. } => Ok(()),
     }

--- a/pintc/src/types.rs
+++ b/pintc/src/types.rs
@@ -579,10 +579,9 @@ impl Type {
             | Self::Unknown(span)
             | Self::Any(span)
             | Self::Custom { span, .. }
-            | Self::Alias { span, .. } => Err(handler.emit_internal_err(
-                "unexpected type when getting size".to_string(),
-                span.clone(),
-            )),
+            | Self::Alias { span, .. } => {
+                Err(handler.emit_internal_err("unexpected type when getting size", span.clone()))
+            }
         }
     }
 
@@ -641,7 +640,7 @@ impl Type {
             | Self::Any(span)
             | Self::Custom { span, .. }
             | Self::Alias { span, .. } => Err(handler.emit_internal_err(
-                "unexpected type when calculating storage slots".to_string(),
+                "unexpected type when calculating storage slots",
                 span.clone(),
             )),
         }

--- a/pintc/tests/loops/map_bad_type.pnt
+++ b/pintc/tests/loops/map_bad_type.pnt
@@ -1,0 +1,22 @@
+predicate test(ary: bool[4]) {
+    let b = map x in ary { x + 11 };
+
+    let c: int[4] = map x in ary { !x };
+}
+
+// parsed <<<
+// predicate ::test(
+//     ::ary: bool[4],
+// ) {
+//     let ::b = map x in ::ary { (::x + 11) };
+//     let ::c: int[4] = map x in ::ary { !::x };
+// }
+// >>>
+
+// typecheck_failure <<<
+// operator invalid type error
+// @58..64: invalid non-numeric type `bool` for operator `+`
+// variable initialization type error
+// @89..108: initializing expression has unexpected type `bool[4]`
+// @80..86: expecting type `int[4]`
+// >>>

--- a/pintc/tests/loops/map_fixed_simple.pnt
+++ b/pintc/tests/loops/map_fixed_simple.pnt
@@ -1,0 +1,32 @@
+predicate test(ary: int[10]) {
+    let evens: int[10] = map x in ary {
+        x % 2 == 1 ? x + 1 : x
+    };
+    constraint evens[4] + evens[0] == 10;
+
+    let zero_map: bool[10] = map y in ary { y == 0 };
+    constraint !zero_map[3];
+}
+
+// parsed <<<
+// predicate ::test(
+//     ::ary: int[10],
+// ) {
+//     let ::evens: int[10] = map x in ::ary { (((::x % 2) == 1) ? (::x + 1) : ::x) };
+//     let ::zero_map: bool[10] = map y in ::ary { (::y == 0) };
+//     constraint ((::evens[4] + ::evens[0]) == 10);
+//     constraint !::zero_map[3];
+// }
+// >>>
+
+// flattened <<<
+// predicate ::test(
+//     ::ary: int[10],
+// ) {
+//     let ::evens: int[10] = map x in ::ary { (((::x % 2) == 1) ? (::x + 1) : ::x) };
+//     let ::zero_map: bool[10] = map y in ::ary { (::y == 0) };
+//     constraint ((::evens[4] + ::evens[0]) == 10);
+//     constraint !::zero_map[3];
+//     constraint __eq_set(__mut_keys(), {0});
+// }
+// >>>

--- a/pintc/tests/macros/bad_splicing.pnt
+++ b/pintc/tests/macros/bad_splicing.pnt
@@ -19,7 +19,7 @@ predicate test() {
 // a macro named `::@add` found with a different signature
 // spliced variable `::b` must be an array
 // @136..137: unable to splice non-array variable `::b`
-// expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `let`, `macro_name`, `match`, `mut`, `predicate`, `storage`, `type`, `union`, `use`, `{`, or `}`, found `b`
-// @25..27: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `let`, `macro_name`, `match`, `mut`, `predicate`, `storage`, `type`, `union`, `use`, `{`, or `}`
+// expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `let`, `macro_name`, `map`, `match`, `mut`, `predicate`, `storage`, `type`, `union`, `use`, `{`, or `}`, found `b`
+// @25..27: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `let`, `macro_name`, `map`, `match`, `mut`, `predicate`, `storage`, `type`, `union`, `use`, `{`, or `}`
 // @130..142: when making macro call to '::@add'
 // >>>

--- a/pintc/tests/macros/splicing_expression_size.pnt
+++ b/pintc/tests/macros/splicing_expression_size.pnt
@@ -14,7 +14,7 @@ predicate test(ary: int[10 + 1]) {
 // unable to determine spliced array size
 // @128..131: unable to determine spliced array size for `::ary` while parsing
 // macro array splicing is currently limited to immediate integer sizes or enumeration unions
-// expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `let`, `macro_name`, `match`, `mut`, `predicate`, `storage`, `type`, `union`, `use`, `{`, or `}`, found `ary`
-// @69..71: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `let`, `macro_name`, `match`, `mut`, `predicate`, `storage`, `type`, `union`, `use`, `{`, or `}`
+// expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `let`, `macro_name`, `map`, `match`, `mut`, `predicate`, `storage`, `type`, `union`, `use`, `{`, or `}`, found `ary`
+// @69..71: expected `!`, `(`, `+`, `-`, `::`, `[`, `a boolean`, `a literal`, `an identifier`, `cond`, `const`, `constraint`, `exists`, `forall`, `if`, `interface`, `intrinsic_name`, `let`, `macro_name`, `map`, `match`, `mut`, `predicate`, `storage`, `type`, `union`, `use`, `{`, or `}`
 // @122..132: when making macro call to '::@sum'
 // >>>

--- a/pintc/tests/optimizations/dead_state_elimination.pnt
+++ b/pintc/tests/optimizations/dead_state_elimination.pnt
@@ -2,7 +2,7 @@ storage {
     x: int,
     arr: int[2],
     tup: { int, int },
-    map: ( int => bool ),
+    bmap: ( int => bool ),
 }
 
 predicate Test(f: int, g: int, h: bool) {
@@ -19,8 +19,8 @@ predicate Test(f: int, g: int, h: bool) {
     let d = storage::tup;
     let d_0 = storage::tup.0;
 
-    let e_0 = storage::map[0];
-    let e_1 = storage::map[1];
+    let e_0 = storage::bmap[0];
+    let e_1 = storage::bmap[1];
 
     constraint f == b + c[0];
     constraint g == d.1 + d_0;
@@ -31,8 +31,8 @@ predicate Test(f: int, g: int, h: bool) {
     let x2 = storage::arr;
     let x3 = storage::tup;
     let x4 = storage::tup.0;
-    let x5 = storage::map[0];
-    let x6 = storage::map[1];
+    let x5 = storage::bmap[0];
+    let x6 = storage::bmap[1];
 
     // mutable key remains, let is eliminated
     let z = mut storage::x;
@@ -43,9 +43,9 @@ predicate Test(f: int, g: int, h: bool) {
 //     x: int,
 //     arr: int[2],
 //     tup: {int, int},
-//     map: ( int => bool ),
+//     bmap: ( int => bool ),
 // }
-// 
+//
 // predicate ::Test(
 //     ::f: int,
 //     ::g: int,
@@ -56,14 +56,14 @@ predicate Test(f: int, g: int, h: bool) {
 //     let ::c: int[2] = mut storage::arr;
 //     let ::d = storage::tup;
 //     let ::d_0 = storage::tup.0;
-//     let ::e_0 = storage::map[0];
-//     let ::e_1 = storage::map[1];
+//     let ::e_0 = storage::bmap[0];
+//     let ::e_1 = storage::bmap[1];
 //     let ::x1 = storage::x;
 //     let ::x2 = storage::arr;
 //     let ::x3 = storage::tup;
 //     let ::x4 = storage::tup.0;
-//     let ::x5 = storage::map[0];
-//     let ::x6 = storage::map[1];
+//     let ::x5 = storage::bmap[0];
+//     let ::x6 = storage::bmap[1];
 //     let ::z = mut storage::x;
 //     constraint (::a' >= (::a + 42));
 //     constraint (((::b == nil) && (::b' == 1)) || (::b' == (::b + 1)));
@@ -79,9 +79,9 @@ predicate Test(f: int, g: int, h: bool) {
 //     x: int,
 //     arr: int[2],
 //     tup: {int, int},
-//     map: ( int => bool ),
+//     bmap: ( int => bool ),
 // }
-// 
+//
 // predicate ::Test(
 //     ::f: int,
 //     ::g: int,
@@ -116,9 +116,9 @@ predicate Test(f: int, g: int, h: bool) {
 //     x: int,
 //     arr: int[2],
 //     tup: {int, int},
-//     map: ( int => bool ),
+//     bmap: ( int => bool ),
 // }
-// 
+//
 // predicate ::Test(
 //     ::f: int,
 //     ::g: int,

--- a/pintc/tests/storage/bad_storage_accesses.pnt
+++ b/pintc/tests/storage/bad_storage_accesses.pnt
@@ -1,6 +1,6 @@
 storage {
     t: { int, int[3] },
-    map: ( int => { int, int, b256 } ),
+    m: ( int => { int, int, b256 } ),
     a: ( b256 => int[storage::t.0] ),
     bb: b256,
 }
@@ -9,7 +9,7 @@ interface Foo {
     storage {
         a: int[3][storage::t.0],
     }
-    
+
     predicate Bar();
 }
 
@@ -26,7 +26,7 @@ predicate Test(
     b: bool,
     u: G,
 ) {
-    constraint x == storage::map[3].2;
+    constraint x == storage::m[3].2;
 
     constraint storage::a[addr][storage::t.0] == 0;
 
@@ -56,7 +56,7 @@ predicate Test(
 // type ::MyType = {int, int[storage::t.0]};
 // storage {
 //     t: {int, int[3]},
-//     map: ( int => {int, int, b256} ),
+//     m: ( int => {int, int, b256} ),
 //     a: ( b256 => int[storage::t.0] ),
 //     bb: b256,
 // }
@@ -66,7 +66,7 @@ predicate Test(
 //     }
 //     predicate Bar();
 // }
-// 
+//
 // predicate ::Test(
 //     ::x: b256,
 //     ::addr: b256,
@@ -74,7 +74,7 @@ predicate Test(
 //     ::b: bool,
 //     ::u: ::G,
 // ) {
-//     constraint (::x == storage::map[3].2);
+//     constraint (::x == storage::m[3].2);
 //     constraint (storage::a[::addr][storage::t.0] == 0);
 //     constraint (::y == storage::t);
 //     constraint ::Foo@[storage::bb]::Bar@[storage::bb]();
@@ -97,49 +97,49 @@ predicate Test(
 
 // typecheck_failure <<<
 // invalid position for accessing storage
-// @546..556: storage cannot be accessed in this position
+// @538..548: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @252..264: storage cannot be accessed in this position
+// @246..258: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @627..639: storage cannot be accessed in this position
+// @619..631: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @488..518: storage cannot be accessed in this position
+// @480..510: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @897..908: storage cannot be accessed in this position
+// @889..900: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @716..728: storage cannot be accessed in this position
+// @708..720: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @295..307: storage cannot be accessed in this position
+// @289..301: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @589..601: storage cannot be accessed in this position
+// @581..593: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @878..889: storage cannot be accessed in this position
+// @870..881: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @453..470: storage cannot be accessed in this position
+// @447..462: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @800..812: storage cannot be accessed in this position
+// @792..804: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @322..334: storage cannot be accessed in this position
+// @316..328: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @678..690: storage cannot be accessed in this position
+// @670..682: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @177..189: storage cannot be accessed in this position
+// @175..187: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // invalid position for accessing storage
-// @95..107: storage cannot be accessed in this position
+// @93..105: storage cannot be accessed in this position
 // storage can only be accessed in the initializer of a `let` declaration
 // compiler internal error: unexpected expression during compile-time evaluation
 // >>>

--- a/pintc/tests/storage/external_storage/lib.pnt
+++ b/pintc/tests/storage/external_storage/lib.pnt
@@ -2,14 +2,14 @@ interface ERC20_1 {
     storage {
         x: int,
         y: bool,
-        map: (int => (int => b256)),
-    } 
+        m: (int => (int => b256)),
+    }
 }
 
 interface ERC20_2 {
     storage {
         x: int,
         y: bool,
-        map: (int => (int => b256)),
-    } 
+        m: (int => (int => b256)),
+    }
 }

--- a/pintc/tests/storage/external_storage/main.pnt
+++ b/pintc/tests/storage/external_storage/main.pnt
@@ -4,14 +4,14 @@ use ::lib::ERC20_1;
 storage {
     x: int,
     y: bool,
-    map: (int => (int => b256)),
+    m: (int => (int => b256)),
 }
 
 interface ERC20_0 {
     storage {
         x: int,
         y: bool,
-        map: (int => (int => b256)),
+        m: (int => (int => b256)),
     }
 }
 
@@ -22,19 +22,19 @@ predicate Foo() {
 
     let internal_x = storage::x;
     let internal_y = storage::y;
-    let internal_map = storage::map[3][4];
+    let internal_map = storage::m[3][4];
 
     let external_x_0 = ::ERC20_0@[addr0]::storage::x;
     let external_y_0 = ERC20_0@[addr0]::storage::y;
-    let external_map_0 = ERC20_0@[addr0]::storage::map[3][4];
+    let external_map_0 = ERC20_0@[addr0]::storage::m[3][4];
 
     let external_x_1 = ERC20_1@[addr1]::storage::x;
     let external_y_1 = ERC20_1@[addr1]::storage::y;
-    let external_map_1 = ERC20_1@[addr1]::storage::map[3][4];
+    let external_map_1 = ERC20_1@[addr1]::storage::m[3][4];
 
     let external_x_2 = lib::ERC20_2@[addr2]::storage::x;
     let external_y_2 = lib::ERC20_2@[addr2]::storage::y;
-    let external_map_2 = lib::ERC20_2@[addr2]::storage::map[3][4];
+    let external_map_2 = lib::ERC20_2@[addr2]::storage::m[3][4];
 }
 
 predicate Bar() {
@@ -44,49 +44,49 @@ predicate Bar() {
 
     let internal_x = storage::x;
     let internal_y = storage::y;
-    let internal_map = storage::map[3][4];
+    let internal_map = storage::m[3][4];
 
     let external_x_0 = ::ERC20_0@[addr0]::storage::x;
     let external_y_0 = ERC20_0@[addr0]::storage::y;
-    let external_map_0 = ERC20_0@[addr0]::storage::map[3][4];
+    let external_map_0 = ERC20_0@[addr0]::storage::m[3][4];
 
     let external_x_1 = ::lib::ERC20_1@[addr1]::storage::x;
     let external_y_1 = ::lib::ERC20_1@[addr1]::storage::y;
-    let external_map_1 = ::lib::ERC20_1@[addr1]::storage::map[3][4];
+    let external_map_1 = ::lib::ERC20_1@[addr1]::storage::m[3][4];
 
     let external_x_2 = ERC20_2@[addr2]::storage::x;
     let external_y_2 = ERC20_2@[addr2]::storage::y;
-    let external_map_2 = ERC20_2@[addr2]::storage::map[3][4];
+    let external_map_2 = ERC20_2@[addr2]::storage::m[3][4];
 }
 
 // parsed <<<
 // storage {
 //     x: int,
 //     y: bool,
-//     map: ( int => ( int => b256 ) ),
+//     m: ( int => ( int => b256 ) ),
 // }
 // interface ::ERC20_0 {
 //     storage {
 //         x: int,
 //         y: bool,
-//         map: ( int => ( int => b256 ) ),
+//         m: ( int => ( int => b256 ) ),
 //     }
 // }
 // interface ::lib::ERC20_1 {
 //     storage {
 //         x: int,
 //         y: bool,
-//         map: ( int => ( int => b256 ) ),
+//         m: ( int => ( int => b256 ) ),
 //     }
 // }
 // interface ::lib::ERC20_2 {
 //     storage {
 //         x: int,
 //         y: bool,
-//         map: ( int => ( int => b256 ) ),
+//         m: ( int => ( int => b256 ) ),
 //     }
 // }
-// 
+//
 // predicate ::Foo(
 // ) {
 //     let ::addr0 = 0x0000000000000000000000000000000000000000000000000000000000000000;
@@ -94,18 +94,18 @@ predicate Bar() {
 //     let ::addr2 = 0x2222222222222222222222222222222222222222222222222222222222222222;
 //     let ::internal_x = storage::x;
 //     let ::internal_y = storage::y;
-//     let ::internal_map = storage::map[3][4];
+//     let ::internal_map = storage::m[3][4];
 //     let ::external_x_0 = ::ERC20_0@[::addr0]::storage::x;
 //     let ::external_y_0 = ::ERC20_0@[::addr0]::storage::y;
-//     let ::external_map_0 = ::ERC20_0@[::addr0]::storage::map[3][4];
+//     let ::external_map_0 = ::ERC20_0@[::addr0]::storage::m[3][4];
 //     let ::external_x_1 = ::lib::ERC20_1@[::addr1]::storage::x;
 //     let ::external_y_1 = ::lib::ERC20_1@[::addr1]::storage::y;
-//     let ::external_map_1 = ::lib::ERC20_1@[::addr1]::storage::map[3][4];
+//     let ::external_map_1 = ::lib::ERC20_1@[::addr1]::storage::m[3][4];
 //     let ::external_x_2 = ::lib::ERC20_2@[::addr2]::storage::x;
 //     let ::external_y_2 = ::lib::ERC20_2@[::addr2]::storage::y;
-//     let ::external_map_2 = ::lib::ERC20_2@[::addr2]::storage::map[3][4];
+//     let ::external_map_2 = ::lib::ERC20_2@[::addr2]::storage::m[3][4];
 // }
-// 
+//
 // predicate ::Bar(
 // ) {
 //     let ::addr0 = 0x0000000000000000000000000000000000000000000000000000000000000000;
@@ -113,16 +113,16 @@ predicate Bar() {
 //     let ::addr2 = 0x2222222222222222222222222222222222222222222222222222222222222222;
 //     let ::internal_x = storage::x;
 //     let ::internal_y = storage::y;
-//     let ::internal_map = storage::map[3][4];
+//     let ::internal_map = storage::m[3][4];
 //     let ::external_x_0 = ::ERC20_0@[::addr0]::storage::x;
 //     let ::external_y_0 = ::ERC20_0@[::addr0]::storage::y;
-//     let ::external_map_0 = ::ERC20_0@[::addr0]::storage::map[3][4];
+//     let ::external_map_0 = ::ERC20_0@[::addr0]::storage::m[3][4];
 //     let ::external_x_1 = ::lib::ERC20_1@[::addr1]::storage::x;
 //     let ::external_y_1 = ::lib::ERC20_1@[::addr1]::storage::y;
-//     let ::external_map_1 = ::lib::ERC20_1@[::addr1]::storage::map[3][4];
+//     let ::external_map_1 = ::lib::ERC20_1@[::addr1]::storage::m[3][4];
 //     let ::external_x_2 = ::lib::ERC20_2@[::addr2]::storage::x;
 //     let ::external_y_2 = ::lib::ERC20_2@[::addr2]::storage::y;
-//     let ::external_map_2 = ::lib::ERC20_2@[::addr2]::storage::map[3][4];
+//     let ::external_map_2 = ::lib::ERC20_2@[::addr2]::storage::m[3][4];
 // }
 // >>>
 
@@ -130,30 +130,30 @@ predicate Bar() {
 // storage {
 //     x: int,
 //     y: bool,
-//     map: ( int => ( int => b256 ) ),
+//     m: ( int => ( int => b256 ) ),
 // }
 // interface ::ERC20_0 {
 //     storage {
 //         x: int,
 //         y: bool,
-//         map: ( int => ( int => b256 ) ),
+//         m: ( int => ( int => b256 ) ),
 //     }
 // }
 // interface ::lib::ERC20_1 {
 //     storage {
 //         x: int,
 //         y: bool,
-//         map: ( int => ( int => b256 ) ),
+//         m: ( int => ( int => b256 ) ),
 //     }
 // }
 // interface ::lib::ERC20_2 {
 //     storage {
 //         x: int,
 //         y: bool,
-//         map: ( int => ( int => b256 ) ),
+//         m: ( int => ( int => b256 ) ),
 //     }
 // }
-// 
+//
 // predicate ::Foo(
 // ) {
 //     let ::addr0: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;
@@ -173,7 +173,7 @@ predicate Bar() {
 //     let ::external_map_2: b256 = __storage_get_extern(::addr2, {2, 3, 4});
 //     constraint __eq_set(__mut_keys(), {0});
 // }
-// 
+//
 // predicate ::Bar(
 // ) {
 //     let ::addr0: b256 = 0x0000000000000000000000000000000000000000000000000000000000000000;

--- a/pintc/tests/storage/mut_storage.pnt
+++ b/pintc/tests/storage/mut_storage.pnt
@@ -5,7 +5,7 @@ storage {
     z: int[2][3],
     w: bool[2][3],
     vec: b256[],
-    map: ( int => { b256, int } ),
+    m: ( int => { b256, int } ),
 }
 
 predicate Foo() {
@@ -15,12 +15,12 @@ predicate Foo() {
     let z = mut storage::z;
     let w_1 = mut storage::w[1];
     let v_3 = mut storage::vec[3];
-    let map_69 = mut storage::map[69];
-    let map_42_1 = mut storage::map[42].1;
-    let vec_len = __vec_len(mut storage::vec); 
+    let map_69 = mut storage::m[69];
+    let map_42_1 = mut storage::m[42].1;
+    let vec_len = __vec_len(mut storage::vec);
 
     // Should not show up in the list of mutable keys
-    let map_43 = storage::map[42].1;
+    let map_43 = storage::m[42].1;
 }
 
 // parsed <<<
@@ -31,9 +31,9 @@ predicate Foo() {
 //     z: int[3][2],
 //     w: bool[3][2],
 //     vec: b256[],
-//     map: ( int => {b256, int} ),
+//     m: ( int => {b256, int} ),
 // }
-// 
+//
 // predicate ::Foo(
 // ) {
 //     let ::x = mut storage::x;
@@ -42,10 +42,10 @@ predicate Foo() {
 //     let ::z = mut storage::z;
 //     let ::w_1 = mut storage::w[1];
 //     let ::v_3 = mut storage::vec[3];
-//     let ::map_69 = mut storage::map[69];
-//     let ::map_42_1 = mut storage::map[42].1;
+//     let ::map_69 = mut storage::m[69];
+//     let ::map_42_1 = mut storage::m[42].1;
 //     let ::vec_len = __vec_len(mut storage::vec);
-//     let ::map_43 = storage::map[42].1;
+//     let ::map_43 = storage::m[42].1;
 // }
 // >>>
 
@@ -57,9 +57,9 @@ predicate Foo() {
 //     z: int[3][2],
 //     w: bool[3][2],
 //     vec: b256[],
-//     map: ( int => {b256, int} ),
+//     m: ( int => {b256, int} ),
 // }
-// 
+//
 // predicate ::Foo(
 // ) {
 //     let ::x: int = __storage_get({0});

--- a/pintc/tests/tests.rs
+++ b/pintc/tests/tests.rs
@@ -321,6 +321,7 @@ mod e2e {
     e2e_test!(generators);
     e2e_test!(interfaces);
     e2e_test!(intrinsics);
+    e2e_test!(loops);
     e2e_test!(macros);
     e2e_test!(modules);
     e2e_test!(optimizations);

--- a/tests/validation_tests/complex_storage.pnt
+++ b/tests/validation_tests/complex_storage.pnt
@@ -1,7 +1,7 @@
 storage {
     address: b256,
     address2: b256,
-    map: (int => b256),
+    imap: (int => b256),
     map_in_map: (int => (b256 => int)),
     map_in_map_in_map: (int => (b256 => (int => b256))),
 }
@@ -9,7 +9,7 @@ storage {
 predicate Foo() {
     let address = mut storage::address;
     let address2 = mut storage::address2;
-    let map_entry = mut storage::map[69];
+    let map_entry = mut storage::imap[69];
     let map_in_map_entry = mut storage::map_in_map[9][0x0000000000000001000000000000000200000000000000030000000000000004];
     let map_in_map_in_map_entry = mut storage::map_in_map_in_map[88][0x0000000000000008000000000000000700000000000000060000000000000005][999];
 

--- a/tests/validation_tests/external_access.pnt
+++ b/tests/validation_tests/external_access.pnt
@@ -10,7 +10,7 @@ interface Bar {
     storage {
         address: b256,
         address2: b256,
-        map: (int => b256),
+        imap: (int => b256),
         map_in_map: (int => (b256 => int)),
         map_in_map_in_map: (int => (b256 => (int => b256))),
     }
@@ -21,7 +21,7 @@ predicate Foo() {
 
     let address = Bar@[addr]::storage::address;
     let address2 = Bar@[addr]::storage::address2;
-    let map_entry = Bar@[addr]::storage::map[69];
+    let map_entry = Bar@[addr]::storage::imap[69];
     let map_in_map_entry = Bar@[addr]::storage::map_in_map[9][0x0000000000000001000000000000000200000000000000030000000000000004];
     let map_in_map_in_map_entry = Bar@[addr]::storage::map_in_map_in_map[88][0x0000000000000008000000000000000700000000000000060000000000000005][999];
 


### PR DESCRIPTION
This is a WIP as ASM gen for `map` has been postponed until we implement the program graph model in the back-end.

I would rather merge this now anyway, as if it stays in a branch while we refactor the back-end it'll go stale and be a pain to rebase later.

Since I was working on this for a few weeks it also has a few other semi-unrelated changes:
- `Handler::emit_internal_error()` takes an `Into<String>` for the message so we can pass `&str` easily if we want.
- Stop checking expression paths against new-types in the type checker.
- Other small changes in the name of consistency.