### PR TITLE
Add type checks to `const` initialisers.

### DIFF
--- a/pintc/src/predicate/analyse/type_check/check_exprs.rs
+++ b/pintc/src/predicate/analyse/type_check/check_exprs.rs
@@ -13,7 +13,7 @@ use crate::{
 use fxhash::FxHashSet;
 
 impl Contract {
-    pub(super) fn type_check_single_expr(
+    pub(crate) fn type_check_single_expr(
         &mut self,
         handler: &Handler,
         pred_key: Option<PredKey>,

--- a/pintc/tests/consts/het_array.pnt
+++ b/pintc/tests/consts/het_array.pnt
@@ -5,7 +5,7 @@ predicate test() {
 
 // parsed <<<
 // const ::a = [11, false];
-// 
+//
 // predicate ::test(
 // ) {
 // }

--- a/pintc/tests/consts/type_check.pnt
+++ b/pintc/tests/consts/type_check.pnt
@@ -1,0 +1,51 @@
+// Const decls which have no decl type but have an inconsistent initialiser type.  They should
+// produce type errors and never attempt to evaluate.
+
+const a = true in 2..3;
+const b = [11, true];
+
+union u = one | two(int);
+const c = u::two(false);
+
+const d = 33 + false;
+const e = 44 ? 55 : 66;
+
+const x = [true, true];
+const f = x[false];
+
+predicate test() { }
+
+// parsed <<<
+// const ::f = ::x[false];
+// const ::b = [11, true];
+// const ::x = [true, true];
+// const ::e = (44 ? 55 : 66);
+// const ::d = (33 + false);
+// const ::a = true in 2..3;
+// const ::c = ::u::two(false);
+// union ::u = one | two(int);
+//
+// predicate ::test(
+// ) {
+// }
+// >>>
+
+// typecheck_failure <<<
+// indexed expression invalid
+// @330..338: value must be an array or a storage map; found `Error`
+// array element type mismatch
+// @189..193: array element has type `bool`
+// expecting array element type `int`
+// condition for select expression must be a `bool`
+// @281..283: invalid type `int`, expecting `bool`
+// operator invalid type error
+// @259..269: invalid non-numeric type `bool` for operator `+`
+// value type and range type differ
+// @168..169: range type mismatch; expecting `bool` type, found `int` type
+// union variant type mismatch
+// @240..245: expecting type `int`, found `bool`
+// attempt to use an invalid constant as an array index
+// @330..338: this must be a non-negative integer value
+// condition for select expression must be a `bool`
+// @281..293: invalid type `int`, expecting `bool`
+// >>>

--- a/pintc/tests/evaluator/cast_error.pnt
+++ b/pintc/tests/evaluator/cast_error.pnt
@@ -10,7 +10,16 @@ const c = 44 as bool;
 
 // typecheck_failure <<<
 // invalid cast
-// @33..48: illegal cast from `int[_]`
+// @33..48: illegal cast from `int[2]`
+// casts may only be made from `bool`s,`int`s, and enumeration unions to `int`
+// invalid cast
+// @10..21: illegal cast from `{int}`
+// casts may only be made from `bool`s,`int`s, and enumeration unions to `int`
+// invalid cast
+// @60..70: illegal cast to `bool`
+// casts may only be made to `int`
+// invalid cast
+// @33..48: illegal cast from `int[2]`
 // casts may only be made from `bool`s,`int`s, and enumeration unions to `int`
 // invalid cast
 // @10..21: illegal cast from `{int}`

--- a/pintc/tests/evaluator/in_exprs.pnt
+++ b/pintc/tests/evaluator/in_exprs.pnt
@@ -1,6 +1,6 @@
 const a = 1 in [1, 2];
 const b = 1 in [3, 2];
-const c = true in [3,2];
+//const c = true in [3,2];
 const d = true in [true, false];
 const e = 1 in 1..2;
 const f = 1 in 3..2;
@@ -32,13 +32,12 @@ predicate Test(
 }
 
 // parsed <<<
-// const ::f = 1 in 3..2;
 // const ::b = 1 in [3, 2];
 // const ::e = 1 in 1..2;
 // const ::d = true in [true, false];
 // const ::a = 1 in [1, 2];
-// const ::c = true in [3, 2];
-// 
+// const ::f = 1 in 3..2;
+//
 // predicate ::Test(
 //     ::g: bool,
 //     ::h: bool,
@@ -64,13 +63,12 @@ predicate Test(
 // >>>
 
 // flattened <<<
-// const ::f: bool = false;
 // const ::b: bool = false;
 // const ::e: bool = true;
 // const ::d: bool = true;
 // const ::a: bool = true;
-// const ::c: bool = false;
-// 
+// const ::f: bool = false;
+//
 // predicate ::Test(
 //     ::g: bool,
 //     ::h: bool,

--- a/pintc/tests/evaluator/select_error.pnt
+++ b/pintc/tests/evaluator/select_error.pnt
@@ -6,5 +6,7 @@ const a = 11 ? 2 : 3;
 
 // typecheck_failure <<<
 // condition for select expression must be a `bool`
+// @10..12: invalid type `int`, expecting `bool`
+// condition for select expression must be a `bool`
 // @10..20: invalid type `int`, expecting `bool`
 // >>>

--- a/pintc/tests/evaluator/tuple_access_error_0.pnt
+++ b/pintc/tests/evaluator/tuple_access_error_0.pnt
@@ -8,4 +8,7 @@ const a = { 11, 22 }.2;
 // invalid tuple accessor
 // @10..22: unable to get field from tuple using `2`
 // tuple has type `{int, int}`
+// invalid tuple accessor
+// @10..22: unable to get field from tuple using `2`
+// tuple has type `{int, int}`
 // >>>

--- a/pintc/tests/evaluator/tuple_access_error_1.pnt
+++ b/pintc/tests/evaluator/tuple_access_error_1.pnt
@@ -8,4 +8,7 @@ const a = { a: 11, b: 22 }.c;
 // invalid tuple accessor
 // @10..28: unable to get field from tuple using `c`
 // tuple has type `{a: int, b: int}`
+// invalid tuple accessor
+// @10..28: unable to get field from tuple using `c`
+// tuple has type `{a: int, b: int}`
 // >>>

--- a/pintc/tests/experimental/cast_error.pnt
+++ b/pintc/tests/experimental/cast_error.pnt
@@ -10,7 +10,16 @@ const c = 44 as bool;
 
 // typecheck_failure <<<
 // invalid cast
-// @33..48: illegal cast from `int[_]`
+// @33..48: illegal cast from `int[2]`
+// casts may only be made from `bool`s,`int`s, and enumeration unions to `int`, or from `int`s, `real`s, and enumeration unions to `real`
+// invalid cast
+// @10..21: illegal cast from `{int}`
+// casts may only be made from `bool`s,`int`s, and enumeration unions to `int`, or from `int`s, `real`s, and enumeration unions to `real`
+// invalid cast
+// @60..70: illegal cast to `bool`
+// casts may only be made to `int` or `real`
+// invalid cast
+// @33..48: illegal cast from `int[2]`
 // casts may only be made from `bool`s,`int`s, and enumeration unions to `int`, or from `int`s, `real`s, and enumeration unions to `real`
 // invalid cast
 // @10..21: illegal cast from `{int}`


### PR DESCRIPTION
This was more painful than expected.  Constant initialiser evaluation is done before type checking so that we may use consts for array ranges (and other places?  I think arrays is it...) This change introduces a preliminary type check for constant initialisers before they are evaluated, mostly so we can catch bad types, as per #913.

But sometimes there will be type errors just because the consts are declared out of order and have dependencies.  That's why we iterate on evaluating them until they all resolve.  So those type errors are bogus and should be thrown away.  The approach I've taken in this PR was a compromise between a few different approaches I attempted and seems to balance out ensuring we report bad types but also not to get too verbose.

Unfortunately it introduces error duplication which are found during the type check but then also during the evaluation.  But I have another PR to address that.

Closes #913.