### PR TITLE
Add a CLI option to prevent contract and ABI JSON files from being written.

### DIFF
--- a/pintc/src/cli.rs
+++ b/pintc/src/cli.rs
@@ -25,6 +25,9 @@ pub struct Args {
 
     #[arg(long = "skip-optimize", hide = true)]
     pub skip_optimize: bool,
+
+    #[arg(long = "no-output", hide = true)]
+    pub no_output: bool,
 }
 
 /// Parses a `&str` that represents a 256-bit unsigned integer in hexadecimal format and converts

--- a/pintc/src/main.rs
+++ b/pintc/src/main.rs
@@ -147,12 +147,14 @@ fn main() -> anyhow::Result<()> {
                 println!("         {pipe} {:<name_col_w$} {}", name, ca);
             }
 
-            // Write ABI and contract
-            serde_json::to_writer_pretty(File::create(json_abi_path)?, &abi)?;
-            serde_json::to_writer(
-                File::create(output_file_path)?,
-                &(compiled_contract.contract, compiled_contract.programs),
-            )?;
+            // Write ABI and contract (unless output is suppressed).
+            if !args.no_output && std::env::var("PINTC_NO_OUTPUT").is_err() {
+                serde_json::to_writer_pretty(File::create(json_abi_path)?, &abi)?;
+                serde_json::to_writer(
+                    File::create(output_file_path)?,
+                    &(compiled_contract.contract, compiled_contract.programs),
+                )?;
+            }
 
             // Report any warnings
             if handler.has_warnings() && !cfg!(test) {


### PR DESCRIPTION
It's a hidden option.  Also suppress JSON output if a `PINTC_NO_OUTPUT` env var is set.

This is a personal peeve and so it needn't be exposed.  I'm frequently annoyed by the littering of `.json` contract files, and `-abi.json` ABI files in my tests.  Yes, they're ignored by Git, but they just annoy me when I find them.  So this is for me.