### PR TITLE
Change handler to emit only a single error per span.

### DIFF
--- a/pintc/src/error/handler.rs
+++ b/pintc/src/error/handler.rs
@@ -110,8 +110,26 @@ impl Handler {
     }
 
     pub fn consume(self) -> (Vec<Error>, Vec<Warning>) {
-        let inner = self.inner.into_inner();
-        (inner.errors, inner.warnings)
+        use super::Spanned;
+
+        let HandlerInner {
+            mut errors,
+            mut warnings,
+        } = self.inner.into_inner();
+
+        let mut seen_errors = fxhash::FxHashSet::default();
+        errors.retain(|err| {
+            let sig = err.span().clone();
+            seen_errors.insert(sig)
+        });
+
+        let mut seen_warnings = fxhash::FxHashSet::default();
+        warnings.retain(|warn| {
+            let sig = warn.span().clone();
+            seen_warnings.insert(sig)
+        });
+
+        (errors, warnings)
     }
 
     pub fn append(&self, other: Handler) {

--- a/pintc/src/predicate/transform/validate.rs
+++ b/pintc/src/predicate/transform/validate.rs
@@ -292,14 +292,15 @@ fn exprs() {
         ],
     );
     // forall
-    let src = "predicate test(k: int) { 
-    constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { !(i - j < k) }; }";
+    let src = "predicate test(k: int) { \
+                   constraint forall i in 0..3, j in 0..3 where !(i >= j), i - 1 >= 0 && j > 0 { \
+                       !(i - j < k) }; \
+                   }";
     check(
         &run_test(src),
-        expect_test::expect![[r#"
-            compiler internal error: forall generator present in final predicate exprs slotmap
-            compiler internal error: range present in final predicate exprs slotmap
-            compiler internal error: range present in final predicate exprs slotmap"#]],
+        expect_test::expect![
+            "compiler internal error: forall generator present in final predicate exprs slotmap"
+        ],
     );
     // exists
     let src = "predicate test(a: int[2][2]) {
@@ -308,10 +309,9 @@ fn exprs() {
     };}";
     check(
         &run_test(src),
-        expect_test::expect![[r#"
-            compiler internal error: exists generator present in final predicate exprs slotmap
-            compiler internal error: range present in final predicate exprs slotmap
-            compiler internal error: range present in final predicate exprs slotmap"#]],
+        expect_test::expect![
+            "compiler internal error: exists generator present in final predicate exprs slotmap"
+        ],
     );
 }
 
@@ -337,11 +337,10 @@ fn variables() {
     validate(&handler, &mut contract);
     check(
         &error::Errors(handler.consume().0).to_string(),
-        expect_test::expect![[r#"
-            compiler internal error: Unknown expr type found invalid predicate expr_types slotmap key
-            compiler internal error: unknown type present in final predicate expr_types slotmap
-            compiler internal error: error expression present in final predicate exprs slotmap
-            compiler internal error: final predicate variable_types slotmap is missing corresponding key from variables slotmap"#]],
+        expect_test::expect![
+            "compiler internal error: \
+                Unknown expr type found invalid predicate expr_types slotmap key"
+        ],
     );
 }
 
@@ -368,8 +367,10 @@ fn vars() {
     validate(&handler, &mut contract);
     check(
         &error::Errors(handler.consume().0).to_string(),
-        expect_test::expect![[r#"
-            compiler internal error: final predicate var_types slotmap is missing corresponding key from vars slotmap"#]],
+        expect_test::expect![
+            "compiler internal error: \
+                final predicate var_types slotmap is missing corresponding key from vars slotmap"
+        ],
     );
 }
 

--- a/pintc/src/span.rs
+++ b/pintc/src/span.rs
@@ -1,6 +1,6 @@
 use std::{fmt, ops::Range, path::Path, sync::Arc};
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Span {
     pub(super) context: Arc<Path>,
     pub(super) range: Range<usize>,

--- a/pintc/tests/arrays/non_const_index.pnt
+++ b/pintc/tests/arrays/non_const_index.pnt
@@ -17,6 +17,4 @@ predicate test(
 // flattening_failure <<<
 // cannot find value `::n` in this scope
 // @65..66: not found in this scope
-// attempt to use a non-constant value as an array index
-// @65..66: this must be a constant
 // >>>

--- a/pintc/tests/arrays/out_of_bounds_index.pnt
+++ b/pintc/tests/arrays/out_of_bounds_index.pnt
@@ -25,6 +25,4 @@ predicate test(b: int[4]) {
 // @100..101: array index is out of bounds
 // attempt to access array with out of bounds index
 // @74..75: array index is out of bounds
-// attempt to use an invalid constant as an array length
-// @127..145: this must be a strictly positive integer value
 // >>>

--- a/pintc/tests/arrays/out_of_bounds_index_multidimensional.pnt
+++ b/pintc/tests/arrays/out_of_bounds_index_multidimensional.pnt
@@ -21,6 +21,4 @@ predicate test(b: int[4][2]) {
 // @122..123: array index is out of bounds
 // attempt to access array with out of bounds index
 // @93..94: array index is out of bounds
-// attempt to access array with out of bounds index
-// @122..123: array index is out of bounds
 // >>>

--- a/pintc/tests/arrays/out_of_bounds_index_multidimensional_second.pnt
+++ b/pintc/tests/arrays/out_of_bounds_index_multidimensional_second.pnt
@@ -21,6 +21,4 @@ predicate test(b: int[4][2]) {
 // @125..126: array index is out of bounds
 // attempt to access array with out of bounds index
 // @96..97: array index is out of bounds
-// attempt to access array with out of bounds index
-// @125..126: array index is out of bounds
 // >>>

--- a/pintc/tests/consts/index_out_of_bounds.pnt
+++ b/pintc/tests/consts/index_out_of_bounds.pnt
@@ -16,6 +16,4 @@ predicate test() {
 // flattening_failure <<<
 // attempt to access array with out of bounds index
 // @69..70: array index is out of bounds
-// attempt to access array with out of bounds index
-// @69..70: array index is out of bounds
 // >>>

--- a/pintc/tests/consts/type_check.pnt
+++ b/pintc/tests/consts/type_check.pnt
@@ -44,8 +44,6 @@ predicate test() { }
 // @168..169: range type mismatch; expecting `bool` type, found `int` type
 // union variant type mismatch
 // @240..245: expecting type `int`, found `bool`
-// attempt to use an invalid constant as an array index
-// @330..338: this must be a non-negative integer value
 // condition for select expression must be a `bool`
 // @281..293: invalid type `int`, expecting `bool`
 // >>>

--- a/pintc/tests/evaluator/cast_error.pnt
+++ b/pintc/tests/evaluator/cast_error.pnt
@@ -18,13 +18,4 @@ const c = 44 as bool;
 // invalid cast
 // @60..70: illegal cast to `bool`
 // casts may only be made to `int`
-// invalid cast
-// @33..48: illegal cast from `int[2]`
-// casts may only be made from `bool`s,`int`s, and enumeration unions to `int`
-// invalid cast
-// @10..21: illegal cast from `{int}`
-// casts may only be made from `bool`s,`int`s, and enumeration unions to `int`
-// invalid cast
-// @60..70: illegal cast from `int`
-// casts may only be made from `bool`s,`int`s, and enumeration unions to `int`
 // >>>

--- a/pintc/tests/evaluator/index_error_0.pnt
+++ b/pintc/tests/evaluator/index_error_0.pnt
@@ -17,6 +17,4 @@ predicate test(c: int) {
 // flattening_failure <<<
 // attempt to access array with out of bounds index
 // @72..73: array index is out of bounds
-// attempt to access array with out of bounds index
-// @72..73: array index is out of bounds
 // >>>

--- a/pintc/tests/evaluator/index_error_1.pnt
+++ b/pintc/tests/evaluator/index_error_1.pnt
@@ -17,10 +17,4 @@ predicate test(a: int) {
 // flattening_failure <<<
 // cannot find value `::a` in this scope
 // @67..68: not found in this scope
-// attempt to use a non-constant value as an array index
-// @67..68: this must be a constant
-// cannot find value `::a` in this scope
-// @67..68: not found in this scope
-// attempt to use a non-constant value as an array length
-// @67..68: this must be a constant
 // >>>

--- a/pintc/tests/evaluator/tuple_access_error_0.pnt
+++ b/pintc/tests/evaluator/tuple_access_error_0.pnt
@@ -8,7 +8,4 @@ const a = { 11, 22 }.2;
 // invalid tuple accessor
 // @10..22: unable to get field from tuple using `2`
 // tuple has type `{int, int}`
-// invalid tuple accessor
-// @10..22: unable to get field from tuple using `2`
-// tuple has type `{int, int}`
 // >>>

--- a/pintc/tests/evaluator/tuple_access_error_1.pnt
+++ b/pintc/tests/evaluator/tuple_access_error_1.pnt
@@ -8,7 +8,4 @@ const a = { a: 11, b: 22 }.c;
 // invalid tuple accessor
 // @10..28: unable to get field from tuple using `c`
 // tuple has type `{a: int, b: int}`
-// invalid tuple accessor
-// @10..28: unable to get field from tuple using `c`
-// tuple has type `{a: int, b: int}`
 // >>>

--- a/pintc/tests/experimental/cast_error.pnt
+++ b/pintc/tests/experimental/cast_error.pnt
@@ -18,13 +18,4 @@ const c = 44 as bool;
 // invalid cast
 // @60..70: illegal cast to `bool`
 // casts may only be made to `int` or `real`
-// invalid cast
-// @33..48: illegal cast from `int[2]`
-// casts may only be made from `bool`s,`int`s, and enumeration unions to `int`, or from `int`s, `real`s, and enumeration unions to `real`
-// invalid cast
-// @10..21: illegal cast from `{int}`
-// casts may only be made from `bool`s,`int`s, and enumeration unions to `int`, or from `int`s, `real`s, and enumeration unions to `real`
-// invalid cast
-// @60..70: illegal cast from `int`
-// casts may only be made from `bool`s,`int`s, and enumeration unions to `int`, or from `int`s, `real`s, and enumeration unions to `real`
 // >>>

--- a/pintc/tests/generators/generator_type_errors.pnt
+++ b/pintc/tests/generators/generator_type_errors.pnt
@@ -32,20 +32,12 @@ predicate test() {
 // typecheck_failure <<<
 // range type must be numeric
 // @67..78: ranges must have numeric bounds; found `bool`
-// range for `forall` must be an `int`
-// @67..78: invalid type `bool`, expecting `int`
 // range type must be numeric
 // @117..128: ranges must have numeric bounds; found `bool`
-// range for `exists` must be an `int`
-// @117..128: invalid type `bool`, expecting `int`
 // range type must be numeric
 // @167..301: ranges must have numeric bounds; found `b256`
-// range for `forall` must be an `int`
-// @167..301: invalid type `b256`, expecting `int`
 // range type must be numeric
 // @340..474: ranges must have numeric bounds; found `b256`
-// range for `exists` must be an `int`
-// @340..474: invalid type `b256`, expecting `int`
 // condition for `forall` must be a `bool`
 // @551..552: invalid type `int`, expecting `bool`
 // condition for `exists` must be a `bool`

--- a/pintc/tests/interfaces/bad_address.pnt
+++ b/pintc/tests/interfaces/bad_address.pnt
@@ -44,16 +44,10 @@ predicate Simple(addr: b256) {
 // operator invalid type error
 // @181..189: invalid non-numeric type `bool` for operator `+`
 // address expression type error
-// @181..189: address expression has unexpected type `int`
-// @181..189: expecting type `b256`
-// address expression type error
 // @294..300: address expression has unexpected type `{int, int}`
 // @294..300: expecting type `b256`
 // operator invalid type error
 // @417..425: invalid non-numeric type `bool` for operator `+`
-// address expression type error
-// @417..425: address expression has unexpected type `int`
-// @417..425: expecting type `b256`
 // address expression type error
 // @530..535: address expression has unexpected type `bool`
 // @530..535: expecting type `b256`

--- a/pintc/tests/modules/07/main.pnt
+++ b/pintc/tests/modules/07/main.pnt
@@ -26,7 +26,4 @@ predicate test() {
 // multiple source files found for module
 // @146..153: multiple source files found for module b
 // both the files `tests/modules/07/b.pnt` and `tests/modules/07/b/b.pnt` exist, where only one or the other is allowed
-// no file found for path
-// @146..153: failed to resolve path b::c::d
-// one of the modules `b::c` or `b` must exist
 // >>>

--- a/pintc/tests/types/empty_array.pnt
+++ b/pintc/tests/types/empty_array.pnt
@@ -14,9 +14,6 @@ predicate test(ary: int[10], vector: int[]) {
 // typecheck_failure <<<
 // illegal empty array value
 // @68..70: empty array values are illegal
-// binary operator type error
-// @68..70: operator `!=` argument has unexpected type `Error[0]`
-// @61..64: expecting type `int[10]`
 // predicate parameters cannot have storage types
 // @29..42: found parameter of storage type int[] here
 // >>>

--- a/pintc/tests/types/new_type_recursion.pnt
+++ b/pintc/tests/types/new_type_recursion.pnt
@@ -33,7 +33,4 @@ predicate test(
 // type alias refers to itself
 // @25..26: type alias `::C` is used recursively in declaration
 // @31..48: `::C` is declared here
-// type alias refers to itself
-// @11..12: type alias `::A` is used recursively in declaration
-// @0..14: `::A` is declared here
 // >>>

--- a/pintc/tests/types/new_type_unknown.pnt
+++ b/pintc/tests/types/new_type_unknown.pnt
@@ -17,8 +17,6 @@ predicate test(a: Ambiguous) {
 // typecheck_failure <<<
 // undefined type
 // @17..33: type is undefined
-// undefined type
-// @17..33: type is undefined
 // cannot find value `::Ambiguous::MissingVariant` in this scope
 // @87..112: not found in this scope
 // >>>

--- a/pintc/tests/types/recursive_array_vars.pnt
+++ b/pintc/tests/types/recursive_array_vars.pnt
@@ -20,9 +20,6 @@ predicate test() {
 // expression has a recursive dependency
 // @74..75: cannot determine type of expression due to dependency
 // @54..58: dependency on expression is recursive
-// expression has a recursive dependency
-// @54..55: cannot determine type of expression due to dependency
-// @72..86: dependency on expression is recursive
 // unable to determine expression type
 // @23..40: type of this expression is ambiguous
 // unable to determine expression type

--- a/pintc/tests/types/undefined_types.pnt
+++ b/pintc/tests/types/undefined_types.pnt
@@ -124,10 +124,6 @@ predicate test(a2: Undefined, b2: Undefined, a: int, b: Foo, d: Baz) {
 // @330..339: type is undefined
 // undefined type
 // @350..359: type is undefined
-// type not allowed in storage
-// @17..26: found type ::Undefined in storage
-// type not allowed in storage
-// @35..44: found type ::Undefined in storage
 // invalid cast
 // @557..572: illegal cast to `::Undefined`
 // casts may only be made to `int`

--- a/pintc/tests/unions/unknown_union.pnt
+++ b/pintc/tests/unions/unknown_union.pnt
@@ -53,8 +53,6 @@ predicate test(
 // @337..352: union variant `::known::good` should not bind a value
 // missing union variant value
 // @405..418: union variant `better` requires a value of type `int`
-// cannot find value `::known::better` in this scope
-// @405..418: not found in this scope
 // union variant type mismatch
 // @491..495: expecting type `int`, found `bool`
 // >>>


### PR DESCRIPTION
I think reporting more than one error per span, even if they're strictly different errors, but especially if they're the same error, is noisy and generally a poor user experience.

So here is a patch which filters errors and warnings uniquely based on their span when extracting them from their `Handler`.  Looking at the changes in tests it looks worthwhile, especially after my last PR which ends up calling the type checker multiple times on consts and can duplicate errors.

But even for multiple errors per span which differ, usually the first one is enough and the others are superflous.  But YMMV and this PR doesn't need to be merged necessarily.