### PR TITLE
Improve error if a `const` is used in a `predicate`

### DIFF
--- a/pintc/src/error/parse_error.rs
+++ b/pintc/src/error/parse_error.rs
@@ -69,6 +69,8 @@ pub enum ParseError {
     TypeNotSupported { ty: String, span: Span },
     #[error("Unsupported literal")]
     LiteralNotSupported { kind: String, span: Span },
+    #[error("`consts` must be declared outside of a `predicate`")]
+    UnsupportedConstLocation { span: Span },
 }
 
 impl ReportableError for ParseError {
@@ -241,6 +243,11 @@ impl ReportableError for ParseError {
                 span: span.clone(),
                 color: Color::Red,
             }],
+            UnsupportedConstLocation { span, .. } => vec![ErrorLabel {
+                message: "unexpected `const`".to_string(),
+                span: span.clone(),
+                color: Color::Red,
+            }],
         }
     }
 
@@ -271,6 +278,9 @@ impl ReportableError for ParseError {
         use ParseError::*;
         match self {
             UnsupportedLeadingPlus { .. } => Some("try removing the `+`".to_string()),
+            UnsupportedConstLocation { .. } => {
+                Some("try declaring the const outside the body of the `predicate`".to_string())
+            }
             _ => None,
         }
     }
@@ -345,6 +355,7 @@ impl Spanned for ParseError {
             | MissingIntrinsic { span, .. }
             | TypeNotSupported { span, .. }
             | LiteralNotSupported { span, .. }
+            | UnsupportedConstLocation { span, .. }
             | Lex { span } => span,
 
             InvalidToken => unreachable!("The `InvalidToken` error is always wrapped in `Lex`."),

--- a/pintc/src/pint_parser.lalrpop
+++ b/pintc/src/pint_parser.lalrpop
@@ -42,6 +42,15 @@ Decl: () = {
 
 // Decls allowed inside predicates.
 PredicateInnerDecl: () = {
+    <l:@L> ConstDecl ";" <r:@R> => {
+        let span = (context.span_from)(l, r);
+        handler.emit_err(Error::Parse {
+            error: ParseError::UnsupportedConstLocation {
+                span: span.clone(),
+            },
+        });
+    },
+
     ConstraintDecl ";",
     IfDecl,
     MatchDecl,

--- a/pintc/tests/consts/bad_pos.pnt
+++ b/pintc/tests/consts/bad_pos.pnt
@@ -9,6 +9,7 @@ predicate A(b: int) {
 }
 
 // parse_failure <<<
-// expected `::`, `an identifier`, `constraint`, `if`, `let`, `macro_name`, `match`, `use`, or `}`, found `const`
-// @69..74: expected `::`, `an identifier`, `constraint`, `if`, `let`, `macro_name`, `match`, `use`, or `}`
+// `consts` must be declared outside of a `predicate`
+// @69..82: unexpected `const`
+// try declaring the const outside the body of the `predicate`
 // >>>


### PR DESCRIPTION
Closes #1052 