### PR TITLE
Fix for Rust v1.83.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request: null
 
 env:
-  RUST_VERSION: 1.81.0
+  RUST_VERSION: 1.83.0
   NIGHTLY_RUST_VERSION: nightly-2024-09-11
   SCIP_VERSION: 8.0.3
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  RUST_VERSION: 1.76.0
+  RUST_VERSION: 1.83.0
 
 jobs:
   deploy:

--- a/pint-solve/src/lib.rs
+++ b/pint-solve/src/lib.rs
@@ -11,7 +11,7 @@ use lalrpop_util::lalrpop_mod;
 #[cfg(feature = "solver-scip")]
 use russcip::ProblemCreated;
 
-lalrpop_mod!(#[allow(unused, clippy::ptr_arg, clippy::type_complexity)] pub flatpint_parser);
+lalrpop_mod!(#[allow(unused, clippy::ptr_arg, clippy::type_complexity, clippy::empty_line_after_outer_attr)] pub flatpint_parser);
 
 pub fn parse_flatpint(
     src: &str,

--- a/pint-solve/src/scip.rs
+++ b/pint-solve/src/scip.rs
@@ -19,9 +19,9 @@ pub struct Solver<'a, State> {
     unique_cons_suffix: usize, // unique suffix for names of cosntraints
 }
 
-impl<'a, State> Solver<'a, State> {
+impl<State> Solver<'_, State> {
     /// Creates a new instance of `Solver` given a `FlatPint` instance.
-    pub fn new(flatpint: &'a FlatPint) -> Solver<ProblemCreated> {
+    pub fn new(flatpint: &FlatPint) -> Solver<ProblemCreated> {
         Solver {
             model: Model::new()
                 .hide_output()
@@ -77,7 +77,7 @@ impl<'a> Solver<'a, ProblemCreated> {
     }
 }
 
-impl<'a> super::Solver<'a, Solved> {
+impl super::Solver<'_, Solved> {
     /// Returns a `FxHashMap` that contains a solution. It maps decision variable names, as
     /// `String`s, to `flatpint::Immediate` values. Returns an empty `FxHashMap` in case a solution
     /// cannot be found

--- a/pint-solve/src/scip/constraint.rs
+++ b/pint-solve/src/scip/constraint.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use russcip::{prelude::*, ProblemCreated};
 
-impl<'a> super::Solver<'a, ProblemCreated> {
+impl super::Solver<'_, ProblemCreated> {
     pub(super) fn convert_constraint(&mut self, constraint_expr: &Expr) -> Result<(), SolveError> {
         let new_cons_name = self.new_cons_name();
         match constraint_expr {

--- a/pint-solve/src/scip/invert.rs
+++ b/pint-solve/src/scip/invert.rs
@@ -7,7 +7,7 @@ use russcip::ProblemCreated;
 /// Invert a Boolean expression. Takes an `ExprKey` and returns another `ExprKey` that
 /// represents its inverse. For example, a `>=` binary op expression becomes a `<` binary op
 /// expression.
-impl<'a> super::Solver<'a, ProblemCreated> {
+impl super::Solver<'_, ProblemCreated> {
     pub(super) fn invert_expression(expr: &Expr) -> Result<Expr, SolveError> {
         match expr {
             Expr::Immediate(value) => match value {

--- a/pint-solve/src/scip/print.rs
+++ b/pint-solve/src/scip/print.rs
@@ -3,7 +3,7 @@ use russcip::{prelude::*, Solved};
 use std::fmt::Write;
 use yansi::Paint;
 
-impl<'a> super::Solver<'a, Solved> {
+impl super::Solver<'_, Solved> {
     /// Pretty print the output of the solver which includes a valid solution for all the variables
     /// in case of success. Skips any helper variables introduced by the solver. Rounds to 3
     /// decimal places.

--- a/pint-solve/src/scip/variable.rs
+++ b/pint-solve/src/scip/variable.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 const DEFAULT_LB: f64 = -f64::INFINITY;
 const DEFAULT_UB: f64 = f64::INFINITY;
 
-impl<'a> super::Solver<'a, ProblemCreated> {
+impl super::Solver<'_, ProblemCreated> {
     pub(super) fn convert_variable(&mut self, var: &Var) {
         let ty = &var.ty;
         let name = &var.name;

--- a/pintc/src/lexer.rs
+++ b/pintc/src/lexer.rs
@@ -636,7 +636,7 @@ impl VecTokenSourceState {
     }
 }
 
-impl<'a> TokenSource<'a> {
+impl TokenSource<'_> {
     fn next(&mut self) -> Option<Result<Token, ParseError>> {
         match self {
             TokenSource::LogosLexer(lex) => lex.next(),
@@ -683,7 +683,7 @@ enum LexerState {
 //
 // We implement special case macro parsing here as an adapter to the adapter, as we need to wrap up
 // macro params and body tokens before passing them to the parser.
-impl<'a> Iterator for Lexer<'a> {
+impl Iterator for Lexer<'_> {
     type Item = Result<(usize, Token, usize), ParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/pintc/src/parser.rs
+++ b/pintc/src/parser.rs
@@ -17,7 +17,7 @@ use std::{
 
 use lalrpop_util::lalrpop_mod;
 
-lalrpop_mod!(#[allow(clippy::ptr_arg, clippy::type_complexity)] pub pint_parser);
+lalrpop_mod!(#[allow(clippy::ptr_arg, clippy::type_complexity, clippy::empty_line_after_outer_attr)] pub pint_parser);
 
 mod use_path;
 pub(crate) use use_path::{UsePath, UseTree};
@@ -314,7 +314,7 @@ macro_rules! parse_with {
     }};
 }
 
-impl<'a> ProjectParser<'a> {
+impl ProjectParser<'_> {
     fn parse_module(
         &mut self,
         src_path: &Arc<Path>,

--- a/pintc/src/parser/tests.rs
+++ b/pintc/src/parser/tests.rs
@@ -14,7 +14,7 @@ use pint_parser as yp;
 use lalrpop_util::lalrpop_mod;
 
 #[cfg(test)]
-lalrpop_mod!(#[allow(unused)] pub pint_parser);
+lalrpop_mod!(#[allow(unused, clippy::empty_line_after_outer_attr)] pub pint_parser);
 
 /// Given a parser, some source code, and a parser context, parse the source code and return the
 /// parsed result or the full set of errors

--- a/pintc/src/parser/use_path.rs
+++ b/pintc/src/parser/use_path.rs
@@ -96,7 +96,7 @@ fn check_use_path(paths: Vec<UsePath>, expect: expect_test::Expect) {
 use lalrpop_util::lalrpop_mod;
 
 #[cfg(test)]
-lalrpop_mod!(#[allow(unused)] pub pint_parser);
+lalrpop_mod!(#[allow(unused, clippy::empty_line_after_outer_attr)] pub pint_parser);
 
 #[test]
 fn gather_use_paths() {

--- a/pintc/src/predicate.rs
+++ b/pintc/src/predicate.rs
@@ -778,7 +778,7 @@ struct BlockStatementExprs<'a> {
     iter: Box<dyn Iterator<Item = ExprKey> + 'a>,
 }
 
-impl<'a> Iterator for BlockStatementExprs<'a> {
+impl Iterator for BlockStatementExprs<'_> {
     type Item = ExprKey;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/pintc/src/predicate/display.rs
+++ b/pintc/src/predicate/display.rs
@@ -59,7 +59,7 @@ impl<'a, T> WithPred<'a, T> {
 
 impl Predicate {
     /// Helps out some `thing: T` by adding `self` as context.
-    pub fn with_pred<'a, T>(&'a self, contract: &'a Contract, thing: T) -> WithPred<T> {
+    pub fn with_pred<'a, T>(&'a self, contract: &'a Contract, thing: T) -> WithPred<'a, T> {
         WithPred {
             thing,
             contract,

--- a/pintc/src/predicate/exprs.rs
+++ b/pintc/src/predicate/exprs.rs
@@ -85,37 +85,37 @@ impl Exprs {
 impl ExprKey {
     /// Returns an `Option` containing the `Expr` corresponding to key `self`. Returns `None` if
     /// the key can't be found in the `exprs` map.
-    pub fn try_get<'a>(&'a self, contract: &'a Contract) -> Option<&Expr> {
+    pub fn try_get<'a>(&self, contract: &'a Contract) -> Option<&'a Expr> {
         contract.exprs.exprs.get(*self)
     }
 
     /// Returns the `Expr` corresponding to key `self`. Panics if the key can't be found in the
     /// `exprs` map.
-    pub fn get<'a>(&'a self, contract: &'a Contract) -> &Expr {
+    pub fn get<'a>(&self, contract: &'a Contract) -> &'a Expr {
         contract.exprs.exprs.get(*self).unwrap()
     }
 
     /// Returns a mutable reference to the `Expr` corresponding to key `self`. Panics if the key
     /// can't be found in the `exprs` map.
-    pub fn get_mut<'a>(&'a self, contract: &'a mut Contract) -> &mut Expr {
+    pub fn get_mut<'a>(&self, contract: &'a mut Contract) -> &'a mut Expr {
         contract.exprs.exprs.get_mut(*self).unwrap()
     }
 
     /// Returns the type of key `self` given a `Contract`. Panics if the type can't be
     /// found in the `expr_types` map.
-    pub fn get_ty<'a>(&'a self, contract: &'a Contract) -> &Type {
+    pub fn get_ty<'a>(&self, contract: &'a Contract) -> &'a Type {
         contract.exprs.expr_types.get(*self).unwrap()
     }
 
     /// Returns a mutable reference to the type of key `self` given a `Contract`. Panics if the type can't be
     /// found in the `expr_types` map.
-    pub fn get_ty_mut<'a>(&'a self, contract: &'a mut Contract) -> &mut Type {
+    pub fn get_ty_mut<'a>(&self, contract: &'a mut Contract) -> &'a mut Type {
         contract.exprs.expr_types.get_mut(*self).unwrap()
     }
 
     /// Set the type of key `self` in a `Contract`. Panics if the type can't be found in
     /// the `expr_types` map.
-    pub fn set_ty<'a>(&'a self, ty: Type, contract: &'a mut Contract) {
+    pub fn set_ty(&self, ty: Type, contract: &mut Contract) {
         contract.exprs.expr_types.insert(*self, ty);
     }
 
@@ -485,7 +485,7 @@ impl<'a> ExprsIter<'a> {
     }
 }
 
-impl<'a> Iterator for ExprsIter<'a> {
+impl Iterator for ExprsIter<'_> {
     type Item = ExprKey;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/pintc/src/predicate/variables.rs
+++ b/pintc/src/predicate/variables.rs
@@ -76,19 +76,19 @@ impl Variables {
 impl VariableKey {
     /// Returns an `Option` containing the `Variable` corresponding to key `self`. Returns `None` if
     /// the key can't be found in the `variables` map.
-    pub fn try_get<'a>(&'a self, pred: &'a Predicate) -> Option<&Variable> {
+    pub fn try_get<'a>(&self, pred: &'a Predicate) -> Option<&'a Variable> {
         pred.variables.variables.get(*self)
     }
 
     /// Returns the `Variable` corresponding to key `self`. Panics if the key can't be found in the
     /// `variables` map.
-    pub fn get<'a>(&'a self, pred: &'a Predicate) -> &Variable {
+    pub fn get<'a>(&self, pred: &'a Predicate) -> &'a Variable {
         pred.variables.variables.get(*self).unwrap()
     }
 
     /// Returns the type of key `self` given a `Predicate`. Panics if the type can't be
     /// found in the `variable_types` map.
-    pub fn get_ty<'a>(&'a self, pred: &'a Predicate) -> &Type {
+    pub fn get_ty<'a>(&self, pred: &'a Predicate) -> &'a Type {
         pred.variables.variable_types.get(*self).unwrap()
     }
 

--- a/pintc/src/util.rs
+++ b/pintc/src/util.rs
@@ -1,4 +1,4 @@
-/// A place for small utility functions which can use used in various places throughout the crate.
+//! A place for small utility functions which can use used in various places throughout the crate.
 
 macro_rules! write_many_iter_with_ctrct {
     ($f: expr, $i: ident, $sep: literal, $contract: ident) => {


### PR DESCRIPTION
1.83.0 introduced a few new warnings about missing lifetimes and clippy became more strict about unused named lifetimes and gaps after attributes.