### PR TITLE
Fix prime coalescing to also take care of the type of the next state op

### DIFF
--- a/pintc/src/asm_gen/asm_builder.rs
+++ b/pintc/src/asm_gen/asm_builder.rs
@@ -984,20 +984,8 @@ impl<'a> AsmBuilder<'a> {
             ));
         }
 
-        // check it's a prime op
-        let tuple_expr = if let Expr::UnaryOp {
-            op: UnaryOp::NextState,
-            expr,
-            ..
-        } = tuple.get(contract)
-        {
-            expr
-        } else {
-            tuple
-        };
-
         // Grab the fields of the tuple
-        let Type::Tuple { ref fields, .. } = tuple_expr.get_ty(contract) else {
+        let Type::Tuple { ref fields, .. } = tuple.get_ty(contract) else {
             return Err(
                 handler.emit_internal_err("type must exist and be a tuple type", empty_span())
             );

--- a/pintc/src/predicate/transform/lower.rs
+++ b/pintc/src/predicate/transform/lower.rs
@@ -1057,6 +1057,12 @@ pub(super) fn coalesce_prime_ops(contract: &mut Contract) {
                     };
 
                     *arg_key_ref = indexed_key;
+
+                    // Now update the type of the next state operator from the type of `a[i]` to the
+                    // type of `a`, since we're changing the placement of the operator from being
+                    // applied to `a[i]` to being applied to `a`.
+                    *op_key.get_ty_mut(contract) = indexed_key.get_ty(contract).clone();
+
                     work_list.push((op_key, indexed_key));
 
                     // Update the index expression to refer to the prime op.
@@ -1087,6 +1093,12 @@ pub(super) fn coalesce_prime_ops(contract: &mut Contract) {
                     };
 
                     *old_arg_key = accessed_key;
+
+                    // Now update the type of the next state operator from the type of `a.x` to the
+                    // type of `a`, since we're changing the placement of the operator from being
+                    // applied to `a.x` to being applied to `a`.
+                    *op_key.get_ty_mut(contract) = accessed_key.get_ty(contract).clone();
+
                     work_list.push((op_key, accessed_key));
 
                     // Update the access expression to refer to the prime op.

--- a/tests/validation_tests/tuples_and_arrays.pnt
+++ b/tests/validation_tests/tuples_and_arrays.pnt
@@ -1,0 +1,29 @@
+storage {
+    a: { int, bool[3], { int, { b256, int}[3] }},
+}
+
+const B = 0x0000000000000001000000000000000100000000000000010000000000000001;
+
+predicate test() {
+    let a = mut storage::a;
+
+    constraint a.1[1]' == true;
+    constraint a.1'[1]' == true;
+    constraint a'.1[1]' == true;
+    constraint a.1'[1] == true;
+
+    constraint a.2.0' == 1;
+    constraint a.2'.0' == 1;
+    constraint a'.2.0' == 1;
+ 
+    constraint a.2.1[0]' == { B, 3 };
+    constraint a.2.1'[0]' == { B, 3 };
+    constraint a.2'.1[0]' == { B, 3 };
+    constraint a'.2'.1[0]' == { B, 3 };
+    constraint a.2'.1[0] == { B, 3 };
+
+    constraint a.2.1[0].1' == 3;
+    constraint a.2'.1'[0]'.1' == 3;
+    constraint a.2.1'[0].1 == 3;
+    constraint a.2'.1[0].1 == 3;
+}

--- a/tests/validation_tests/tuples_and_arrays.solution.json
+++ b/tests/validation_tests/tuples_and_arrays.solution.json
@@ -1,0 +1,57 @@
+{
+  "solutions": [
+    {
+      "predicate_to_solve": {
+        "contract": "<>",
+        "predicate": "<::test>"
+      },
+      "predicate_data": [],
+      "state_mutations": [
+        {
+          "key": [0, 0],
+          "value": [0]
+        },
+        {
+          "key": [0, 1],
+          "value": [0]
+        },
+        {
+          "key": [0, 2],
+          "value": [1]
+        },
+        {
+          "key": [0, 3],
+          "value": [1]
+        },
+        {
+          "key": [0, 4],
+          "value": [1]
+        },
+        {
+          "key": [0, 5],
+          "value": [1, 1, 1, 1]
+        },
+        {
+          "key": [0, 6],
+          "value": [3]
+        },
+        {
+          "key": [0, 7],
+          "value": [0, 0, 0, 0]
+        },
+        {
+          "key": [0, 8],
+          "value": [3]
+        },
+        {
+          "key": [0, 9],
+          "value": [0, 0, 0, 0]
+        },
+        {
+          "key": [0, 10],
+          "value": [0]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is somewhat of a follow up to #1036. I started hitting this same issue in other places and I think the better fix is in the type checker. The old fix handles tuples and only in the backend. This fix is more general and fixes arrays where code like this currently fails:

```rust
storage {
    a: int[3],
}

predicate foo() {
    let a = storage::a;
    constraint a[0]' == 0;
}
```

The missing piece was updating the type of the unary op expressions since we go from `a.x'` to `a'.x` so the type of the op should change from the type of `a.x` to the type of `a`. Same goes for array indexing. This also affects #1039 which allows syntax such as `storage::my_map[x]'` (so not just arrays!).